### PR TITLE
Remove unused focus method

### DIFF
--- a/src/Main_App/event_map_utils.py
+++ b/src/Main_App/event_map_utils.py
@@ -112,10 +112,6 @@ class EventMapMixin:
                 frame.destroy()
         self.event_map_entries.clear()
 
-    def _focus_next_id_entry(self, event):
-        # (left intentionally blank)
-        pass
-
     def _add_row_and_focus_label(self, event):
         """Callback for Return/Enter key in event map entries to add a new row."""
         self.add_event_map_entry()


### PR DESCRIPTION
## Summary
- remove `_focus_next_id_entry` from event_map utilities

## Testing
- `python -m py_compile src/Main_App/event_map_utils.py`
- `python -m compileall -q src/Main_App/event_map_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68470b29f348832cb0665a91692a7a80