### PR TITLE
Add post-hoc factor for condition by roi

### DIFF
--- a/src/Tools/Stats/posthoc_tests.py
+++ b/src/Tools/Stats/posthoc_tests.py
@@ -1,0 +1,133 @@
+# posthoc_tests.py
+# -*- coding: utf-8 -*-
+"""Utility functions for post-hoc comparisons after repeated measures ANOVA.
+
+This module implements paired comparisons across levels of a factor
+(e.g., conditions or ROIs) using paired t-tests with multiple comparison
+corrections. It is designed to be called after an RM-ANOVA to pinpoint
+which specific levels differ from each other.
+
+The functions return a detailed text log explaining the results so that
+the user can easily interpret the findings in a publication-ready format.
+"""
+
+from itertools import combinations
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+from statsmodels.stats.multitest import multipletests
+
+
+def run_posthoc_pairwise_tests(data, dv_col, factor_col, subject_col,
+                               correction="holm", alpha=0.05):
+    """Run pairwise repeated-measures t-tests.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        Long-format data containing one row per observation with columns for
+        subject ID, the dependent variable, and a within-subject factor.
+    dv_col : str
+        Name of the dependent variable column.
+    factor_col : str
+        Name of the column representing the factor to compare (e.g., ``condition``
+        or ``roi``).
+    subject_col : str
+        Name of the subject identifier column.
+    correction : str, optional
+        Method for p-value correction. Any method accepted by
+        ``statsmodels.stats.multitest.multipletests`` is valid. Default ``"holm"``.
+    alpha : float, optional
+        Significance level used when interpreting corrected p-values.
+
+    Returns
+    -------
+    tuple
+        (log_output: str, results_df: pandas.DataFrame)
+    """
+    output_lines = [
+        "============================================================",
+        "              Post-hoc Pairwise Comparisons",
+        "============================================================",
+        f"Factor analyzed: '{factor_col}'",
+        f"Correction method: {correction}",
+        f"Significance level: alpha = {alpha}\n",
+    ]
+
+    if factor_col not in data.columns or dv_col not in data.columns or subject_col not in data.columns:
+        output_lines.append("Required columns missing from data. Cannot run post-hoc tests.")
+        return "\n".join(output_lines), pd.DataFrame()
+
+    levels = data[factor_col].dropna().unique()
+    if len(levels) < 2:
+        output_lines.append("Not enough levels for pairwise comparisons.")
+        return "\n".join(output_lines), pd.DataFrame()
+
+    comparisons = list(combinations(levels, 2))
+    test_stats = []
+    p_values = []
+    n_pairs = []
+
+    for level_a, level_b in comparisons:
+        df_a = data[data[factor_col] == level_a]
+        df_b = data[data[factor_col] == level_b]
+        merged = pd.merge(
+            df_a[[subject_col, dv_col]],
+            df_b[[subject_col, dv_col]],
+            on=subject_col,
+            suffixes=("_a", "_b"),
+        )
+        pair_count = len(merged)
+        if pair_count < 3:
+            output_lines.append(f"Comparison {level_a} vs {level_b}: insufficient paired data (N={pair_count}).")
+            test_stats.append(np.nan)
+            p_values.append(np.nan)
+            n_pairs.append(pair_count)
+            continue
+        t_stat, p_val = stats.ttest_rel(merged[f"{dv_col}_a"], merged[f"{dv_col}_b"])
+        test_stats.append(t_stat)
+        p_values.append(p_val)
+        n_pairs.append(pair_count)
+
+    # Correct for multiple comparisons (ignore NaNs)
+    valid_idx = [i for i, p in enumerate(p_values) if not np.isnan(p)]
+    corrected_p = [np.nan] * len(p_values)
+    significant = [False] * len(p_values)
+    if valid_idx:
+        pvals = [p_values[i] for i in valid_idx]
+        reject, pvals_corr, _, _ = multipletests(pvals, alpha=alpha, method=correction)
+        for i, p_corr, rej in zip(valid_idx, pvals_corr, reject):
+            corrected_p[i] = p_corr
+            significant[i] = rej
+
+    results_records = []
+    for idx, (level_a, level_b) in enumerate(comparisons):
+        t_stat = test_stats[idx]
+        p_val = p_values[idx]
+        p_corr = corrected_p[idx]
+        sig = significant[idx]
+        output_lines.append(f"--- {level_a} vs {level_b} ---")
+        if np.isnan(p_val):
+            output_lines.append("  Skipped: insufficient paired observations.\n")
+            continue
+        output_lines.append(f"  t({n_pairs[idx]-1}) = {t_stat:.3f}")
+        output_lines.append(f"  Raw p-value = {p_val:.4f}")
+        output_lines.append(f"  Corrected p-value = {p_corr:.4f}")
+        if sig:
+            output_lines.append("  FINDING: SIGNIFICANT DIFFERENCE after correction.\n")
+        else:
+            output_lines.append("  Finding: No significant difference after correction.\n")
+        results_records.append({
+            "Level_A": level_a,
+            "Level_B": level_b,
+            "N_Pairs": n_pairs[idx],
+            "t_statistic": t_stat,
+            "p_value": p_val,
+            "p_value_corrected": p_corr,
+            "Significant": sig,
+        })
+
+    output_lines.append("============================================================")
+    results_df = pd.DataFrame(results_records)
+    return "\n".join(output_lines), results_df

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -27,6 +27,7 @@ import scipy.stats as stats
 
 from . import stats_export  # Excel export helpers
 from . import stats_analysis  # Heavy data processing functions
