### PR TITLE
Add per-tab reset buttons in settings

### DIFF
--- a/src/Main_App/roi_settings_editor.py
+++ b/src/Main_App/roi_settings_editor.py
@@ -46,3 +46,11 @@ class ROISettingsEditor:
             if name and electrodes:
                 pairs.append((name, electrodes))
         return pairs
+
+    def set_pairs(self, pairs):
+        for ent in list(self.entries):
+            self.remove_entry(ent['frame'])
+        for name, electrodes in pairs:
+            self.add_entry(name, ','.join(electrodes))
+        if not pairs:
+            self.add_entry()

--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -85,6 +85,16 @@ class SettingsManager:
         self.config.read_dict(DEFAULTS)
         self.save()
 
+    def reset_sections(self, sections: List[str]) -> None:
+        """Reset only the specified sections to their default values."""
+        for section in sections:
+            if section in DEFAULTS:
+                if not self.config.has_section(section):
+                    self.config.add_section(section)
+                for opt, val in DEFAULTS[section].items():
+                    self.config.set(section, opt, val)
+        self.save()
+
     def get(self, section: str, option: str, fallback: str = '') -> str:
         return self.config.get(section, option, fallback=fallback)
 


### PR DESCRIPTION
## Summary
- support resetting individual settings sections
- allow ROI editor to be reloaded with default pairs
- add reset buttons to each settings tab with confirmation prompt

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855863acbe4832c958e1ea0f847dd49