### PR TITLE
Refactor Stats UI and unify logging

### DIFF
--- a/src/Tools/Stats/mixed_effects_model.py
+++ b/src/Tools/Stats/mixed_effects_model.py
@@ -6,9 +6,7 @@ statsmodels MixedLM on long-format data.
 """
 
 import pandas as pd
-import logging
-
-logger = logging.getLogger(__name__)
+from .stats_logging import logger
 
 
 def run_mixed_effects_model(data: pd.DataFrame, dv_col: str, group_col: str, fixed_effects: list):

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -16,9 +16,7 @@ import os
 import glob
 import re
 import traceback
-import logging
-
-logger = logging.getLogger(__name__)
+from .stats_logging import logger
 
 import customtkinter as ctk
 import tkinter as tk
@@ -31,17 +29,9 @@ import scipy.stats as stats
 from . import stats_export  # Assuming stats_export.py is in the same package
 from .repeated_m_anova import run_repeated_measures_anova  # Assuming repeated_m_anova.py
 from .mixed_effects_model import run_mixed_effects_model
+from . import stats_ui
 from config import FONT_BOLD, FONT_MAIN, init_fonts
-
-# Regions of Interest (10-20 montage)
-ROIS = {
-    "Frontal Lobe": ["F3", "F4", "Fz"],
-    "Occipital Lobe": ["O1", "O2", "Oz"],
-    "Parietal Lobe": ["P3", "P4", "Pz"],
-    "Central Lobe": ["C3", "C4", "Cz"]
-}
-ALL_ROIS_OPTION = "(All ROIs)"
-HARMONIC_CHECK_ALPHA = 0.05  # Significance level for one-sample t-test
+from .stats_constants import ROIS, ALL_ROIS_OPTION, HARMONIC_CHECK_ALPHA
 
 
 class StatsAnalysisWindow(ctk.CTkToplevel):
@@ -126,108 +116,9 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
             return False
 
     def create_widgets(self):
-        validate_num_cmd = (self.register(self._validate_numeric), '%P')
+        """Delegate UI construction to the stats_ui module."""
+        stats_ui.build_ui(self)
 
-        main_frame = ctk.CTkFrame(self)
-        main_frame.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)
-        self.grid_rowconfigure(0, weight=1)
-        self.grid_columnconfigure(0, weight=1)
-        main_frame.grid_columnconfigure(0, weight=1)
-
-        # --- Row 0: Folder Selection ---
-        folder_frame = ctk.CTkFrame(main_frame)
-        folder_frame.grid(row=0, column=0, sticky="ew", padx=5, pady=(5, 10))
-        folder_frame.grid_columnconfigure(1, weight=1)
-        ctk.CTkLabel(folder_frame, text="Data Folder:").grid(row=0, column=0, padx=5, pady=5, sticky="w")
-        ctk.CTkEntry(folder_frame, textvariable=self.stats_data_folder_var, state="readonly").grid(row=0, column=1,
-                                                                                                   padx=5, pady=5,
-                                                                                                   sticky="ew")
-        ctk.CTkButton(folder_frame, text="Browse...", command=self.browse_folder).grid(row=0, column=2, padx=5, pady=5)
-        ctk.CTkLabel(folder_frame, textvariable=self.detected_info_var, justify="left", anchor="w").grid(row=1,
-                                                                                                         column=0,
-                                                                                                         columnspan=3,
-                                                                                                         padx=5, pady=5,
-                                                                                                         sticky="w")
-
-        # --- Row 1: Common Setup ---
-        common_setup_frame = ctk.CTkFrame(main_frame)
-        common_setup_frame.grid(row=1, column=0, sticky="ew", padx=5, pady=5)
-        common_setup_frame.grid_columnconfigure(1, weight=1)
-        common_setup_frame.grid_columnconfigure(3, weight=1)
-        ctk.CTkLabel(common_setup_frame, text="Base Freq (Hz):").grid(row=0, column=0, padx=5, pady=5, sticky="w")
-        ctk.CTkEntry(common_setup_frame, textvariable=self.base_freq_var, validate='key',
-                     validatecommand=validate_num_cmd, width=100).grid(row=0, column=1, padx=5, pady=5, sticky="w")
-        ctk.CTkLabel(common_setup_frame, text="ROI (Paired/ANOVA):").grid(row=1, column=0, padx=5, pady=5, sticky="w")
-        roi_options = [ALL_ROIS_OPTION] + list(ROIS.keys())
-        self.roi_menu = ctk.CTkOptionMenu(common_setup_frame, variable=self.roi_var,
-                                          values=roi_options)  # Stored instance
-        self.roi_menu.grid(row=1, column=1, padx=5, pady=5, sticky="ew")
-        ctk.CTkLabel(common_setup_frame, text="Condition A (Paired):").grid(row=2, column=0, padx=5, pady=5, sticky="w")
-        self.condA_menu = ctk.CTkOptionMenu(common_setup_frame, variable=self.condition_A_var, values=["(Scan Folder)"],
-                                            command=lambda *_: self.update_condition_B_options())  # Already stored
-        self.condA_menu.grid(row=2, column=1, padx=5, pady=5, sticky="ew")
-        ctk.CTkLabel(common_setup_frame, text="Condition B (Paired):").grid(row=2, column=2, padx=(15, 5), pady=5,
-                                                                            sticky="w")
-        self.condB_menu = ctk.CTkOptionMenu(common_setup_frame, variable=self.condition_B_var,
-                                            values=["(Scan Folder)"])  # Already stored
-        self.condB_menu.grid(row=2, column=3, padx=5, pady=5, sticky="ew")
-
-        ctk.CTkLabel(common_setup_frame, text="Alpha (Sig. Level):").grid(row=3, column=0, padx=5, pady=5, sticky="w")
-        ctk.CTkEntry(common_setup_frame, textvariable=self.alpha_var, validate='key',
-                     validatecommand=validate_num_cmd, width=100).grid(row=3, column=1, padx=5, pady=5, sticky="w")
-
-        # --- Row 2: Section A - Summed BCA Analysis ---
-        summed_bca_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
-        summed_bca_frame.grid(row=2, column=0, sticky="ew", padx=5, pady=(10, 5))
-        ctk.CTkLabel(summed_bca_frame, text="Summed BCA Analysis:", font=FONT_BOLD).pack(anchor="w",
-                                                                                                          pady=(0, 5))
-        buttons_summed_frame = ctk.CTkFrame(summed_bca_frame)
-        buttons_summed_frame.pack(fill="x", padx=0, pady=0)  # Use pack for horizontal button layout
-        ctk.CTkButton(buttons_summed_frame, text="Run Paired Tests (Summed BCA)", command=self.run_paired_tests).pack(
-            side="left", padx=(0, 5), pady=5)
-        ctk.CTkButton(buttons_summed_frame, text="Run RM-ANOVA (Summed BCA)", command=self.run_rm_anova).pack(
-            side="left", padx=5, pady=5)
-        ctk.CTkButton(buttons_summed_frame, text="Run Mixed Model (Summed BCA)", command=self.run_mixed_model).pack(
-            side="left", padx=5, pady=5)
-        self.export_paired_tests_btn = ctk.CTkButton(buttons_summed_frame, text="Export Paired Results",
-                                                     state="disabled", command=self.export_paired_results)
-        self.export_paired_tests_btn.pack(side="left", padx=5, pady=5)
-        self.export_rm_anova_btn = ctk.CTkButton(buttons_summed_frame, text="Export RM-ANOVA", state="disabled",
-                                                 command=self.export_rm_anova_results)
-        self.export_rm_anova_btn.pack(side="left", padx=5, pady=5)
-        self.export_mixed_model_btn = ctk.CTkButton(buttons_summed_frame, text="Export Mixed Model", state="disabled",
-                                                   command=self.export_mixed_model_results)
-        self.export_mixed_model_btn.pack(side="left", padx=5, pady=5)
-
-        # --- Row 3: Section B - Harmonic Significance Check ---
-        harmonic_check_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
-        harmonic_check_frame.grid(row=3, column=0, sticky="ew", padx=5, pady=5)
-        ctk.CTkLabel(harmonic_check_frame, text="Per-Harmonic Significance Check:",
-                     font=FONT_BOLD).pack(anchor="w", pady=(0, 5))
-        controls_harmonic_frame = ctk.CTkFrame(harmonic_check_frame)
-        controls_harmonic_frame.pack(fill="x", padx=0, pady=0)
-        ctk.CTkLabel(controls_harmonic_frame, text="Metric:").grid(row=0, column=0, padx=(0, 5), pady=5, sticky="w")
-        self.harmonic_metric_menu = ctk.CTkOptionMenu(controls_harmonic_frame, variable=self.harmonic_metric_var,
-                                                      values=["SNR", "Z Score"])  # Stored instance
-        self.harmonic_metric_menu.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
-        ctk.CTkLabel(controls_harmonic_frame, text="Mean Threshold:").grid(row=0, column=2, padx=(15, 5), pady=5,
-                                                                           sticky="w")
-        ctk.CTkEntry(controls_harmonic_frame, textvariable=self.harmonic_threshold_var, validate='key',
-                     validatecommand=validate_num_cmd, width=100).grid(row=0, column=3, padx=5, pady=5, sticky="w")
-        ctk.CTkButton(controls_harmonic_frame, text="Run Harmonic Check", command=self.run_harmonic_check).grid(row=0,
-                                                                                                                column=4,
-                                                                                                                padx=15,
-                                                                                                                pady=5)
-        self.export_harmonic_check_btn = ctk.CTkButton(controls_harmonic_frame, text="Export Harmonic Results",
-                                                       state="disabled", command=self.export_harmonic_check_results)
-        self.export_harmonic_check_btn.grid(row=0, column=5, padx=5, pady=5)
-        controls_harmonic_frame.grid_columnconfigure(1, weight=1)  # Allow metric menu to expand
-
-        # --- Row 4: Results Textbox ---
-        self.results_textbox = ctk.CTkTextbox(main_frame, wrap="word", state="disabled",
-                                              font=ctk.CTkFont(family="Courier New", size=12))
-        self.results_textbox.grid(row=4, column=0, sticky="nsew", padx=5, pady=(10, 5))
-        main_frame.grid_rowconfigure(4, weight=1)
 
     def browse_folder(self):
         current_folder = self.stats_data_folder_var.get()

--- a/src/Tools/Stats/stats_constants.py
+++ b/src/Tools/Stats/stats_constants.py
@@ -1,0 +1,11 @@
+"""Shared constants for the Stats tool."""
+
+ROIS = {
+    "Frontal Lobe": ["F3", "F4", "Fz"],
+    "Occipital Lobe": ["O1", "O2", "Oz"],
+    "Parietal Lobe": ["P3", "P4", "Pz"],
+    "Central Lobe": ["C3", "C4", "Cz"],
+}
+
+ALL_ROIS_OPTION = "(All ROIs)"
+HARMONIC_CHECK_ALPHA = 0.05

--- a/src/Tools/Stats/stats_logging.py
+++ b/src/Tools/Stats/stats_logging.py
@@ -1,0 +1,11 @@
+"""Simple logger configuration for the Stats package."""
+
+import logging
+
+logger = logging.getLogger('fpvs.stats')
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('[%(levelname)s] %(name)s: %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)

--- a/src/Tools/Stats/stats_ui.py
+++ b/src/Tools/Stats/stats_ui.py
@@ -1,0 +1,105 @@
+"""UI helper functions for the Stats tool."""
+
+import customtkinter as ctk
+
+from config import FONT_BOLD
+from .stats_constants import ALL_ROIS_OPTION, ROIS
+
+
+def build_ui(win):
+    """Construct all widgets for a :class:`StatsAnalysisWindow`."""
+    validate_num_cmd = (win.register(win._validate_numeric), '%P')
+
+    main_frame = ctk.CTkFrame(win)
+    main_frame.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)
+    win.grid_rowconfigure(0, weight=1)
+    win.grid_columnconfigure(0, weight=1)
+    main_frame.grid_columnconfigure(0, weight=1)
+
+    # --- Row 0: Folder Selection ---
+    folder_frame = ctk.CTkFrame(main_frame)
+    folder_frame.grid(row=0, column=0, sticky="ew", padx=5, pady=(5, 10))
+    folder_frame.grid_columnconfigure(1, weight=1)
+    ctk.CTkLabel(folder_frame, text="Data Folder:").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+    ctk.CTkEntry(folder_frame, textvariable=win.stats_data_folder_var, state="readonly").grid(
+        row=0, column=1, padx=5, pady=5, sticky="ew")
+    ctk.CTkButton(folder_frame, text="Browse...", command=win.browse_folder).grid(row=0, column=2, padx=5, pady=5)
+    ctk.CTkLabel(folder_frame, textvariable=win.detected_info_var, justify="left", anchor="w").grid(
+        row=1, column=0, columnspan=3, padx=5, pady=5, sticky="w")
+
+    # --- Row 1: Common Setup ---
+    common_setup_frame = ctk.CTkFrame(main_frame)
+    common_setup_frame.grid(row=1, column=0, sticky="ew", padx=5, pady=5)
+    common_setup_frame.grid_columnconfigure(1, weight=1)
+    common_setup_frame.grid_columnconfigure(3, weight=1)
+    ctk.CTkLabel(common_setup_frame, text="Base Freq (Hz):").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+    ctk.CTkEntry(common_setup_frame, textvariable=win.base_freq_var, validate='key',
+                 validatecommand=validate_num_cmd, width=100).grid(row=0, column=1, padx=5, pady=5, sticky="w")
+    ctk.CTkLabel(common_setup_frame, text="ROI (Paired/ANOVA):").grid(row=1, column=0, padx=5, pady=5, sticky="w")
+    roi_options = [ALL_ROIS_OPTION] + list(ROIS.keys())
+    win.roi_menu = ctk.CTkOptionMenu(common_setup_frame, variable=win.roi_var,
+                                    values=roi_options)
+    win.roi_menu.grid(row=1, column=1, padx=5, pady=5, sticky="ew")
+    ctk.CTkLabel(common_setup_frame, text="Condition A (Paired):").grid(row=2, column=0, padx=5, pady=5, sticky="w")
+    win.condA_menu = ctk.CTkOptionMenu(common_setup_frame, variable=win.condition_A_var, values=["(Scan Folder)"],
+                                       command=lambda *_: win.update_condition_B_options())
+    win.condA_menu.grid(row=2, column=1, padx=5, pady=5, sticky="ew")
+    ctk.CTkLabel(common_setup_frame, text="Condition B (Paired):").grid(row=2, column=2, padx=(15, 5), pady=5,
+                                                                        sticky="w")
+    win.condB_menu = ctk.CTkOptionMenu(common_setup_frame, variable=win.condition_B_var,
+                                      values=["(Scan Folder)"])
+    win.condB_menu.grid(row=2, column=3, padx=5, pady=5, sticky="ew")
+
+    ctk.CTkLabel(common_setup_frame, text="Alpha (Sig. Level):").grid(row=3, column=0, padx=5, pady=5, sticky="w")
+    ctk.CTkEntry(common_setup_frame, textvariable=win.alpha_var, validate='key',
+                 validatecommand=validate_num_cmd, width=100).grid(row=3, column=1, padx=5, pady=5, sticky="w")
+
+    # --- Row 2: Section A - Summed BCA Analysis ---
+    summed_bca_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
+    summed_bca_frame.grid(row=2, column=0, sticky="ew", padx=5, pady=(10, 5))
+    ctk.CTkLabel(summed_bca_frame, text="Summed BCA Analysis:", font=FONT_BOLD).pack(anchor="w", pady=(0, 5))
+    buttons_summed_frame = ctk.CTkFrame(summed_bca_frame)
+    buttons_summed_frame.pack(fill="x", padx=0, pady=0)
+    ctk.CTkButton(buttons_summed_frame, text="Run Paired Tests (Summed BCA)", command=win.run_paired_tests).pack(
+        side="left", padx=(0, 5), pady=5)
+    ctk.CTkButton(buttons_summed_frame, text="Run RM-ANOVA (Summed BCA)", command=win.run_rm_anova).pack(
+        side="left", padx=5, pady=5)
+    ctk.CTkButton(buttons_summed_frame, text="Run Mixed Model (Summed BCA)", command=win.run_mixed_model).pack(
+        side="left", padx=5, pady=5)
+    win.export_paired_tests_btn = ctk.CTkButton(buttons_summed_frame, text="Export Paired Results",
+                                               state="disabled", command=win.export_paired_results)
+    win.export_paired_tests_btn.pack(side="left", padx=5, pady=5)
+    win.export_rm_anova_btn = ctk.CTkButton(buttons_summed_frame, text="Export RM-ANOVA", state="disabled",
+                                            command=win.export_rm_anova_results)
+    win.export_rm_anova_btn.pack(side="left", padx=5, pady=5)
+    win.export_mixed_model_btn = ctk.CTkButton(buttons_summed_frame, text="Export Mixed Model", state="disabled",
+                                              command=win.export_mixed_model_results)
+    win.export_mixed_model_btn.pack(side="left", padx=5, pady=5)
+
+    # --- Row 3: Section B - Harmonic Significance Check ---
+    harmonic_check_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
+    harmonic_check_frame.grid(row=3, column=0, sticky="ew", padx=5, pady=5)
+    ctk.CTkLabel(harmonic_check_frame, text="Per-Harmonic Significance Check:",
+                 font=FONT_BOLD).pack(anchor="w", pady=(0, 5))
+    controls_harmonic_frame = ctk.CTkFrame(harmonic_check_frame)
+    controls_harmonic_frame.pack(fill="x", padx=0, pady=0)
+    ctk.CTkLabel(controls_harmonic_frame, text="Metric:").grid(row=0, column=0, padx=(0, 5), pady=5, sticky="w")
+    win.harmonic_metric_menu = ctk.CTkOptionMenu(controls_harmonic_frame, variable=win.harmonic_metric_var,
+                                                values=["SNR", "Z Score"])
+    win.harmonic_metric_menu.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
+    ctk.CTkLabel(controls_harmonic_frame, text="Mean Threshold:").grid(row=0, column=2, padx=(15, 5), pady=5,
+                                                                       sticky="w")
+    ctk.CTkEntry(controls_harmonic_frame, textvariable=win.harmonic_threshold_var, validate='key',
+                 validatecommand=validate_num_cmd, width=100).grid(row=0, column=3, padx=5, pady=5, sticky="w")
+    ctk.CTkButton(controls_harmonic_frame, text="Run Harmonic Check", command=win.run_harmonic_check).grid(
+        row=0, column=4, padx=15, pady=5)
+    win.export_harmonic_check_btn = ctk.CTkButton(controls_harmonic_frame, text="Export Harmonic Results",
+                                                 state="disabled", command=win.export_harmonic_check_results)
+    win.export_harmonic_check_btn.grid(row=0, column=5, padx=5, pady=5)
+    controls_harmonic_frame.grid_columnconfigure(1, weight=1)
+
+    # --- Row 4: Results Textbox ---
+    win.results_textbox = ctk.CTkTextbox(main_frame, wrap="word", state="disabled",
+                                        font=ctk.CTkFont(family="Courier New", size=12))
+    win.results_textbox.grid(row=4, column=0, sticky="nsew", padx=5, pady=(10, 5))
+    main_frame.grid_rowconfigure(4, weight=1)


### PR DESCRIPTION
## Summary
- move ROI constants to `stats_constants.py`
- provide common logger via `stats_logging.py`
- extract widget layout into new `stats_ui.py`
- refactor `stats.py` and `mixed_effects_model.py` to use the new modules

## Testing
- `python -m py_compile src/Tools/Stats/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841eb2b510c832c993f0063404c1918