### PR TITLE
Update check shows popup only when new version

### DIFF
--- a/src/Main_App/update_manager.py
+++ b/src/Main_App/update_manager.py
@@ -20,19 +20,21 @@ def cleanup_old_executable():
         pass
 
 
-def check_for_updates_async(app, silent=True):
+def check_for_updates_async(app, silent=True, notify_if_no_update=True):
     """Check for updates in a background thread.
 
     Args:
         app: Reference to the main application instance.
         silent: If True, suppress message boxes and only log results.
+        notify_if_no_update: When ``False`` and ``silent`` is ``False``,
+            suppress the "Up to Date" popup.
     """
     threading.Thread(
-        target=_check_for_updates, args=(app, silent), daemon=True
+        target=_check_for_updates, args=(app, silent, notify_if_no_update), daemon=True
     ).start()
 
 
-def _check_for_updates(app, silent=True):
+def _check_for_updates(app, silent=True, notify_if_no_update=True):
     """Fetch release info and schedule any UI dialogs on the main thread."""
     app.log("Checking for updates...")
     try:
@@ -73,10 +75,11 @@ def _check_for_updates(app, silent=True):
             if silent:
                 app.log("No update available.")
             else:
-                app.after(0, lambda: messagebox.showinfo(
-                    "Up to Date",
-                    f"You are running the latest version ({FPVS_TOOLBOX_VERSION}).",
-                ))
+                if notify_if_no_update:
+                    app.after(0, lambda: messagebox.showinfo(
+                        "Up to Date",
+                        f"You are running the latest version ({FPVS_TOOLBOX_VERSION}).",
+                    ))
     except Exception as e:
         app.log(f"Update check failed: {e}")
         if not silent:

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -208,7 +208,9 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
 
         # Automatically check for updates without blocking the UI
         try:
-            update_manager.check_for_updates_async(self, silent=False)
+            update_manager.check_for_updates_async(
+                self, silent=False, notify_if_no_update=False
+            )
         except Exception as e:
             self.log(f"Auto update check failed: {e}")
 


### PR DESCRIPTION
## Summary
- tweak `update_manager` to allow suppressing the "Up to Date" dialog
- call the async update check with new flag from `fpvs_app`

## Testing
- `python -m py_compile src/Main_App/update_manager.py src/fpvs_app.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461f76230c832c8572b8dd4a8facc4