### PR TITLE
Refactor update checks and cleanup

### DIFF
--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -97,6 +97,8 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
     def __init__(self):
         super().__init__()
 
+        update_manager.cleanup_old_executable()
+
         self.settings = SettingsManager()
 
 
@@ -206,7 +208,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
 
         # Automatically check for updates without blocking the UI
         try:
-            update_manager.check_for_updates_async(self)
+            update_manager.check_for_updates_async(self, silent=False)
         except Exception as e:
             self.log(f"Auto update check failed: {e}")
 


### PR DESCRIPTION
## Summary
- ensure message boxes run on the UI thread
- remove leftover updater backups on startup
- trigger update checks with visible prompts by default

## Testing
- `python3 -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845c0d90aa8832c9c340f8dc2abfc8d