### PR TITLE
Ensure stats modules refresh ROIs from settings

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -99,8 +99,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.master_app = master
 
         # Reload ROI configuration in case settings changed
-        rois_from_settings = load_rois_from_settings(getattr(self.master_app, 'settings', None))
-        apply_rois_to_modules(rois_from_settings)
+        self.refresh_rois()
 
         # Data structures
         self.subject_data = {}
@@ -145,6 +144,11 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         if default_folder and os.path.isdir(default_folder):
             self.scan_folder()
         self.protocol("WM_DELETE_WINDOW", self.on_close)
+
+    def refresh_rois(self):
+        """Reload ROI definitions from settings and update all modules."""
+        rois_from_settings = load_rois_from_settings(getattr(self.master_app, "settings", None))
+        apply_rois_to_modules(rois_from_settings)
 
     # Bind imported methods to keep class API unchanged
     browse_folder = browse_folder

--- a/src/Tools/Stats/stats_runners.py
+++ b/src/Tools/Stats/stats_runners.py
@@ -14,6 +14,7 @@ from .posthoc_tests import (
     run_posthoc_pairwise_tests,
     run_interaction_posthocs as perform_interaction_posthocs,
 )
+from .stats_helpers import load_rois_from_settings, apply_rois_to_modules
 
 # These variables are set from settings at runtime
 ROIS = {}
@@ -21,6 +22,7 @@ HARMONIC_CHECK_ALPHA = 0.05
 
 
 def run_rm_anova(self):
+    self.refresh_rois()
     self.log_to_main_app("Running RM-ANOVA (Summed BCA)...")
     self.results_textbox.configure(state="normal");
     self.results_textbox.delete("1.0", tk.END)  # Clear textbox
@@ -210,6 +212,7 @@ def run_rm_anova(self):
 
 
 def run_mixed_model(self):
+    self.refresh_rois()
     """Run a linear mixed-effects model on the summed BCA data."""
     self.log_to_main_app("Running Mixed Effects Model (Summed BCA)...")
     self.results_textbox.configure(state="normal")
@@ -284,6 +287,7 @@ def run_mixed_model(self):
 
 
 def run_posthoc_tests(self):
+    self.refresh_rois()
     self.log_to_main_app("Running post-hoc pairwise tests...")
     self.results_textbox.configure(state="normal")
     self.results_textbox.delete("1.0", tk.END)
@@ -344,6 +348,7 @@ def run_posthoc_tests(self):
 
 
 def run_interaction_posthocs(self):
+    self.refresh_rois()
     """
     Runs post-hoc tests to break down a significant interaction from the last RM-ANOVA.
     This version builds a summary of significant findings and places it at the top of the output.
@@ -465,6 +470,7 @@ def run_interaction_posthocs(self):
 
 
 def run_harmonic_check(self):
+    self.refresh_rois()
     self.log_to_main_app("Running Per-Harmonic Significance Check...")
     self.results_textbox.configure(state="normal");
     self.results_textbox.delete("1.0", tk.END)


### PR DESCRIPTION
## Summary
- update StatsAnalysisWindow to provide a `refresh_rois` method
- call `refresh_rois` during init and before each stats run
- refresh ROIs on all stats routines so changes in settings are honored

## Testing
- `python -m py_compile src/Tools/Stats/stats.py src/Tools/Stats/stats_runners.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517cae34d4832cafc78148134e1054