### PR TITLE
Fix Tcl argument error when setting default font

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -51,7 +51,11 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         # Ensure fonts are initialised in case this window is launched
         # independently of the main application.
         init_fonts()
-        self.option_add("*Font", FONT_MAIN)
+        # ``option_add`` expects a concrete priority value.  Without it the
+        # ``None`` forwarded by ``tkinter.Misc.option_add`` can cause Tcl to
+        # complain about the number of arguments.  Using ``str`` and an
+        # explicit priority sidesteps that issue.
+        self.option_add("*Font", str(FONT_MAIN), 80)
         self.title("FPVS Statistical Analysis Tool")
         self.geometry("950x950")  # Adjusted for clarity of layout
         self.grab_set()

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -100,7 +100,13 @@ class FPVSApp(ctk.CTk):
         init_fonts()
 
         # use modern default font
-        self.option_add("*Font", FONT_MAIN)
+        # ``option_add`` internally forwards arguments directly to the
+        # underlying Tcl interpreter. Passing ``None`` as the optional
+        # priority argument results in Tcl receiving five tokens instead of
+        # four, which raises "wrong # args" on some platforms. Casting the
+        # ``CTkFont`` instance to ``str`` and explicitly providing the default
+        # priority avoids this issue.
+        self.option_add("*Font", str(FONT_MAIN), 80)
 
 
         # 2) State variables


### PR DESCRIPTION
## Summary
- explicitly cast `CTkFont` instances to string when setting default font
- provide explicit priority argument when calling `option_add`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: IndentationError in existing `Compiler Script.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd4db9f0832c86b5f96dd3185e5d