### PR TITLE
Fix settings window z-order

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -16,6 +16,8 @@ class SettingsWindow(ctk.CTkToplevel):
         self.geometry("420x600")
         self.resizable(False, False)
         self._build_ui()
+        self.grab_set()
+        self.focus_force()
 
     def _build_ui(self):
         pad = 10


### PR DESCRIPTION
## Summary
- make settings window modal and focused so it opens above the main GUI

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845f31994ec832cbca4b4e4102281d0