### PR TITLE
Fix harmonic threshold export key

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -949,7 +949,8 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
                 'T_Statistic': item['T_Statistic'],
                 'P_Value': item['P_Value'],
                 'df': item['df'],
-                'Threshold_Used': item['Threshold_Criteria_Mean_Value']  # The mean value threshold
+                # Store the mean value threshold used for this harmonic
+                'Threshold': item['Threshold_Criteria_Mean_Value']
             })
         if not findings_dict: messagebox.showwarning("No Results",
                                                      "Failed to structure harmonic results for export."); return

--- a/src/Tools/Stats/stats_export.py
+++ b/src/Tools/Stats/stats_export.py
@@ -99,7 +99,7 @@ def export_significance_results_to_excel(findings_dict, metric, threshold, paren
     Args:
         findings_dict (dict): Nested {condition: {roi: [finding_list]}}.
                               finding_list contains dicts with keys like 'Frequency',
-                              'Mean_MetricName', 'N_Subjects', 'T_Statistic', 'P_Value', 'df', 'Threshold_Used'.
+                              'Mean_MetricName', 'N_Subjects', 'T_Statistic', 'P_Value', 'df', 'Threshold'.
         metric (str): Metric analyzed (e.g., "SNR", "Z-Score").
         threshold (float): Mean value threshold used.
         parent_folder (str): Path for suggesting save location.


### PR DESCRIPTION
## Summary
- rename `Threshold_Used` to `Threshold` when exporting harmonic check data
- update docs in `stats_export.export_significance_results_to_excel`

## Testing
- `python -m py_compile src/Tools/Stats/stats.py src/Tools/Stats/stats_export.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b57af9f4832c9fdb528db6bea9f2