### PR TITLE
Add BCA plotting utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The FPVS Toolbox is a GUI based application for preprocessing, cleaning, and ana
 - Built in Statistical analysis tool with repeated-measures ANOVA, linear mixed-effects models, and post-hoc pairwise tests to check for significant FPVS oddball responses in the Frontal, Central, Parietal, and Occipital lobes
 - Image Resizer tool for quickly resizing images for PsychoPy experiments
 - Averaging utility for combining epochs across files prior to post‑processing (useful if one needs to combine two similar FPVS experiments prior to calculating BCA)
+- Publication quality BCA frequency plots
 
 ## Features currently under development:
 
 - Publication quality 2D heatmaps
-- Publication quality BCA frequency plots
 
 
 ## Installation
@@ -38,11 +38,18 @@ The application can also be launched from source on Windows. Clone the repositor
 - `scipy`
 - `customtkinter`
 - `statsmodels` (for statistical analyses)
+- `matplotlib`
 
 After installing the dependencies, start the GUI with:
 
 ```bash
 python src/main.py
+```
+
+To generate a BCA frequency plot from an Excel results file:
+
+```bash
+python -m Tools.bca_plotter results.xlsx -o bca_plot.png
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To generate a BCA frequency plot from an Excel results file:
 python -m Tools.bca_plotter results.xlsx -o bca_plot.png
 ```
 
+The BCA Plotter is also available from the **Tools** menu inside the GUI.
+
 
 
 ## License

--- a/src/Main_App/menu_bar.py
+++ b/src/Main_App/menu_bar.py
@@ -45,6 +45,8 @@ class AppMenuBar:
         tools_menu.add_separator()
         tools_menu.add_command(label="Image_Resizer", command=self.app_ref.open_image_resizer)
         tools_menu.add_separator()
+        tools_menu.add_command(label="BCA Plotter", command=self.app_ref.open_bca_plotter)
+        tools_menu.add_separator()
         tools_menu.add_command(
             label="Average Epochs in Pre-Processing Phase",
             command=self.app_ref.open_advanced_analysis_window,

--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -24,6 +24,7 @@ DEFAULTS = {
         'main_size': '750x920',
         'stats_size': '700x650',
         'resizer_size': '600x600',
+        'bca_plot_size': '600x300',
         'advanced_size': '500x500'
     },
     'stim': {

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -80,30 +80,35 @@ class SettingsWindow(ctk.CTkToplevel):
         ctk.CTkEntry(gen_tab, textvariable=resize_var).grid(row=6, column=1, columnspan=2, sticky="ew", padx=pad)
         self.resize_var = resize_var
 
-        ctk.CTkLabel(gen_tab, text="Advanced Analysis Size (WxH)").grid(row=7, column=0, sticky="w", padx=pad)
+        ctk.CTkLabel(gen_tab, text="BCA Plotter Size (WxH)").grid(row=7, column=0, sticky="w", padx=pad)
+        plot_size_var = tk.StringVar(value=self.manager.get('gui', 'bca_plot_size', '600x300'))
+        ctk.CTkEntry(gen_tab, textvariable=plot_size_var).grid(row=7, column=1, columnspan=2, sticky="ew", padx=pad)
+        self.plot_size_var = plot_size_var
+
+        ctk.CTkLabel(gen_tab, text="Advanced Analysis Size (WxH)").grid(row=8, column=0, sticky="w", padx=pad)
         adv_var = tk.StringVar(value=self.manager.get('gui', 'advanced_size', '1050x850'))
-        ctk.CTkEntry(gen_tab, textvariable=adv_var).grid(row=7, column=1, columnspan=2, sticky="ew", padx=pad)
+        ctk.CTkEntry(gen_tab, textvariable=adv_var).grid(row=8, column=1, columnspan=2, sticky="ew", padx=pad)
         self.adv_var = adv_var
 
-        ctk.CTkLabel(gen_tab, text="Stim Channel").grid(row=8, column=0, sticky="w", padx=pad, pady=(pad, 0))
+        ctk.CTkLabel(gen_tab, text="Stim Channel").grid(row=9, column=0, sticky="w", padx=pad, pady=(pad, 0))
         stim_var = tk.StringVar(value=self.manager.get('stim', 'channel', 'Status'))
-        ctk.CTkEntry(gen_tab, textvariable=stim_var).grid(row=8, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0))
+        ctk.CTkEntry(gen_tab, textvariable=stim_var).grid(row=9, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0))
         self.stim_var = stim_var
 
