### PR TITLE
Fix event map default row loading

### DIFF
--- a/src/Main_App/event_map_utils.py
+++ b/src/Main_App/event_map_utils.py
@@ -102,6 +102,16 @@ class EventMapMixin:
         except Exception as e:
             self.log(f"Error removing Event Map row: {e}\n{traceback.format_exc()}")
 
+    def clear_event_map_entries(self):
+        """Remove all event map rows without adding a new blank row."""
+        if not hasattr(self, 'event_map_entries'):
+            return
+        for entry in list(self.event_map_entries):
+            frame = entry.get('frame')
+            if frame and frame.winfo_exists():
+                frame.destroy()
+        self.event_map_entries.clear()
+
     def _focus_next_id_entry(self, event):
         # (left intentionally blank)
         pass

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -480,15 +480,17 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
 
         # Event map defaults
         pairs = self.settings.get_event_pairs()
+        # Clear any existing rows without auto-adding a blank one
+        self.clear_event_map_entries()
         if pairs:
-            # Remove existing default row first
-            for entry in list(self.event_map_entries):
-                self.remove_event_map_entry(entry['frame'])
             for label, id_val in pairs:
                 self.add_event_map_entry()
                 row = self.event_map_entries[-1]
                 row['label'].insert(0, label)
                 row['id'].insert(0, id_val)
+        else:
+            # Ensure at least one empty row is present
+            self.add_event_map_entry()
 
         # Stim channel override
         global DEFAULT_STIM_CHANNEL


### PR DESCRIPTION
## Summary
- add a method to clear event map entries
- avoid leaving a blank row when loading defaults

## Testing
- `python -m py_compile src/Main_App/event_map_utils.py src/fpvs_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68447b896008832cb791ba4e490c3da6