### PR TITLE
Bundle mne stubs for PyInstaller

### DIFF
--- a/src/Compiler Script.py
+++ b/src/Compiler Script.py
@@ -6,6 +6,7 @@ pyinstaller `
   --paths=src `
   -i "C:\Users\zackm\OneDrive - Mississippi State University\Office Desktop\ToolBox Icon.ico" `
   --collect-all mne `
+  --collect-data mne `
   --hidden-import=mne.io.bdf `
   --hidden-import=mne.io.eeglab `
   --hidden-import=scipy `

--- a/src/Misc/Compiler Script.py
+++ b/src/Misc/Compiler Script.py
@@ -25,6 +25,8 @@ if __name__ == "__main__":
 
         "--collect-all",
         "mne",
+        "--collect-data",
+        "mne",
         "--hidden-import",
         "mne.io.bdf",
         "--hidden-import",


### PR DESCRIPTION
## Summary
- include data stubs for the `mne` package when building executables

## Testing
- `python -m py_compile src/Misc/Compiler Script.py`


------
https://chatgpt.com/codex/tasks/task_e_6844903d770c832cb93479a9ca4458f1