### PR TITLE
Update fast_cpp setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ python src/main.py
 
 The `src/fast_cpp` directory contains a small C++ extension that can
 accelerate downsampling and filtering operations. Building the extension
-requires a C++ compiler and the `pybind11` package:
+requires a C++ compiler and the `pybind11` package. The build command
+can be executed from the repository root:
 
 ```bash
 pip install pybind11

--- a/src/fast_cpp/setup.py
+++ b/src/fast_cpp/setup.py
@@ -1,10 +1,13 @@
+from pathlib import Path
 from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
+
+this_dir = Path(__file__).resolve().parent
 
 ext_modules = [
     Pybind11Extension(
         "downsample_filter",
-        ["downsample_filter.cpp"],
+        [this_dir / "downsample_filter.cpp"],
     ),
 ]
 


### PR DESCRIPTION
## Summary
- make `src/fast_cpp/setup.py` reference the C++ source relative to `__file__`
- mention the build command can be run from the repo root in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68498e5257d0832ca7d34f458cf2e241