-        ctk.CTkLabel(gen_tab, text="Default Conditions (comma)").grid(row=9, column=0, sticky="w", padx=pad, pady=(pad, 0))
+        ctk.CTkLabel(gen_tab, text="Default Conditions (comma)").grid(row=10, column=0, sticky="w", padx=pad, pady=(pad, 0))
         cond_var = tk.StringVar(value=self.manager.get('events', 'labels', ''))
-        ctk.CTkEntry(gen_tab, textvariable=cond_var).grid(row=9, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0))
+        ctk.CTkEntry(gen_tab, textvariable=cond_var).grid(row=10, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0))
         self.cond_var = cond_var
 
-        ctk.CTkLabel(gen_tab, text="Default IDs (comma)").grid(row=10, column=0, sticky="w", padx=pad)
+        ctk.CTkLabel(gen_tab, text="Default IDs (comma)").grid(row=11, column=0, sticky="w", padx=pad)
         id_var = tk.StringVar(value=self.manager.get('events', 'ids', ''))
-        ctk.CTkEntry(gen_tab, textvariable=id_var).grid(row=10, column=1, columnspan=2, sticky="ew", padx=pad)
+        ctk.CTkEntry(gen_tab, textvariable=id_var).grid(row=11, column=1, columnspan=2, sticky="ew", padx=pad)
         self.id_var = id_var
 
         debug_default = self.manager.get('debug', 'enabled', 'False').lower() == 'true'
         self.debug_var = tk.BooleanVar(value=debug_default)
-        ctk.CTkLabel(gen_tab, text="Debug Mode").grid(row=11, column=0, sticky="w", padx=pad, pady=(pad, 0))
-        ctk.CTkCheckBox(gen_tab, text="Enable", variable=self.debug_var).grid(row=11, column=1, sticky="w", padx=pad, pady=(pad, 0))
+        ctk.CTkLabel(gen_tab, text="Debug Mode").grid(row=12, column=0, sticky="w", padx=pad, pady=(pad, 0))
+        ctk.CTkCheckBox(gen_tab, text="Enable", variable=self.debug_var).grid(row=12, column=1, sticky="w", padx=pad, pady=(pad, 0))
 
         # --- Stats Tab ---
         ctk.CTkLabel(stats_tab, text="FPVS Base Frequency (Hz)").grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, 0))
@@ -154,6 +159,7 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('gui', 'main_size', self.main_var.get())
         self.manager.set('gui', 'stats_size', self.stats_var.get())
         self.manager.set('gui', 'resizer_size', self.resize_var.get())
+        self.manager.set('gui', 'bca_plot_size', self.plot_size_var.get())
         self.manager.set('gui', 'advanced_size', self.adv_var.get())
         self.manager.set('stim', 'channel', self.stim_var.get())
         self.manager.set('events', 'labels', self.cond_var.get())

--- a/src/Tools/__init__.py
+++ b/src/Tools/__init__.py
@@ -1,6 +1,6 @@
 # src/Tools/__init__.py
 """Utility and helper modules bundled with the FPVS Toolbox."""
 
-from .bca_plotter import generate_bca_plot
+from .bca_plotter import generate_bca_plot, BCAPlotterWindow
 
-__all__ = ["generate_bca_plot"]
+__all__ = ["generate_bca_plot", "BCAPlotterWindow"]

--- a/src/Tools/__init__.py
+++ b/src/Tools/__init__.py
@@ -1,0 +1,6 @@
+# src/Tools/__init__.py
+"""Utility and helper modules bundled with the FPVS Toolbox."""
+
+from .bca_plotter import generate_bca_plot
+
+__all__ = ["generate_bca_plot"]