+from .posthoc_tests import run_posthoc_pairwise_tests
 
 # Regions of Interest (10-20 montage)
 ROIS = {
@@ -59,6 +60,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.paired_tests_results_data = []
         self.rm_anova_results_data = None  # Will store ANOVA table (ideally DataFrame)
         self.harmonic_check_results_data = []
+        self.posthoc_results_data = None  # DataFrame from post-hoc pairwise tests
 
         # UI state variables
         self.stats_data_folder_var = tk.StringVar(master=self, value=default_folder)
@@ -69,6 +71,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.condition_B_var = tk.StringVar(master=self)
         self.harmonic_metric_var = tk.StringVar(master=self, value="SNR")
         self.harmonic_threshold_var = tk.StringVar(master=self, value="1.96")
+        self.posthoc_factor_var = tk.StringVar(master=self, value="condition")
 
         # UI Widget References (stored for potential future dynamic updates)
         self.roi_menu = None
@@ -80,6 +83,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.export_paired_tests_btn = None
         self.export_rm_anova_btn = None
         self.export_harmonic_check_btn = None
+        self.export_posthoc_btn = None
 
         self.create_widgets()
         if default_folder and os.path.isdir(default_folder):
@@ -155,6 +159,13 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
                                             values=["(Scan Folder)"])  # Already stored
         self.condB_menu.grid(row=2, column=3, padx=5, pady=5, sticky="ew")
 
+        ctk.CTkLabel(common_setup_frame, text="Post-hoc Factor:").grid(row=3, column=0, padx=5, pady=5, sticky="w")
+        ctk.CTkOptionMenu(
+            common_setup_frame,
+            variable=self.posthoc_factor_var,
+            values=["condition", "roi", "condition by roi"],
+        ).grid(row=3, column=1, padx=5, pady=5, sticky="ew")
+
         # --- Row 2: Section A - Summed BCA Analysis ---
         summed_bca_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
         summed_bca_frame.grid(row=2, column=0, sticky="ew", padx=5, pady=(10, 5))
@@ -165,6 +176,8 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         ctk.CTkButton(buttons_summed_frame, text="Run Paired Tests (Summed BCA)", command=self.run_paired_tests).pack(
             side="left", padx=(0, 5), pady=5)
         ctk.CTkButton(buttons_summed_frame, text="Run RM-ANOVA (Summed BCA)", command=self.run_rm_anova).pack(
+            side="left", padx=5, pady=5)
+        ctk.CTkButton(buttons_summed_frame, text="Run Post-hoc Tests", command=self.run_posthoc_tests).pack(
             side="left", padx=5, pady=5)
         self.export_paired_tests_btn = ctk.CTkButton(
             buttons_summed_frame,
@@ -188,6 +201,18 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
             ),
         )
         self.export_rm_anova_btn.pack(side="left", padx=5, pady=5)
+        self.export_posthoc_btn = ctk.CTkButton(
+            buttons_summed_frame,
+            text="Export Post-hoc Results",
+            state="disabled",
+            command=lambda: stats_export.export_posthoc_results_to_excel(
+                results_df=self.posthoc_results_data,
+                factor=self.posthoc_factor_var.get(),
+                parent_folder=self.stats_data_folder_var.get(),
+                log_func=self.log_to_main_app,
+            ),
+        )
+        self.export_posthoc_btn.pack(side="left", padx=5, pady=5)
 
         # --- Row 3: Section B - Harmonic Significance Check ---
         harmonic_check_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
@@ -605,6 +630,55 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.results_textbox.configure(state="disabled")
         self.log_to_main_app("RM-ANOVA (Summed BCA) attempt complete.")
 
