### PR TITLE
Add concise module overviews

### DIFF
--- a/src/Main_App/app_logic.py
+++ b/src/Main_App/app_logic.py
@@ -1,4 +1,7 @@
-"""Core processing functions for FPVS Toolbox."""
+"""Handles the main preprocessing routine for the FPVS Toolbox.
+It manages referencing, filtering, resampling and kurtosis-based
+artifact rejection while logging progress for the user. Cleaned
+``mne.Raw`` objects are returned for further analysis."""
 
 import os
 import gc

--- a/src/Main_App/event_map_utils.py
+++ b/src/Main_App/event_map_utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Helper mixin for event map UI utilities."""
+"""Utility mixin for managing the Event Map interface.
+It lets the user add or remove rows that map condition labels to
+numeric IDs and validates the entries in the scrollable frame."""
 import tkinter as tk
 import customtkinter as ctk
 import traceback

--- a/src/Main_App/file_selection.py
+++ b/src/Main_App/file_selection.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""File and folder selection mixin."""
+"""Mixin used by the GUI to choose EEG files and output folders.
+It opens standard selection dialogs, stores the chosen paths and
+updates progress details before processing starts."""
 import os
 import glob
 from tkinter import filedialog, messagebox

--- a/src/Main_App/load_utils.py
+++ b/src/Main_App/load_utils.py
@@ -1,4 +1,7 @@
-"""Utility functions for loading EEG files."""
+"""Helper functions for reading EEG recordings into MNE.
+Supported ``.bdf`` and ``.set`` files are loaded with the
+appropriate options, and warnings are shown for unsupported
+formats."""
 
 import os
 from tkinter import messagebox

--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -1,4 +1,6 @@
-"""Mixin providing a simple logging helper for the FPVS app."""
+"""Mixin that timestamps and routes messages to the on-screen log
+and the console. It also exposes a tiny debug wrapper that respects
+the application's settings."""
 import tkinter as tk
 import pandas as pd
 

--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Processing-related mixins for the FPVS Toolbox."""
+"""Mixins that drive the background processing workflow.
+They start worker threads, load each file, call preprocessing and
+post-processing routines and update progress so the GUI stays
+responsive."""
 import gc
 import os
 import queue

--- a/src/Main_App/validation_mixins.py
+++ b/src/Main_App/validation_mixins.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Validation logic separated from the main app."""
+"""Checks all user selections before processing begins.
+Paths and numeric parameters are verified and helpful error
+messages are shown when something is missing so the pipeline
+doesn't run with invalid settings."""
 import os
 import traceback
 import tkinter as tk


### PR DESCRIPTION
## Summary
- update module-level docstrings across Main_App to give a quick synopsis of each file

## Testing
- `python -m py_compile src/Main_App/app_logic.py src/Main_App/file_selection.py src/Main_App/load_utils.py src/Main_App/logging_mixin.py src/Main_App/event_map_utils.py src/Main_App/processing_utils.py src/Main_App/validation_mixins.py`

------
https://chatgpt.com/codex/tasks/task_e_684835744e68832cb83eba5f42788af1