--- a/src/Tools/bca_plotter.py
+++ b/src/Tools/bca_plotter.py
@@ -1,0 +1,123 @@
+# bca_plotter.py
+"""Utilities for plotting BCA frequency spectra.
+
+This module loads BCA (baseline-corrected amplitude) values from Excel
+results files and generates publication quality frequency plots.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def load_bca_values(excel_path: str | Path, roi_channels: Optional[Sequence[str]] = None
+                     ) -> Tuple[np.ndarray, np.ndarray]:
+    """Load BCA amplitude values from an Excel results file.
+
+    Parameters
+    ----------
+    excel_path : str or Path
+        Path to the Excel file containing a sheet named ``"BCA (uV)"``.
+    roi_channels : sequence of str, optional
+        Electrode names to average. If ``None`` all channels are included.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(frequencies, amplitudes)`` arrays averaged across the specified
+        channels.
+    """
+    df = pd.read_excel(excel_path, sheet_name="BCA (uV)", index_col="Electrode")
+    freq_cols = [c for c in df.columns if isinstance(c, str) and c.endswith("_Hz")]
+    if roi_channels is not None:
+        df = df.reindex(roi_channels).dropna(how="all")
+    mean_vals = df[freq_cols].mean(axis=0, skipna=True)
+    freqs = np.array([float(c[:-3]) for c in freq_cols], dtype=float)
+    amps = mean_vals.to_numpy(dtype=float)
+    return freqs, amps
+
+
+def generate_bca_plot(
+    excel_file: str | Path,
+    output_path: str | Path | None = None,
+    roi_channels: Optional[Sequence[str]] = None,
+    max_freq: float = 10.0,
+    y_max: float = 0.3,
+    dpi: int = 300,
+) -> None:
+    """Create a BCA frequency plot from an Excel results file.
+
+    Parameters
+    ----------
+    excel_file : str or Path
+        Path to the results workbook.
+    output_path : str or Path, optional
+        If provided, the plot is saved to this path instead of shown.
+    roi_channels : sequence of str, optional
+        Channels to average. ``None`` averages across all channels.
+    max_freq : float, default 10.0
+        Highest frequency to display on the x-axis.
+    y_max : float, default 0.3
+        Upper limit for the amplitude axis.
+    dpi : int, default 300
+        Resolution used when saving the figure.
+    """
+    freqs, amps = load_bca_values(excel_file, roi_channels)
+    mask = freqs <= max_freq
+    freqs, amps = freqs[mask], amps[mask]
+
+    fig, ax = plt.subplots(figsize=(6, 4), dpi=dpi)
+    ax.stem(freqs, amps, basefmt=" ", use_line_collection=True)
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel("BCA (uV)")
+    ax.set_ylim(0, y_max)
+    ax.set_xlim(0, max_freq)
+    ax.set_title("Baseline Corrected Amplitude")
+    ax.grid(True, linestyle=":", linewidth=0.5)
+
+    if output_path:
+        fig.tight_layout()
+        plt.savefig(output_path, dpi=dpi)
+        plt.close(fig)
+    else:
+        plt.show()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate a BCA frequency plot from an Excel results file.")
+    parser.add_argument("excel_file", help="Path to results workbook")
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="PATH",
+        help="Save plot to this path instead of displaying",
+    )
+    parser.add_argument(
+        "--roi",
+        metavar="CH1,CH2",
+        help="Comma separated list of ROI channels to average",
+    )
+    parser.add_argument("--max-freq", type=float, default=10.0, help="Max frequency to display")
+    parser.add_argument("--y-max", type=float, default=0.3, help="Max amplitude for y-axis")
+    parser.add_argument("--dpi", type=int, default=300, help="Figure resolution when saving")
+
+    args = parser.parse_args()
+
+    roi_list: Optional[Sequence[str]] = args.roi.split(",") if args.roi else None
+
+    generate_bca_plot(
+        args.excel_file,
+        output_path=args.output,
+        roi_channels=roi_list,
+        max_freq=args.max_freq,
+        y_max=args.y_max,
+        dpi=args.dpi,
+    )

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -76,6 +76,7 @@ from Tools.Average_Preprocessing import AdvancedAnalysisWindow
 
 # Image resizer
 from Tools.Image_Resizer import FPVSImageResizer
+from Tools.bca_plotter import BCAPlotterWindow
 
 # Statistics toolbox
 import Tools.Stats as stats
@@ -261,6 +262,12 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         # We pass `self` so the new window is a child of the main app:
         win = FPVSImageResizer(self)
         win.geometry(self.settings.get('gui', 'resizer_size', '800x600'))
+
+    def open_bca_plotter(self):
+        """Open the BCA Plotter window."""
+        self.debug("BCA plotter window requested")
+        win = BCAPlotterWindow(self)
+        win.geometry(self.settings.get('gui', 'bca_plot_size', '600x300'))
 
 
     # --- Menu Methods ---

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -10,6 +10,7 @@ output_folder =
 main_size = 750x920
 stats_size = 800x650
 resizer_size = 800x600
+bca_plot_size = 600x300
 advanced_size = 800x800
 
 [stim]


### PR DESCRIPTION
## Summary
- implement `bca_plotter` for plotting BCA frequency spectra
- expose `generate_bca_plot` in `Tools` package
- document BCA plots and matplotlib dependency in README

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_685035259070832ca09541e28f48fa78