### PR TITLE
Fix NameError for DEFAULT_STIM_CHANNEL in validation mixins

### DIFF
--- a/src/Main_App/validation_mixins.py
+++ b/src/Main_App/validation_mixins.py
@@ -4,6 +4,7 @@ import os
 import traceback
 import tkinter as tk
 from tkinter import messagebox
+from config import DEFAULT_STIM_CHANNEL
 
 class ValidationMixin:
     def _validate_inputs(self):


### PR DESCRIPTION
## Summary
- import `DEFAULT_STIM_CHANNEL` from `config` so `_validate_inputs` has access to it

## Testing
- `pytest -q`
- *(failed: `ModuleNotFoundError: No module named 'numpy'` when trying to import `Main_App.validation_mixins`)*

------
https://chatgpt.com/codex/tasks/task_e_68472db4d2c8832ca96736cae46b98da