### PR TITLE
Fix NameError by importing missing modules in stats_ui

### DIFF
--- a/src/Tools/Stats/stats_ui.py
+++ b/src/Tools/Stats/stats_ui.py
@@ -1,5 +1,10 @@
 # UI creation method extracted from stats.py
 
+import customtkinter as ctk
+from config import FONT_BOLD
+from . import stats_export
+from .stats_analysis import ROIS, ALL_ROIS_OPTION
+
 
 def create_widgets(self):
     validate_num_cmd = (self.register(self._validate_numeric), '%P')


### PR DESCRIPTION
## Summary
- fix `NameError: name 'ctk' is not defined` when opening the statistical analysis tool
- add missing imports for constants and modules used by the stats UI

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b1bb3ad7c832ca2ca62fd08de7a03