### PR TITLE
Add RM-ANOVA balance checks

### DIFF
--- a/src/Tools/Stats/stats_runners.py
+++ b/src/Tools/Stats/stats_runners.py
@@ -204,6 +204,9 @@ def run_rm_anova(self):
     except ImportError:
         output_text += "Error: The `repeated_m_anova.py` module or its dependency `statsmodels` could not be loaded.\nPlease ensure `statsmodels` is installed (`pip install statsmodels`).\nContact developer if issues persist.\n"
         self.log_to_main_app("ImportError during RM-ANOVA execution, likely statsmodels or the custom module.")
+    except ValueError as e:
+        output_text += f"RM-ANOVA failed: {e}\n"
+        self.log_to_main_app(f"RM-ANOVA failed: {e}")
     except Exception as e:
         output_text += f"RM-ANOVA analysis failed unexpectedly: {e}\n"
         output_text += "Common issues include insufficient data after removing missing values, or data not having\nenough variation or levels for each factor (e.g., needing at least 2 conditions).\n"


### PR DESCRIPTION
## Summary
- check design balance in `run_repeated_measures_anova`
- surface detailed imbalance errors to the GUI

## Testing
- `python -m py_compile src/Tools/Stats/repeated_m_anova.py src/Tools/Stats/stats_runners.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a516c424832cb7050e2992fb7c4e