### PR TITLE
Allow main app use while tools are open

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -18,7 +18,6 @@ class SettingsWindow(ctk.CTkToplevel):
         self.geometry("600x600")
         self.resizable(False, False)
         self._build_ui()
-        self.grab_set()
         self.focus_force()
 
     def _build_ui(self):

--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -105,7 +105,6 @@ class AdvancedAnalysisWindow(ctk.CTkToplevel):
         self.log("Advanced Averaging Analysis window initialized.")
         self._check_main_app_params()
 
-        self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self._on_close)
         self.after(100, self._center_window)
         self._update_start_processing_button_state()
@@ -834,13 +833,11 @@ class AdvancedAnalysisWindow(ctk.CTkToplevel):
             else:
                 return
         else:
-            self.grab_release();
             self.destroy()
 
     def _force_destroy(self):
         if self.processing_thread and self.processing_thread.is_alive():
             self.log("Thread still active after timeout. Forcing close.")
-        self.grab_release();
         self.destroy()
 
 

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -68,7 +68,6 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.option_add("*Font", str(FONT_MAIN), 80)
         self.title("FPVS Statistical Analysis Tool")
         self.geometry("950x950")  # Adjusted for clarity of layout
-        self.grab_set()
         self.focus_force()
 
         self.master_app = master
@@ -247,7 +246,6 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
 
     def on_close(self):
         self.log_to_main_app("Closing Stats Analysis window.")
-        self.grab_release()
         self.destroy()
 
     def _load_base_freq(self):

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -221,7 +221,6 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         # AdvancedAnalysisWindow is imported from Tools.Average_Preprocessing
         adv_win = AdvancedAnalysisWindow(master=self)
         adv_win.geometry(self.settings.get('gui', 'advanced_size', '1050x850'))
-        adv_win.grab_set()  # Make it modal
 
     def _set_controls_enabled(self, enabled: bool):
         """
@@ -250,7 +249,6 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         # Pass the folder path so the stats window can suggest it
         stats_win = stats.StatsAnalysisWindow(master=self, default_folder=last_output_folder)
         stats_win.geometry(self.settings.get('gui', 'stats_size', '950x950'))
-        stats_win.grab_set()
 
     def open_image_resizer(self):
         """Open the FPVS Image_Resizer tool in a new CTkToplevel."""
@@ -258,7 +256,6 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         # We pass `self` so the new window is a child of the main app:
         win = FPVSImageResizer(self)
         win.geometry(self.settings.get('gui', 'resizer_size', '800x600'))
-        win.grab_set()  # optional: make it modal
 
 
     # --- Menu Methods ---


### PR DESCRIPTION
## Summary
- remove modal `grab_set()` behaviour from all toolbox windows
- drop `grab_release()` cleanup since grabs are no longer used

## Testing
- `python3 -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ff2c6060832c8747dbe3367cf6ba