### PR TITLE
Add mixed-effects analysis

### DIFF
--- a/src/Tools/Stats/mixed_effects_model.py
+++ b/src/Tools/Stats/mixed_effects_model.py
@@ -1,0 +1,56 @@
+# mixed_effects_model.py
+# -*- coding: utf-8 -*-
+"""
+Provides a helper function to run a linear mixed effects model using
+statsmodels MixedLM on long-format data.
+"""
+
+import pandas as pd
+
+
+def run_mixed_effects_model(data: pd.DataFrame, dv_col: str, group_col: str, fixed_effects: list):
+    """Run a linear mixed effects model.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Long-format DataFrame containing all variables.
+    dv_col : str
+        Name of the dependent variable column.
+    group_col : str
+        Column specifying grouping variable for random intercepts (e.g., subject).
+    fixed_effects : list of str
+        Column names to include as fixed effects.
+
+    Returns
+    -------
+    pd.DataFrame
+        Table of fixed effect coefficients with p-values.
+    """
+    try:
+        import statsmodels.formula.api as smf
+    except ImportError:
+        raise ImportError(
+            "statsmodels is required for mixed effects modeling. Please install it via `pip install statsmodels`."
+        )
+
+    required_cols = [dv_col, group_col] + fixed_effects
+    missing = [col for col in required_cols if col not in data.columns]
+    if missing:
+        raise ValueError(f"Missing required columns in data for MixedLM: {missing}")
+
+    df = data.dropna(subset=required_cols)
+    if df.empty:
+        raise ValueError("After dropping missing values, no data remain for MixedLM.")
+
+    fixed_formula = " + ".join(fixed_effects)
+    formula = f"{dv_col} ~ {fixed_formula}"
+
+    try:
+        model = smf.mixedlm(formula, df, groups=df[group_col])
+        result = model.fit()
+        summary_table = result.summary().tables[1]
+        df_result = pd.DataFrame(summary_table.data[1:], columns=summary_table.data[0])
+        return df_result
+    except Exception as e:
+        raise RuntimeError(f"Failed to run mixed effects model: {e}")

--- a/src/Tools/Stats/stats_export.py
+++ b/src/Tools/Stats/stats_export.py
@@ -270,3 +270,41 @@ def export_rm_anova_results_to_excel(anova_table, parent_folder, log_func=print)
     except Exception as e:
         log_func(f"!!! RM-ANOVA Export Failed: {e}\n{traceback.format_exc()}")
         messagebox.showerror("Export Failed", f"Could not save Excel file: {e}")
+
+
+# --- Export Function for Mixed Effects Model Results ---
+def export_mixedlm_results_to_excel(mixedlm_table, parent_folder, log_func=print):
+    """Exports MixedLM fixed effects table to a formatted Excel file."""
+    log_func("Attempting to export Mixed Model results...")
+    if mixedlm_table is None or not isinstance(mixedlm_table, pd.DataFrame) or mixedlm_table.empty:
+        log_func("No Mixed Model results data available or data is not a DataFrame.")
+        messagebox.showwarning("No Results", "No Mixed Model results available to export or data format is incorrect.")
+        return
+
+    df_export = mixedlm_table.copy()
+
+    initial_dir = parent_folder if os.path.isdir(parent_folder) else os.path.expanduser("~")
+    suggested_filename = "Stats_MixedModel_SummedBCA.xlsx"
+
+    save_path = filedialog.asksaveasfilename(
+        title="Save Mixed Model Results (Summed BCA)",
+        initialdir=initial_dir, initialfile=suggested_filename, defaultextension=".xlsx",
+        filetypes=[("Excel Workbook", "*.xlsx"), ("All Files", "*.*")]
+    )
+    if not save_path:
+        log_func("Mixed Model export cancelled.")
+        return
+
+    try:
+        log_func(f"Exporting Mixed Model results to: {save_path}")
+        with pd.ExcelWriter(save_path, engine='xlsxwriter') as writer:
+            _auto_format_and_write_excel(writer, df_export, 'Mixed Model Results', log_func)
+        log_func("Mixed Model results export successful.")
+        messagebox.showinfo("Export Successful", f"Mixed Model results exported to:\n{save_path}")
+    except PermissionError:
+        err_msg = f"Permission denied writing to {save_path}. File may be open or folder write-protected."
+        log_func(f"!!! Export Failed: {err_msg}")
+        messagebox.showerror("Export Failed", err_msg)
+    except Exception as e:
+        log_func(f"!!! Mixed Model Export Failed: {e}\n{traceback.format_exc()}")
+        messagebox.showerror("Export Failed", f"Could not save Excel file: {e}")


### PR DESCRIPTION
## Summary
- add MixedLM helper function
- export MixedLM results via stats UI
- run Mixed Effects model from the stats window

## Testing
- `python -m py_compile src/Tools/Stats/mixed_effects_model.py src/Tools/Stats/stats_export.py src/Tools/Stats/stats.py`

------
https://chatgpt.com/codex/tasks/task_e_6840bc1b08bc832cadb2ca8bf564896f