### PR TITLE
Fix ROI case-insensitivity

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -167,6 +167,18 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('debug', 'enabled', str(self.debug_var.get()))
         self.manager.save()
 
+        # Update ROI definitions in any open Stats windows
+        try:
+            from Tools.Stats.stats_helpers import load_rois_from_settings, apply_rois_to_modules
+            from Tools.Stats.stats import StatsAnalysisWindow
+            rois = load_rois_from_settings(self.manager)
+            apply_rois_to_modules(rois)
+            for child in self.master.winfo_children():
+                if isinstance(child, StatsAnalysisWindow):
+                    child.refresh_rois()
+        except Exception:
+            pass
+
         try:
             from config import update_target_frequencies
             update_target_frequencies(float(self.odd_var.get()), float(self.bca_var.get()))

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -149,6 +149,11 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         """Reload ROI definitions from settings and update all modules."""
         rois_from_settings = load_rois_from_settings(getattr(self.master_app, "settings", None))
         apply_rois_to_modules(rois_from_settings)
+        if self.roi_menu is not None:
+            new_values = [ALL_ROIS_OPTION] + list(rois_from_settings.keys())
+            self.roi_menu.configure(values=new_values)
+            if self.roi_var.get() not in new_values:
+                self.roi_var.set(ALL_ROIS_OPTION)
 
     # Bind imported methods to keep class API unchanged
     browse_folder = browse_folder

--- a/src/Tools/Stats/stats_helpers.py
+++ b/src/Tools/Stats/stats_helpers.py
@@ -63,7 +63,7 @@ def aggregate_bca_sum(self, file_path, roi_name):
     )
 
 
-def prepare_all_subject_summed_bca_data(self):
+def prepare_all_subject_summed_bca_data(self, roi_filter=None):
     self.log_to_main_app("Preparing summed BCA data...")
     self.all_subject_data = stats_analysis.prepare_all_subject_summed_bca_data(
         self.subjects,
@@ -71,6 +71,7 @@ def prepare_all_subject_summed_bca_data(self):
         self.subject_data,
         self.base_freq,
         self.log_to_main_app,
+        roi_filter=roi_filter,
     ) or {}
     return bool(self.all_subject_data)
 

--- a/src/Tools/Stats/stats_ui.py
+++ b/src/Tools/Stats/stats_ui.py
@@ -3,6 +3,7 @@
 import customtkinter as ctk
 from config import FONT_BOLD
 from . import stats_export
+from .stats_analysis import ROIS, ALL_ROIS_OPTION
 
 
 def create_widgets(self):
@@ -94,6 +95,15 @@ def create_widgets(self):
         ),
     )
     self.export_posthoc_btn.grid(row=2, column=1, padx=5, pady=(0, 5), sticky="ew")
+
+    # ROI selection menu
+    roi_frame = ctk.CTkFrame(summed_bca_frame, fg_color="transparent")
+    roi_frame.pack(fill="x", padx=0, pady=(5, 0))
+    ctk.CTkLabel(roi_frame, text="ROI:").grid(row=0, column=0, padx=(0, 5), pady=5, sticky="w")
+    self.roi_menu = ctk.CTkOptionMenu(roi_frame, variable=self.roi_var,
+                                      values=[ALL_ROIS_OPTION] + list(ROIS.keys()))
+    self.roi_menu.grid(row=0, column=1, padx=5, pady=5, sticky="w")
+    roi_frame.grid_columnconfigure(1, weight=1)
 
 
     # --- Row 3: Section B - Harmonic Significance Check ---


### PR DESCRIPTION
## Summary
- normalize electrode labels to upper case when reading Excel files
- allow selecting a single ROI from a new option menu
- update ROI refresh logic and runners to respect the selection
- refresh Stats ROI list after saving settings

## Testing
- `python -m py_compile src/Tools/Stats/stats.py src/Tools/Stats/stats_analysis.py src/Tools/Stats/stats_helpers.py src/Tools/Stats/stats_runners.py src/Tools/Stats/stats_ui.py src/Main_App/settings_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68556b544074832cabe6b8987aac7016