### PR TITLE
Fix export bug in stats_export

### DIFF
--- a/src/Tools/Stats/stats_export.py
+++ b/src/Tools/Stats/stats_export.py
@@ -127,7 +127,10 @@ def export_significance_results_to_excel(findings_dict, metric, threshold, paren
                     'df': finding.get('df', np.nan),
                     'T_Statistic': finding.get('T_Statistic', np.nan),
                     'P_Value': finding.get('P_Value', np.nan),
-                    'Mean_Threshold_Used': finding.get('Threshold', np.nan)  # 'Threshold' from stats.py
+                    # Attempt to use the explicit key from stats.py if present,
+                    # otherwise fall back to any older key name
+                    'Mean_Threshold_Used': finding.get('Threshold_Used',
+                                                    finding.get('Threshold', np.nan))
                 }
                 flat_results.append(row)
 


### PR DESCRIPTION
## Summary
- fix field name for threshold used when exporting harmonic check results

## Testing
- `python -m py_compile src/Tools/Stats/stats_export.py`
- `find src -name '*.py' ! -name 'Compiler Script.py' ! -name 'Test .set files.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6841bf40caa0832cb152eb5e17409ad1