### PR TITLE
Ensure new windows have focus

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -116,6 +116,8 @@ class AdvancedAnalysisWindow(ctk.CTkToplevel):
         self.lift()
         self.attributes('-topmost', True)
         self.after(0, lambda: self.attributes('-topmost', False))
+        # Give the window focus so it appears above the main GUI
+        self.focus_force()
 
         self.source_eeg_files: List[str] = []
         self.defined_groups: List[Dict[str, Any]] = []

--- a/src/Tools/Image_Resizer/FPVSImageResizer.py
+++ b/src/Tools/Image_Resizer/FPVSImageResizer.py
@@ -111,6 +111,8 @@ class FPVSImageResizerCTK(ctk.CTkToplevel):
         self.lift()
         self.attributes('-topmost', True)
         self.after(0, lambda: self.attributes('-topmost', False))
+        # Focus the window so it appears on top of the main GUI
+        self.focus_force()
         self.cancel_requested = False
         self.input_folder = ""
         self.output_folder = ""


### PR DESCRIPTION
## Summary
- bring Advanced Averaging Analysis window to the front
- bring Image Resizer window to the front

## Testing
- `python -m py_compile src/Tools/Average_Preprocessing/advanced_analysis.py src/Tools/Image_Resizer/FPVSImageResizer.py`


------
https://chatgpt.com/codex/tasks/task_e_684706aad7d8832c8211d1a66f18059e