### PR TITLE
Fix Stats tool initialization

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -24,6 +24,10 @@ import customtkinter as ctk
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
+# Import fonts and initialization helper from the main config so the Stats
+# window uses the same style settings as the rest of the application.
+from config import init_fonts, FONT_MAIN, FONT_BOLD
+
 import pandas as pd
 import numpy as np
 import scipy.stats as stats


### PR DESCRIPTION
## Summary
- import fonts and init helper from `config` in the stats tool

## Testing
- `python -m py_compile src/Tools/Stats/stats.py`
- `python -m py_compile src/fpvs_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68446e5662ac832c93b4cfdbb6dbbfb1