### PR TITLE
Fix Stats harmonic check frequency filtering

### DIFF
--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -55,6 +55,7 @@ from .stats_runners import (
 )
 from .stats_helpers import (
     _load_base_freq,
+    _load_bca_upper_limit,
     _load_alpha,
     _validate_numeric,
     _get_included_freqs,
@@ -117,6 +118,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
         self.stats_data_folder_var = tk.StringVar(master=self, value=default_folder)
         self.detected_info_var = tk.StringVar(master=self, value="Select folder containing FPVS results.")
         self.base_freq = self._load_base_freq()
+        self.bca_upper_limit = self._load_bca_upper_limit()
         self.alpha_var = tk.StringVar(master=self, value=self._load_alpha())
         self.roi_var = tk.StringVar(master=self, value=ALL_ROIS_OPTION)
         self.condition_A_var = tk.StringVar(master=self)
@@ -169,6 +171,7 @@ class StatsAnalysisWindow(ctk.CTkToplevel):
     log_to_main_app = log_to_main_app
     on_close = on_close
     _load_base_freq = _load_base_freq
+    _load_bca_upper_limit = _load_bca_upper_limit
     _load_alpha = _load_alpha
     _validate_numeric = _validate_numeric
     _get_included_freqs = _get_included_freqs

--- a/src/Tools/Stats/stats_helpers.py
+++ b/src/Tools/Stats/stats_helpers.py
@@ -42,6 +42,12 @@ def _load_alpha(self):
     return SettingsManager().get('analysis', 'alpha', '0.05')
 
 
+def _load_bca_upper_limit(self):
+    if hasattr(self.master_app, 'settings'):
+        return self.master_app.settings.get('analysis', 'bca_upper_limit', '16.8')
+    return SettingsManager().get('analysis', 'bca_upper_limit', '16.8')
+
+
 def _validate_numeric(self, P):
     if P in ("", "-"): return True
     try:
@@ -53,7 +59,10 @@ def _validate_numeric(self, P):
 
 def _get_included_freqs(self, all_col_names):
     return stats_analysis.get_included_freqs(
-        self.base_freq, all_col_names, self.log_to_main_app
+        self.base_freq,
+        all_col_names,
+        self.log_to_main_app,
+        max_freq=self.bca_upper_limit,
     )
 
 

--- a/src/Tools/Stats/stats_runners.py
+++ b/src/Tools/Stats/stats_runners.py
@@ -6,6 +6,7 @@ import pandas as pd
 import numpy as np
 from scipy import stats
 import traceback
+import os
 
 from .repeated_m_anova import run_repeated_measures_anova
 from .mixed_effects_model import run_mixed_effects_model


### PR DESCRIPTION
## Summary
- import `os` in harmonic check runner to avoid NameError
- expose BCA upper limit from settings in Stats window
- filter harmonic frequencies against `bca_upper_limit`

## Testing
- `python -m py_compile src/Tools/Stats/stats_analysis.py src/Tools/Stats/stats_runners.py src/Tools/Stats/stats_helpers.py src/Tools/Stats/stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68557abb61b8832c8e0de848779488d3