### PR TITLE
Remove ROI dropdown from stats tool

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -129,7 +129,6 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
 
 
         # UI Widget References (stored for potential future dynamic updates)
-        self.roi_menu = None
         self.condA_menu = None
         self.condB_menu = None
         self.harmonic_metric_menu = None

--- a/src/Tools/Stats/stats_ui.py
+++ b/src/Tools/Stats/stats_ui.py
@@ -3,7 +3,6 @@
 import customtkinter as ctk
 from config import FONT_BOLD
 from . import stats_export
-from .stats_analysis import ROIS, ALL_ROIS_OPTION
 
 
 def create_widgets(self):
@@ -95,16 +94,6 @@ def create_widgets(self):
         ),
     )
     self.export_posthoc_btn.grid(row=2, column=1, padx=5, pady=(0, 5), sticky="ew")
-
-    # ROI selection menu
-    roi_frame = ctk.CTkFrame(summed_bca_frame, fg_color="transparent")
-    roi_frame.pack(fill="x", padx=0, pady=(5, 0))
-    ctk.CTkLabel(roi_frame, text="ROI:").grid(row=0, column=0, padx=(0, 5), pady=5, sticky="w")
-    self.roi_menu = ctk.CTkOptionMenu(roi_frame, variable=self.roi_var,
-                                      values=[ALL_ROIS_OPTION] + list(ROIS.keys()))
-    self.roi_menu.grid(row=0, column=1, padx=5, pady=5, sticky="w")
-    roi_frame.grid_columnconfigure(1, weight=1)
-
 
     # --- Row 3: Section B - Harmonic Significance Check ---
     harmonic_check_frame = ctk.CTkFrame(main_frame, fg_color="transparent")


### PR DESCRIPTION
## Summary
- remove ROI dropdown UI from stats tool
- drop unused imports and attribute

## Testing
- `python -m py_compile src/Tools/Stats/stats.py src/Tools/Stats/stats_ui.py`
- `git ls-files '*.py' | grep -v 'Compiler Script.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6855791768f4832cbfacc6414ac238ac