### PR TITLE
Add alpha setting to Stats

### DIFF
--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -28,7 +28,8 @@ DEFAULTS = {
     'analysis': {
         'base_freq': '6.0',
         'oddball_freq': '1.2',
-        'bca_upper_limit': '16.8'
+        'bca_upper_limit': '16.8',
+        'alpha': '0.05'
     },
     'debug': {
         'enabled': 'False'

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -106,6 +106,11 @@ class SettingsWindow(ctk.CTkToplevel):
         ctk.CTkEntry(stats_tab, textvariable=bca_var).grid(row=2, column=1, columnspan=2, sticky="ew", padx=pad)
         self.bca_var = bca_var
 
+        ctk.CTkLabel(stats_tab, text="Alpha Level").grid(row=3, column=0, sticky="w", padx=pad, pady=(pad, 0))
+        alpha_var = tk.StringVar(value=self.manager.get('analysis', 'alpha', '0.05'))
+        ctk.CTkEntry(stats_tab, textvariable=alpha_var).grid(row=3, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0))
+        self.alpha_var = alpha_var
+
         btn_frame = ctk.CTkFrame(self, fg_color="transparent")
         btn_frame.grid(row=1, column=0, pady=(0, pad))
         ctk.CTkButton(btn_frame, text="Reset to Defaults", command=self._reset).pack(side="left", padx=pad)
@@ -134,6 +139,7 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('analysis', 'base_freq', self.base_var.get())
         self.manager.set('analysis', 'oddball_freq', self.odd_var.get())
         self.manager.set('analysis', 'bca_upper_limit', self.bca_var.get())
+        self.manager.set('analysis', 'alpha', self.alpha_var.get())
         prev_debug = self.manager.get('debug', 'enabled', 'False').lower() == 'true'
         self.manager.set('debug', 'enabled', str(self.debug_var.get()))
         self.manager.save()

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -88,6 +88,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.stats_data_folder_var = tk.StringVar(master=self, value=default_folder)
         self.detected_info_var = tk.StringVar(master=self, value="Select folder containing FPVS results.")
         self.base_freq = self._load_base_freq()
+        self.alpha_var = tk.StringVar(master=self, value=self._load_alpha())
         self.roi_var = tk.StringVar(master=self, value=ALL_ROIS_OPTION)
         self.condition_A_var = tk.StringVar(master=self)
         self.condition_B_var = tk.StringVar(master=self)
@@ -252,6 +253,11 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         if hasattr(self.master_app, 'settings'):
             return self.master_app.settings.get('analysis', 'base_freq', '6.0')
         return SettingsManager().get('analysis', 'base_freq', '6.0')
+
+    def _load_alpha(self):
+        if hasattr(self.master_app, 'settings'):
+            return self.master_app.settings.get('analysis', 'alpha', '0.05')
+        return SettingsManager().get('analysis', 'alpha', '0.05')
 
     def _validate_numeric(self, P):
         if P in ("", "-"): return True


### PR DESCRIPTION
## Summary
- support alpha setting in settings manager
- allow editing alpha level on the Stats tab
- load alpha in StatsAnalysisWindow for RM-ANOVA

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_684704a99530832cbac387618752a483