### PR TITLE
Fix CTkFont initialization timing

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -31,7 +31,7 @@ import scipy.stats as stats
 from . import stats_export  # Assuming stats_export.py is in the same package
 from .repeated_m_anova import run_repeated_measures_anova  # Assuming repeated_m_anova.py
 from .mixed_effects_model import run_mixed_effects_model
-from config import FONT_BOLD, FONT_MAIN
+from config import FONT_BOLD, FONT_MAIN, init_fonts
 
 # Regions of Interest (10-20 montage)
 ROIS = {
@@ -47,6 +47,10 @@ HARMONIC_CHECK_ALPHA = 0.05  # Significance level for one-sample t-test
 class StatsAnalysisWindow(ctk.CTkToplevel):
     def __init__(self, master, default_folder=""):
         super().__init__(master)
+
+        # Ensure fonts are initialised in case this window is launched
+        # independently of the main application.
+        init_fonts()
         self.option_add("*Font", FONT_MAIN)
         self.title("FPVS Statistical Analysis Tool")
         self.geometry("950x950")  # Adjusted for clarity of layout

--- a/src/config.py
+++ b/src/config.py
@@ -27,6 +27,29 @@ LABEL_ID_ENTRY_WIDTH  = 120
 
 # --- Fonts ---
 FONT_FAMILY = "Segoe UI"
-FONT_MAIN = ctk.CTkFont(family=FONT_FAMILY, size=12)
-FONT_BOLD = ctk.CTkFont(family=FONT_FAMILY, size=12, weight="bold")
-FONT_HEADING = ctk.CTkFont(family=FONT_FAMILY, size=14, weight="bold")
+
+# Font variables are initialised after a Tk root exists.  They are set to
+# ``None`` here and configured via :func:`init_fonts` which should be called
+# once a ``ctk.CTk`` instance has been created.
+FONT_MAIN = None
+FONT_BOLD = None
+FONT_HEADING = None
+
+
+def init_fonts() -> None:
+    """Initialise global ``customtkinter`` fonts.
+
+    ``customtkinter.CTkFont`` requires a default Tk root window. Importing this
+    module before a root exists would raise ``RuntimeError: Too early to use
+    font``.  Call this function after creating the main application window to
+    populate the global font variables.
+    """
+    global FONT_MAIN, FONT_BOLD, FONT_HEADING
+
+    if FONT_MAIN is None:
+        FONT_MAIN = ctk.CTkFont(family=FONT_FAMILY, size=12)
+    if FONT_BOLD is None:
+        FONT_BOLD = ctk.CTkFont(family=FONT_FAMILY, size=12, weight="bold")
+    if FONT_HEADING is None:
+        FONT_HEADING = ctk.CTkFont(family=FONT_FAMILY, size=14, weight="bold")
+

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -53,6 +53,7 @@ from config import (
     DEFAULT_STIM_CHANNEL,
     CORNER_RADIUS,
     PAD_X,
+    init_fonts,
     FONT_MAIN,
     FONT_BOLD,
     FONT_HEADING
@@ -94,6 +95,9 @@ class FPVSApp(ctk.CTk):
 
     def __init__(self):
         super().__init__()
+
+        # Initialise fonts now that a root window exists
+        init_fonts()
 
         # use modern default font
         self.option_add("*Font", FONT_MAIN)


### PR DESCRIPTION
## Summary
- delay CustomTkinter font setup until after creating a Tk root
- initialise fonts within `FPVSApp` and stats window

## Testing
- `python -m py_compile src/config.py src/fpvs_app.py src/Tools/Stats/stats.py`


------
https://chatgpt.com/codex/tasks/task_e_6840c9eda7cc832c843e2d789e6a448a