### PR TITLE
Add advanced averaging module docstrings

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -1,4 +1,11 @@
 # advanced_analysis.py
+"""GUI window for advanced averaging of multiple EEG files.
+
+This module defines :class:`AdvancedAnalysisWindow`, a stand-alone window used
+to configure and launch averaging of preprocessed EEG data from multiple files.
+Users can group source files together, choose an averaging method and then
+initiate processing via :mod:`advanced_analysis_core`.
+"""
 
 import tkinter as tk
 from tkinter import filedialog

--- a/src/Tools/Average_Preprocessing/advanced_analysis_core.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_core.py
@@ -1,4 +1,11 @@
 # advanced_analysis_core.py
+"""Core processing logic for the advanced averaging window.
+
+This module implements functions that take the groups configured in the
+``advanced_analysis`` GUI and perform the actual averaging, leveraging the main
+FPVS application's loading, preprocessing and post-processing callbacks.
+"""
+
 import os
 import gc
 import logging


### PR DESCRIPTION
## Summary
- document Advanced Analysis window in `advanced_analysis.py`
- summarize the core averaging implementation in `advanced_analysis_core.py`

## Testing
- `python -m py_compile src/Tools/Average_Preprocessing/advanced_analysis.py src/Tools/Average_Preprocessing/advanced_analysis_core.py`

------
https://chatgpt.com/codex/tasks/task_e_684835796030832c8d9845df31e5dbdb