### PR TITLE
Fix update manager installer lookup

### DIFF
--- a/src/Main_App/update_manager.py
+++ b/src/Main_App/update_manager.py
@@ -96,8 +96,8 @@ def _find_exe_asset(data):
     """
 
     for asset in data.get("assets", []):
-        name = asset.get("name", "")
-        if name.lower().endswith("-setup.exe"):
+        name = asset.get("name", "").lower()
+        if name.endswith("-setup.exe") or name.endswith("setup.exe") or name.endswith(".exe"):
             return asset.get("browser_download_url")
     return None
 


### PR DESCRIPTION
## Summary
- relax search pattern for installer asset

## Testing
- `python -m py_compile src/Main_App/update_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684715a0d684832cb94bd224e5dee220