### PR TITLE
Expose GUI width constants

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -24,3 +24,16 @@ version.
 The build scripts locate the repository root automatically before running
 PyInstaller, so they work even if launched from another directory.
 
+## Configuration
+
+The look and feel of the interface can be tweaked by editing constants in
+`config.py`.  In particular, several width settings control the advanced
+processing window:
+
+- `BUTTON_WIDTH`
+- `ADV_ENTRY_WIDTH`
+- `ADV_LABEL_ID_ENTRY_WIDTH`
+- `ADV_ID_ENTRY_WIDTH`
+
+Adjust these as desired to better fit your screen or preferences.
+

--- a/src/config.py
+++ b/src/config.py
@@ -25,6 +25,13 @@ PAD_Y                 = 5
 ENTRY_WIDTH           = 100
 LABEL_ID_ENTRY_WIDTH  = 120
 
+# Additional GUI dimensions used in advanced processing windows.
+# Modify these to adjust default control sizes.
+BUTTON_WIDTH             = 180
+ADV_ENTRY_WIDTH          = ENTRY_WIDTH
+ADV_LABEL_ID_ENTRY_WIDTH = int(ENTRY_WIDTH * 1.5)
+ADV_ID_ENTRY_WIDTH       = int(ENTRY_WIDTH * 0.5)
+
 # --- Fonts ---
 FONT_FAMILY = "Segoe UI"
 


### PR DESCRIPTION
## Summary
- provide default width settings in `config.py`
- mention new constants in README

## Testing
- `python -m py_compile src/config.py src/Tools/Average_Preprocessing/advanced_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6840d2a9d920832c9300a9d867c688c2