### PR TITLE
Ensure new windows appear on top

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -18,6 +18,10 @@ class SettingsWindow(ctk.CTkToplevel):
         self.geometry("600x600")
         self.resizable(False, False)
         self._build_ui()
+        # Bring settings window to the front when opened
+        self.lift()
+        self.attributes('-topmost', True)
+        self.after(0, lambda: self.attributes('-topmost', False))
         self.focus_force()
 
     def _build_ui(self):

--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -95,6 +95,11 @@ class AdvancedAnalysisWindow(ctk.CTkToplevel):
         self.geometry("1050x850")
         self.minsize(950, 750)
 
+        # Ensure this window opens above the main application
+        self.lift()
+        self.attributes('-topmost', True)
+        self.after(0, lambda: self.attributes('-topmost', False))
+
         self.source_eeg_files: List[str] = []
         self.defined_groups: List[Dict[str, Any]] = []
         self.selected_group_index: Optional[int] = None

--- a/src/Tools/Image_Resizer/FPVSImageResizer.py
+++ b/src/Tools/Image_Resizer/FPVSImageResizer.py
@@ -107,6 +107,10 @@ class FPVSImageResizerCTK(ctk.CTkToplevel):
         super().__init__(parent)
         self.title("FPVS Image_Resizer")
         self.geometry("800x600")
+        # Ensure this window opens above the main application
+        self.lift()
+        self.attributes('-topmost', True)
+        self.after(0, lambda: self.attributes('-topmost', False))
         self.cancel_requested = False
         self.input_folder = ""
         self.output_folder = ""

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -68,6 +68,10 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.option_add("*Font", str(FONT_MAIN), 80)
         self.title("FPVS Statistical Analysis Tool")
         self.geometry("950x950")  # Adjusted for clarity of layout
+        # Ensure stats window opens above the main app
+        self.lift()
+        self.attributes('-topmost', True)
+        self.after(0, lambda: self.attributes('-topmost', False))
         self.focus_force()
 
         self.master_app = master

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -109,6 +109,11 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         self.geometry(self.settings.get('gui', 'main_size', '750x920'))
         ctk.set_appearance_mode(self.settings.get('appearance', 'mode', 'System'))
 
+        # Ensure the main window appears above other applications on launch
+        self.lift()
+        self.attributes('-topmost', True)
+        self.after(0, lambda: self.attributes('-topmost', False))
+
 
         # --- Core State Variables ---
         self.busy = False


### PR DESCRIPTION
## Summary
- guarantee top-level windows open above the main app
- raise the main application when launching

## Testing
- `python -m py_compile src/fpvs_app.py src/Main_App/settings_window.py src/Tools/Average_Preprocessing/advanced_analysis.py src/Tools/Image_Resizer/FPVSImageResizer.py src/Tools/Stats/stats.py`

------
https://chatgpt.com/codex/tasks/task_e_684703f0f6f8832c9acd8db26ee216d5