### PR TITLE
Remove legacy symlink

### DIFF
--- a/src/Main App
+++ b/src/Main App
@@ -1,1 +1,0 @@
-Main_App


### PR DESCRIPTION
## Summary
- delete `src/Main App` symlink
- keep imports referencing `Main_App`

## Testing
- `find src -name '*.py' ! -name 'Compiler Script.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68470b3ef1c4832ca908f54a4bcae1b5