### PR TITLE
Allow editing ROI settings

### DIFF
--- a/src/Main_App/roi_settings_editor.py
+++ b/src/Main_App/roi_settings_editor.py
@@ -1,0 +1,48 @@
+import customtkinter as ctk
+import tkinter as tk
+
+class ROISettingsEditor:
+    def __init__(self, parent, initial_pairs):
+        self.parent = parent
+        self.entries = []
+        self.scroll = ctk.CTkScrollableFrame(parent, label_text="")
+        self.scroll.grid_columnconfigure(0, weight=1)
+        self.scroll.grid_columnconfigure(1, weight=1)
+        for name, electrodes in initial_pairs:
+            self.add_entry(name, ','.join(electrodes))
+        if not initial_pairs:
+            self.add_entry()
+
+    def add_entry(self, name="", electrodes=""):
+        frame = ctk.CTkFrame(self.scroll, fg_color="transparent")
+        frame.pack(fill="x", pady=1, padx=1)
+        frame.grid_columnconfigure(0, weight=1)
+        frame.grid_columnconfigure(1, weight=1)
+        name_entry = ctk.CTkEntry(frame, placeholder_text="ROI Name")
+        name_entry.insert(0, name)
+        name_entry.grid(row=0, column=0, sticky="ew", padx=(0,5))
+        elec_entry = ctk.CTkEntry(frame, placeholder_text="Electrodes comma sep")
+        elec_entry.insert(0, electrodes)
+        elec_entry.grid(row=0, column=1, sticky="ew", padx=(0,5))
+        btn = ctk.CTkButton(frame, text="✕", width=28, command=lambda f=frame: self.remove_entry(f))
+        btn.grid(row=0, column=2, sticky="e")
+        self.entries.append({'frame': frame, 'name': name_entry, 'elec': elec_entry, 'button': btn})
+
+    def remove_entry(self, frame):
+        for i, ent in enumerate(self.entries):
+            if ent['frame'] is frame:
+                if frame.winfo_exists():
+                    frame.destroy()
+                self.entries.pop(i)
+                break
+        if not self.entries:
+            self.add_entry()
+
+    def get_pairs(self):
+        pairs = []
+        for ent in self.entries:
+            name = ent['name'].get().strip()
+            electrodes = [e.strip().upper() for e in ent['elec'].get().split(',') if e.strip()]
+            if name and electrodes:
+                pairs.append((name, electrodes))
+        return pairs

--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -39,6 +39,10 @@ DEFAULTS = {
         'bca_upper_limit': '16.8',
         'alpha': '0.05'
     },
+    'rois': {
+        'names': 'Frontal Lobe;Central Lobe;Parietal Lobe;Occipital Lobe',
+        'electrodes': 'F3,F4,Fz;C3,C4,Cz;P3,P4,Pz;O1,O2,Oz'
+    },
     'debug': {
         'enabled': 'False'
     }
@@ -103,6 +107,22 @@ class SettingsManager:
         ids = ','.join([p[1] for p in pairs])
         self.set('events', 'labels', labels)
         self.set('events', 'ids', ids)
+
+    # --- Convenience helpers for ROI mappings ---
+    def get_roi_pairs(self) -> List[Tuple[str, List[str]]]:
+        names = [n.strip() for n in self.get('rois', 'names', '').split(';') if n.strip()]
+        groups = [g.strip() for g in self.get('rois', 'electrodes', '').split(';') if g.strip()]
+        pairs = []
+        for name, group in zip(names, groups):
+            electrodes = [e.strip().upper() for e in group.split(',') if e.strip()]
+            pairs.append((name, electrodes))
+        return pairs
+
+    def set_roi_pairs(self, pairs: List[Tuple[str, List[str]]]) -> None:
+        names = ';'.join([p[0] for p in pairs])
+        electrodes = ';'.join([','.join([e.upper() for e in p[1]]) for p in pairs])
+        self.set('rois', 'names', names)
+        self.set('rois', 'electrodes', electrodes)
 
     def debug_enabled(self) -> bool:
         return self.get('debug', 'enabled', 'False').lower() == 'true'

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -12,6 +12,7 @@ import customtkinter as ctk
 
 from config import init_fonts, FONT_MAIN
 from .settings_manager import SettingsManager
+from .roi_settings_editor import ROISettingsEditor
 
 
 class SettingsWindow(ctk.CTkToplevel):
@@ -125,6 +126,13 @@ class SettingsWindow(ctk.CTkToplevel):
         ctk.CTkEntry(stats_tab, textvariable=alpha_var).grid(row=3, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0))
         self.alpha_var = alpha_var
 
