### PR TITLE
Add module docstrings

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,12 @@
+"""FPVS Toolbox configuration and helper utilities.
+
+This module defines global constants used across the application such as
+version identifiers, default GUI dimensions and font configuration.  It also
+provides helper functions for loading frequency settings, computing the target
+frequency array and initialising ``customtkinter`` fonts once a Tk root window
+exists.
+"""
+
 import numpy as np
 import customtkinter as ctk
 from Main_App.settings_manager import SettingsManager

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@
 
 #!/usr/bin/env python3
 
+"""Entry point for launching the FPVS Toolbox GUI application."""
+
 from ctypes import windll
 try:
     windll.shcore.SetProcessDpiAwareness(1)


### PR DESCRIPTION
## Summary
- add module docstring for configuration helpers in `src/config.py`
- add explanatory module docstring for launching the GUI in `src/main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848357c1e50832cb8cc7e1c9535510b