### PR TITLE
Use warnings.warn for ImportError handling

### DIFF
--- a/src/Main_App/ui_event_map_manager.py
+++ b/src/Main_App/ui_event_map_manager.py
@@ -7,6 +7,7 @@ of the FPVS Toolbox.
 import tkinter as tk
 import customtkinter as ctk
 import traceback
+import warnings
 from typing import Optional, Dict, Any
 
 try:
@@ -17,7 +18,7 @@ try:
     from config import PAD_X, PAD_Y, CORNER_RADIUS, LABEL_ID_ENTRY_WIDTH
     # ``LABEL_ID_ENTRY_WIDTH`` is used for the Condition Label entry.
 except ImportError:
-    print(
+    warnings.warn(
         "Warning [ui_event_map_manager.py]: Could not import from config. "
         "Using fallback UI constants."
     )

--- a/src/Main_App/ui_setup_panels.py
+++ b/src/Main_App/ui_setup_panels.py
@@ -6,6 +6,7 @@ UI panels for the FPVS Toolbox.
 """
 import tkinter as tk
 import customtkinter as ctk
+import warnings
 
 # Attempt to import constants from config.py
 try:
@@ -23,7 +24,7 @@ try:
         # event map manager.
     )
 except ImportError:
-    print(
+    warnings.warn(
         "Warning [ui_setup_panels.py]: Could not import from config. "
         "Using fallback UI constants."
     )


### PR DESCRIPTION
## Summary
- add `warnings` import
- use `warnings.warn` when config fallback is needed

## Testing
- `python -m py_compile src/Main_App/ui_setup_panels.py src/Main_App/ui_event_map_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68470b589c44832c8d72df57268729fd