### PR TITLE
Ensure tool windows stay above main GUI

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -9,6 +9,8 @@ from .settings_manager import SettingsManager
 class SettingsWindow(ctk.CTkToplevel):
     def __init__(self, master, manager: SettingsManager):
         super().__init__(master)
+        # Ensure this window stays above its parent
+        self.transient(master)
         self.manager = manager
         init_fonts()
         self.option_add("*Font", str(FONT_MAIN), 80)

--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -90,6 +90,8 @@ class AdvancedAnalysisWindow(ctk.CTkToplevel):
 
     def __init__(self, master: ctk.CTkBaseClass):
         super().__init__(master)
+        # Keep this window above its parent
+        self.transient(master)
         self.master_app = master
         self.title("Advanced Averaging Analysis")
 

--- a/src/Tools/Image_Resizer/FPVSImageResizer.py
+++ b/src/Tools/Image_Resizer/FPVSImageResizer.py
@@ -105,6 +105,8 @@ ctk.set_default_color_theme("blue")
 class FPVSImageResizerCTK(ctk.CTkToplevel):
     def __init__(self, parent):
         super().__init__(parent)
+        # Keep this window above the main application
+        self.transient(parent)
         self.title("FPVS Image_Resizer")
         self.geometry("800x600")
         # Ensure this window opens above the main application

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -57,6 +57,8 @@ HARMONIC_CHECK_ALPHA = 0.05  # Significance level for one-sample t-test
 class StatsAnalysisWindow(ctk.CTkToplevel):
     def __init__(self, master, default_folder=""):
         super().__init__(master)
+        # Keep this window above its parent
+        self.transient(master)
 
         # Ensure fonts are initialised in case this window is launched
         # independently of the main application.


### PR DESCRIPTION
## Summary
- keep toplevel windows transient to their parent so they appear on top

## Testing
- `python -m py_compile src/Main_App/settings_window.py src/Tools/Image_Resizer/FPVSImageResizer.py src/Tools/Stats/stats.py src/Tools/Average_Preprocessing/advanced_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_684707d169a8832caeeb4be9103d3d86