+        ctk.CTkLabel(stats_tab, text="Regions of Interest", font=ctk.CTkFont(weight="bold")).grid(row=4, column=0, columnspan=3, sticky="w", padx=pad, pady=(pad, 0))
+        roi_pairs = self.manager.get_roi_pairs()
+        self.roi_editor = ROISettingsEditor(stats_tab, roi_pairs)
+        self.roi_editor.scroll.grid(row=5, column=0, columnspan=3, sticky="nsew", padx=pad)
+        stats_tab.rowconfigure(5, weight=1)
+        ctk.CTkButton(stats_tab, text="+ Add ROI", command=self.roi_editor.add_entry).grid(row=6, column=0, columnspan=3, sticky="w", padx=pad, pady=(0, pad))
+
         btn_frame = ctk.CTkFrame(self, fg_color="transparent")
         btn_frame.grid(row=1, column=0, pady=(0, pad))
         ctk.CTkButton(btn_frame, text="Reset to Defaults", command=self._reset).pack(side="left", padx=pad)
@@ -154,6 +162,7 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('analysis', 'oddball_freq', self.odd_var.get())
         self.manager.set('analysis', 'bca_upper_limit', self.bca_var.get())
         self.manager.set('analysis', 'alpha', self.alpha_var.get())
+        self.manager.set_roi_pairs(self.roi_editor.get_pairs())
         prev_debug = self.manager.get('debug', 'enabled', 'False').lower() == 'true'
         self.manager.set('debug', 'enabled', str(self.debug_var.get()))
         self.manager.save()

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -62,16 +62,14 @@ from .stats_helpers import (
     prepare_all_subject_summed_bca_data,
     log_to_main_app,
     on_close,
+    load_rois_from_settings,
+    apply_rois_to_modules,
 )
 
 
 # Regions of Interest (10-20 montage)
-ROIS = {
-    "Frontal Lobe": ["F3", "F4", "Fz"],
-    "Occipital Lobe": ["O1", "O2", "Oz"],
-    "Parietal Lobe": ["P3", "P4", "Pz"],
-    "Central Lobe": ["C3", "C4", "Cz"]
-}
+ROIS = load_rois_from_settings()
+apply_rois_to_modules(ROIS)
 ALL_ROIS_OPTION = "(All ROIs)"
 HARMONIC_CHECK_ALPHA = 0.05  # Significance level for one-sample t-test
 
@@ -99,6 +97,10 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.focus_force()
 
         self.master_app = master
+
+        # Reload ROI configuration in case settings changed
+        rois_from_settings = load_rois_from_settings(getattr(self.master_app, 'settings', None))
+        apply_rois_to_modules(rois_from_settings)
 
         # Data structures
         self.subject_data = {}

--- a/src/Tools/Stats/stats_analysis.py
+++ b/src/Tools/Stats/stats_analysis.py
@@ -8,14 +8,33 @@ import numpy as np
 import scipy.stats as stats
 
 from .repeated_m_anova import run_repeated_measures_anova
+from Main_App.settings_manager import SettingsManager
 
 # Regions of Interest (10-20 montage)
-ROIS = {
+DEFAULT_ROIS = {
     "Frontal Lobe": ["F3", "F4", "Fz"],
     "Occipital Lobe": ["O1", "O2", "Oz"],
     "Parietal Lobe": ["P3", "P4", "Pz"],
     "Central Lobe": ["C3", "C4", "Cz"],
 }
+
+def _load_rois():
+    mgr = SettingsManager()
+    pairs = mgr.get_roi_pairs()
+    rois = {}
+    for name, electrodes in pairs:
+        if name and electrodes:
+            rois[name] = [e.upper() for e in electrodes]
+    for name, default_chans in DEFAULT_ROIS.items():
+        rois.setdefault(name, default_chans)
+    return rois
+
+ROIS = _load_rois()
+
+def set_rois(rois_dict):
+    """Update the module-level ROI dictionary."""
+    global ROIS
+    ROIS = {name: [e.upper() for e in chans] for name, chans in rois_dict.items()}
 ALL_ROIS_OPTION = "(All ROIs)"
 HARMONIC_CHECK_ALPHA = 0.05
 

--- a/src/Tools/Stats/stats_runners.py
+++ b/src/Tools/Stats/stats_runners.py
@@ -15,6 +15,10 @@ from .posthoc_tests import (
     run_interaction_posthocs as perform_interaction_posthocs,
 )
 
+# These variables are set from settings at runtime
+ROIS = {}
+HARMONIC_CHECK_ALPHA = 0.05
+
 
 def run_rm_anova(self):
     self.log_to_main_app("Running RM-ANOVA (Summed BCA)...")


### PR DESCRIPTION
## Summary
- allow customizable ROI names and electrodes in settings
- add ROISettingsEditor UI for editing ROIs
- load ROI settings for stats modules
- ensure ROI configuration updates during stats analysis

## Testing
- `python -m py_compile $(git ls-files '*.py' | tr '\n' ' ' | sed 's#src/Compiler Script.py##')` *(fails: No such file or directory)*
- `python - <<'EOF'
import compileall, pathlib
files=[p for p in pathlib.Path('.').rglob('*.py') if 'Compiler Script.py' not in str(p)]
res=compileall.compile_file
for f in files:
    try:
        compileall.compile_file(str(f), quiet=1)
    except Exception as e:
        print('error', f, e)
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685028d7ea90832c93d14ac454cd404e