### PR TITLE
Improve auto-update mechanism

### DIFF
--- a/src/Main_App/update_manager.py
+++ b/src/Main_App/update_manager.py
@@ -71,6 +71,7 @@ def _find_exe_asset(data):
 
 
 def _perform_update(url, version, changelog, app):
+    """Download the update and schedule replacement of the running executable."""
     try:
         app.log(f"Downloading update from {url}")
         with requests.get(url, stream=True, timeout=10) as r:
@@ -82,15 +83,72 @@ def _perform_update(url, version, changelog, app):
                 tmp_path = tmp.name
 
         current_exe = sys.executable
+        pid = os.getpid()
         backup = current_exe + ".old"
-        app.log("Replacing executable...")
-        try:
-            if os.path.exists(backup):
-                os.remove(backup)
-        except Exception:
-            pass
-        os.replace(current_exe, backup)
-        os.replace(tmp_path, current_exe)
+        script_ext = ".bat" if os.name == "nt" else ".sh"
+        script = tempfile.NamedTemporaryFile(delete=False, suffix=script_ext)
+        script_path = script.name
+        script.close()
+        log_path = script_path + ".log"
+
+        if os.name == "nt":
+            lines = f"""@echo off
+set EXE=\"{current_exe}\"
+set NEW=\"{tmp_path}\"
+set BACKUP=\"{backup}\"
+set LOG=\"{log_path}\"
+:wait
+tasklist /FI "PID eq {pid}" | find "{pid}" >nul
+if not errorlevel 1 (
+    timeout /T 1 >nul
+    goto wait
+)
+echo Updating >> "%LOG%" 2>&1
+move /Y "%EXE%" "%BACKUP%" >> "%LOG%" 2>&1
+if errorlevel 1 goto fail
+move /Y "%NEW%" "%EXE%" >> "%LOG%" 2>&1
+if errorlevel 1 goto fail
+start "" "%EXE%"
+del "%BACKUP%" >> "%LOG%" 2>&1
+del "%~f0"
+exit /b
+:fail
+echo Failed to replace executable >> "%LOG%" 2>&1
+exit /b 1
+"""
+        else:
+            lines = f"""#!/bin/sh
+EXE=\"{current_exe}\"
+NEW=\"{tmp_path}\"
+BACKUP=\"{backup}\"
+LOG=\"{log_path}\"
+while kill -0 {pid} 2>/dev/null; do
+    sleep 1
+done
+echo Updating >> "$LOG" 2>&1
+mv "$EXE" "$BACKUP" >> "$LOG" 2>&1
+if [ $? -ne 0 ]; then
+    echo Failed to backup executable >> "$LOG" 2>&1
+    exit 1
+fi
+mv "$NEW" "$EXE" >> "$LOG" 2>&1
+if [ $? -ne 0 ]; then
+    echo Failed to replace executable >> "$LOG" 2>&1
+    mv "$BACKUP" "$EXE" >> "$LOG" 2>&1
+    exit 1
+fi
+"$EXE" &
+rm -f "$BACKUP"
+rm -- "$0"
+"""
+
+        with open(script_path, "w", newline="\r\n" if os.name == "nt" else "\n") as f:
+            f.write(lines)
+        if os.name != "nt":
+            os.chmod(script_path, 0o755)
+
+        app.log(f"Launching update script {script_path}")
+        subprocess.Popen([script_path], close_fds=True)
 
         messagebox.showinfo(
             "Update Installed",
@@ -98,7 +156,6 @@ def _perform_update(url, version, changelog, app):
             "The application will now restart.\n\n",
             f"Changelog:\n{changelog}",
         )
-        subprocess.Popen([current_exe])
         app.destroy()
     except Exception as e:
         app.log(f"Update failed: {e}")


### PR DESCRIPTION
## Summary
- create a temporary script that waits for the current process to exit
- move the downloaded executable into place through the script
- launch the script and exit the app

## Testing
- `python -m py_compile src/Main_App/update_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c0e9592c832c8e90f1ec17ca8679