+    def run_posthoc_tests(self):
+        self.log_to_main_app("Running post-hoc pairwise tests...")
+        self.results_textbox.configure(state="normal")
+        self.results_textbox.delete("1.0", tk.END)
+        self.export_posthoc_btn.configure(state="disabled")
+        self.posthoc_results_data = None
+
+        if not self.all_subject_data and not self.prepare_all_subject_summed_bca_data():
+            messagebox.showerror("Data Error", "Summed BCA data could not be prepared for post-hoc tests.")
+            self.results_textbox.configure(state="disabled")
+            return
+
+        long_format_data = []
+        for pid, cond_data in self.all_subject_data.items():
+            for cond_name, roi_data in cond_data.items():
+                for roi_name, value in roi_data.items():
+                    if not pd.isna(value):
+                        long_format_data.append({'subject': pid, 'condition': cond_name, 'roi': roi_name, 'value': value})
+
+        if not long_format_data:
+            messagebox.showerror("Data Error", "No valid data available for post-hoc tests after filtering NaNs.")
+            self.results_textbox.configure(state="disabled")
+            return
+
+        df_long = pd.DataFrame(long_format_data)
+        factor = self.posthoc_factor_var.get()
+        if factor not in ["condition", "roi", "condition by roi"]:
+            messagebox.showerror("Input Error", f"Invalid factor selected for post-hoc tests: {factor}")
+            self.results_textbox.configure(state="disabled")
+            return
+
+        factor_col = factor
+        if factor == "condition by roi":
+            df_long[factor] = df_long["condition"].astype(str) + " | " + df_long["roi"].astype(str)
+
+        output_text, results_df = run_posthoc_pairwise_tests(
+            data=df_long,
+            dv_col='value',
+            factor_col=factor_col,
+            subject_col='subject'
+        )
+
+        self.posthoc_results_data = results_df
+        self.results_textbox.insert("1.0", output_text)
+        if results_df is not None and not results_df.empty:
+            self.export_posthoc_btn.configure(state="normal")
+        self.results_textbox.configure(state="disabled")
+        self.log_to_main_app("Post-hoc pairwise tests complete.")
+
     def run_harmonic_check(self):
         self.log_to_main_app("Running Per-Harmonic Significance Check...")
         self.results_textbox.configure(state="normal");
@@ -841,6 +915,9 @@ if __name__ == "__main__":
             def export_significance_results_to_excel(self, findings_dict, metric, threshold, parent_folder,
                                                      log_func): log_func(
                 f"Mock: export_significance_results_to_excel called for {metric}")
+
+            def export_posthoc_results_to_excel(self, results_df, factor, parent_folder, log_func): log_func(
+                "Mock: export_posthoc_results_to_excel called")
 
 
         class MockRepeatedMAnova:

--- a/src/Tools/Stats/stats_export.py
+++ b/src/Tools/Stats/stats_export.py
@@ -272,3 +272,42 @@ def export_rm_anova_results_to_excel(anova_table, parent_folder, log_func=print)
     except Exception as e:
         log_func(f"!!! RM-ANOVA Export Failed: {e}\n{traceback.format_exc()}")
         messagebox.showerror("Export Failed", f"Could not save Excel file: {e}")
+
+
+# --- Export Function for Post-hoc Pairwise Test Results ---
+def export_posthoc_results_to_excel(results_df, factor, parent_folder, log_func=print):
+    """Exports post-hoc pairwise test results to an Excel file."""
+    log_func("Attempting to export Post-hoc results...")
+    if results_df is None or not isinstance(results_df, pd.DataFrame) or results_df.empty:
+        log_func("No Post-hoc results data available to export.")
+        messagebox.showwarning("No Results", "No Post-hoc results to export.")
+        return
+
+    df_export = results_df.copy()
+    preferred_cols = ['Level_A', 'Level_B', 'N_Pairs', 't_statistic', 'p_value', 'p_value_corrected', 'Significant']
+    df_export = df_export[[col for col in preferred_cols if col in df_export.columns]]
+
+    initial_dir = parent_folder if os.path.isdir(parent_folder) else os.path.expanduser("~")
+    factor_name = factor.replace(' ', '_')
+    suggested_filename = f"Stats_Posthoc_{factor_name}.xlsx"
+
+    save_path = filedialog.asksaveasfilename(
+        title=f"Save Post-hoc Results ({factor})",
+        initialdir=initial_dir, initialfile=suggested_filename, defaultextension=".xlsx",
+        filetypes=[("Excel Workbook", "*.xlsx"), ("All Files", "*.*")]
+    )
+    if not save_path: log_func("Post-hoc export cancelled."); return
+
+    try:
+        log_func(f"Exporting Post-hoc results to: {save_path}")
+        with pd.ExcelWriter(save_path, engine='xlsxwriter') as writer:
+            _auto_format_and_write_excel(writer, df_export, 'Post-hoc Results', log_func)
+        log_func("Post-hoc results export successful.")
+        messagebox.showinfo("Export Successful", f"Post-hoc results exported to:\n{save_path}")
+    except PermissionError:
+        err_msg = f"Permission denied writing to {save_path}. File may be open or folder write-protected."
+        log_func(f"!!! Export Failed: {err_msg}")
+        messagebox.showerror("Export Failed", err_msg)
+    except Exception as e:
+        log_func(f"!!! Post-hoc Export Failed: {e}\n{traceback.format_exc()}")
+        messagebox.showerror("Export Failed", f"Could not save Excel file: {e}")


### PR DESCRIPTION
## Summary
- extend Stats GUI to let users choose a post‑hoc factor of **condition by roi**
- build combined factor column in `run_posthoc_tests` when selected

## Testing
- `python3 -m py_compile src/Tools/Stats/posthoc_tests.py src/Tools/Stats/stats_export.py src/Tools/Stats/stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68420721df8c832cb9df8d36eace4d4a