### PR TITLE
Fix settings debug option clipped

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -13,7 +13,9 @@ class SettingsWindow(ctk.CTkToplevel):
         init_fonts()
         self.option_add("*Font", str(FONT_MAIN), 80)
         self.title("Settings")
-        self.geometry("420x600")
+        # Widen the window slightly so the debug checkbox
+        # is not clipped on some platforms
+        self.geometry("460x600")
         self.resizable(False, False)
         self._build_ui()
         self.grab_set()


### PR DESCRIPTION
## Summary
- widen settings window so debug checkbox is fully visible

## Testing
- `python -m py_compile src/Main_App/settings_window.py`


------
https://chatgpt.com/codex/tasks/task_e_6845f572558c832cacfa8ad350e82bc2