### PR TITLE
Fix initial event map row focus handling

### DIFF
--- a/src/Main_App/ui_event_map_manager.py
+++ b/src/Main_App/ui_event_map_manager.py
@@ -83,7 +83,10 @@ class EventMapManager:
         self.app_ref.add_map_button.pack(side="left")
 
 
-        self._add_new_event_row_ui(focus_new_row=True)
+        # The initial row should not request focus to avoid log spam about a
+        # missing widget during startup. Subsequent rows will still request
+        # focus when added via the "+ Add Condition" button.
+        self._add_new_event_row_ui(focus_new_row=False)
 
 
     def add_event_map_entry_from_manager(self, event=None):


### PR DESCRIPTION
## Summary
- stop focusing the initial Event Map row to avoid missing widget logs

## Testing
- `python -m py_compile src/Main_App/ui_event_map_manager.py`
- `python src/main.py` *(fails: ImportError: cannot import name 'windll')*

------
https://chatgpt.com/codex/tasks/task_e_68448cf92094832ca399aa6550a780ea