### PR TITLE
Add global debug mode toggle

### DIFF
--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -18,3 +18,7 @@ class LoggingMixin:
         except Exception as e:  # pragma: no cover - best effort logging
             print(f"[Log Error] {e}. Message: {message}")
         print(formatted, end="")
+
+    def debug(self, message: str) -> None:
+        if hasattr(self, 'settings') and getattr(self, 'settings').debug_enabled():
+            self.log(f"[DEBUG] {message}")

--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -23,6 +23,9 @@ DEFAULTS = {
     'events': {
         'labels': '',
         'ids': ''
+    },
+    'debug': {
+        'enabled': 'False'
     }
 }
 
@@ -77,3 +80,6 @@ class SettingsManager:
         ids = ','.join([p[1] for p in pairs])
         self.set('events', 'labels', labels)
         self.set('events', 'ids', ids)
+
+    def debug_enabled(self) -> bool:
+        return self.get('debug', 'enabled', 'False').lower() == 'true'

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -72,8 +72,12 @@ class SettingsWindow(ctk.CTkToplevel):
         ctk.CTkEntry(self, textvariable=id_var).grid(row=10, column=1, columnspan=2, sticky="ew", padx=pad)
         self.id_var = id_var
 
+        debug_default = self.manager.get('debug', 'enabled', 'False').lower() == 'true'
+        self.debug_var = tk.BooleanVar(value=debug_default)
+        ctk.CTkLabel(self, text="Debug Mode").grid(row=11, column=0, sticky="w", padx=pad, pady=(pad,0))
+        ctk.CTkCheckBox(self, text="Enable", variable=self.debug_var).grid(row=11, column=1, sticky="w", padx=pad, pady=(pad,0))
         btn_frame = ctk.CTkFrame(self, fg_color="transparent")
-        btn_frame.grid(row=11, column=0, columnspan=3, pady=(pad*2, pad))
+        btn_frame.grid(row=12, column=0, columnspan=3, pady=(pad*2, pad))
         ctk.CTkButton(btn_frame, text="Reset to Defaults", command=self._reset).pack(side="left", padx=pad)
         ctk.CTkButton(btn_frame, text="Save", command=self._save).pack(side="right", padx=pad)
 
@@ -97,10 +101,16 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('stim','channel', self.stim_var.get())
         self.manager.set('events','labels', self.cond_var.get())
         self.manager.set('events','ids', self.id_var.get())
+        prev_debug = self.manager.get('debug', 'enabled', 'False').lower() == 'true'
+        self.manager.set('debug','enabled', str(self.debug_var.get()))
         self.manager.save()
 
         # Apply the new appearance mode immediately across the app
         if hasattr(self.master, "set_appearance_mode"):
             self.master.set_appearance_mode(self.mode_var.get())
+
+        if prev_debug != self.debug_var.get():
+            from tkinter import messagebox
+            messagebox.showinfo("Restart Required", "Please restart the app for debug mode changes to take effect.")
 
         self.destroy()

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -153,6 +153,8 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         self.log_text = None
         self.progress_bar = None
         self.menubar = None
+        self.date_label = None
+        self.debug_label = None
 
         # --- Register Validation Commands ---
         self.validate_num_cmd = (self.register(self._validate_numeric_input), '%P')
@@ -212,6 +214,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
     def open_advanced_analysis_window(self):
         """Opens the Advanced Preprocessing Epoch Averaging window."""
         self.log("Opening Advanced Analysis (Preprocessing Epoch Averaging) tool...")
+        self.debug("Advanced analysis window requested")
         # AdvancedAnalysisWindow is imported from Tools.Average_Preprocessing
         adv_win = AdvancedAnalysisWindow(master=self)
         adv_win.geometry(self.settings.get('gui', 'advanced_size', '1050x850'))
@@ -232,6 +235,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
     def open_stats_analyzer(self):
         """Opens the statistical analysis Toplevel window."""
         self.log("Opening Statistical Analysis tool...")  # Log the action
+        self.debug("Stats window requested")
 
         # Get the last used output folder path from the main GUI's variable
         last_output_folder = self.save_folder_path.get()
@@ -247,6 +251,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
 
     def open_image_resizer(self):
         """Open the FPVS Image_Resizer tool in a new CTkToplevel."""
+        self.debug("Image resizer window requested")
         # We pass `self` so the new window is a child of the main app:
         win = FPVSImageResizer(self)
         win.geometry(self.settings.get('gui', 'resizer_size', '800x600'))
@@ -401,6 +406,8 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         top_bar.grid_columnconfigure(0, weight=0)  # Select button
         top_bar.grid_columnconfigure(1, weight=1)  # Output folder button (centered)
         top_bar.grid_columnconfigure(2, weight=0)  # Start button
+        top_bar.grid_columnconfigure(3, weight=0)  # Date label
+        top_bar.grid_columnconfigure(4, weight=0)  # Debug label
 
         self.select_button = ctk.CTkButton(top_bar, text="Select EEG File…",
                                            command=self.select_data_source,
@@ -418,6 +425,13 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
                                           corner_radius=CORNER_RADIUS, width=180,
                                           font=ctk.CTkFont(weight="bold"))
         self.start_button.grid(row=0, column=2, sticky="e", padx=(PAD_X, 0))
+
+        from datetime import datetime
+        self.date_label = ctk.CTkLabel(top_bar, text=datetime.now().strftime("%Y-%m-%d"))
+        self.date_label.grid(row=0, column=3, padx=(PAD_X, 0))
+        if self.settings.debug_enabled():
+            self.debug_label = ctk.CTkLabel(top_bar, text="DEBUG MODE ENABLED", text_color="red")
+            self.debug_label.grid(row=0, column=4, padx=(PAD_X, 0))
 
         # --- Create Setup Panels using SetupPanelManager ---
         # (Options Panel on row=1, Params Panel on row=2, inside main_frame)


### PR DESCRIPTION
## Summary
- add debug flag to settings
- allow toggling debug mode in settings window
- create new debug method in logging mixin
- show date and optional DEBUG label in main window
- log debug when auxiliary windows open

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447ee215f0832c9f26db87d5d05dde