### PR TITLE
Document Main_App modules

### DIFF
--- a/src/Main_App/__init__.py
+++ b/src/Main_App/__init__.py
@@ -1,0 +1,8 @@
+
+"""Top-level package for the FPVS Toolbox main application.
+
+This package exposes the core GUI and processing modules that make up the
+FPVS Toolbox application.  Importing ``Main_App`` allows external code to
+access utility classes such as :class:`SettingsManager` and tools for checking
+application updates.
+"""

--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -1,3 +1,11 @@
+"""Utilities for storing and retrieving user preferences.
+
+This module defines :class:`SettingsManager` which reads and writes an INI file
+containing GUI options, analysis defaults and other persistent settings.  It
+also provides helpers for manipulating event label/ID pairs and detecting debug
+mode.
+"""
+
 import os
 import sys
 import configparser

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -1,3 +1,11 @@
+"""GUI window for editing FPVS Toolbox preferences.
+
+The :class:`SettingsWindow` presents tabs of configurable options such as file
+paths, appearance settings and analysis parameters.  It interfaces with
+``SettingsManager`` to load existing values and persist any changes made by the
+user.
+"""
+
 import tkinter as tk
 from tkinter import filedialog
 import customtkinter as ctk

--- a/src/Main_App/update_manager.py
+++ b/src/Main_App/update_manager.py
@@ -1,3 +1,10 @@
+"""Check for and install application updates from GitHub releases.
+
+This module exposes helper functions to query the update API, prompt users
+about new versions and download installers.  It handles these tasks on a
+background thread so the main GUI remains responsive.
+"""
+
 import os
 import sys
 import threading


### PR DESCRIPTION
## Summary
- add package summary in `Main_App/__init__.py`
- document purpose of settings manager
- describe settings window behavior
- add overview for update manager

## Testing
- `python -m compileall -q src/Main_App`

------
https://chatgpt.com/codex/tasks/task_e_684835729704832c9c0d64440f583286