### PR TITLE
Fix config imports

### DIFF
--- a/src/Main_App/ui_event_map_manager.py
+++ b/src/Main_App/ui_event_map_manager.py
@@ -10,10 +10,17 @@ import traceback
 from typing import Optional, Dict, Any
 
 try:
-    from ..config import PAD_X, PAD_Y, CORNER_RADIUS, LABEL_ID_ENTRY_WIDTH
-    # LABEL_ID_ENTRY_WIDTH is used for the Condition Label entry
+    # When running ``main.py`` directly, relative imports like ``..config``
+    # fail because the package hierarchy is not established. Importing from
+    # ``config`` ensures the constants are available regardless of how the app
+    # is launched.
+    from config import PAD_X, PAD_Y, CORNER_RADIUS, LABEL_ID_ENTRY_WIDTH
+    # ``LABEL_ID_ENTRY_WIDTH`` is used for the Condition Label entry.
 except ImportError:
-    print("Warning [ui_event_map_manager.py]: Could not import from ..config. Using fallback UI constants.")
+    print(
+        "Warning [ui_event_map_manager.py]: Could not import from config. "
+        "Using fallback UI constants."
+    )
     PAD_X = 5
     PAD_Y = 5
     CORNER_RADIUS = 6

--- a/src/Main_App/ui_setup_panels.py
+++ b/src/Main_App/ui_setup_panels.py
@@ -9,13 +9,24 @@ import customtkinter as ctk
 
 # Attempt to import constants from config.py
 try:
-    from ..config import (
-        ENTRY_WIDTH, PAD_X, PAD_Y, CORNER_RADIUS
-        # DEFAULT_STIM_CHANNEL and STIM_CHANNEL_ENTRY_WIDTH are no longer needed here
-        # LABEL_ID_ENTRY_WIDTH is for event_map, not these panels
+    # When ``main.py`` is executed directly the package hierarchy is not
+    # recognised, so ``..config`` cannot be resolved.  Importing from
+    # ``config`` allows the app to run both as ``python src/main.py`` and
+    # ``python -m src.main``.
+    from config import (
+        ENTRY_WIDTH,
+        PAD_X,
+        PAD_Y,
+        CORNER_RADIUS,
+        # ``DEFAULT_STIM_CHANNEL`` and ``STIM_CHANNEL_ENTRY_WIDTH`` are no
+        # longer needed here. ``LABEL_ID_ENTRY_WIDTH`` is only used in the
+        # event map manager.
     )
 except ImportError:
-    print("Warning [ui_setup_panels.py]: Could not import from ..config. Using fallback UI constants.")
+    print(
+        "Warning [ui_setup_panels.py]: Could not import from config. "
+        "Using fallback UI constants."
+    )
     ENTRY_WIDTH = 80
     PAD_X = 5
     PAD_Y = 5


### PR DESCRIPTION
## Summary
- import config constants directly so main.py can be run as a script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447e6aec4c832ca52a207299f4902e