### PR TITLE
Add option to save preprocessed FIF files

### DIFF
--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -360,6 +360,15 @@ class ProcessingMixin:
                         finally:
                             self.data_paths = temp_original_data_paths
                             self.preprocessed_data = temp_original_preprocessed_data
+                    if raw_proc is not None and getattr(self, 'save_fif_var', None) and getattr(self.save_fif_var, 'get', lambda: False)():
+                        try:
+                            fif_dir = os.path.join(save_folder, ".fif files")
+                            os.makedirs(fif_dir, exist_ok=True)
+                            fif_path = os.path.join(fif_dir, os.path.splitext(f_name)[0] + '.fif')
+                            mne.io.write_raw_fif(raw_proc, fif_path, overwrite=True)
+                            gui_queue.put({'type': 'log', 'message': f"Preprocessed FIF saved to: {fif_path}"})
+                        except Exception as e_save:
+                            gui_queue.put({'type': 'log', 'message': f"Error saving FIF for {f_name}: {e_save}"})
                     elif raw_proc is not None:
                         gui_queue.put(
                             {'type': 'log', 'message': f"Skipping Excel generation for {f_name} (no valid epochs)."})

--- a/src/Main_App/ui_setup_panels.py
+++ b/src/Main_App/ui_setup_panels.py
@@ -182,3 +182,14 @@ class SetupPanelManager:
         self.app_ref.max_bad_channels_alert_entry.insert(0, "10")
         self.app_ref.max_bad_channels_alert_entry.grid(row=5, column=3, padx=PAD_X, pady=PAD_Y,
                                                        sticky="w")  # Moved to row 5, col 3
+
+        # Row 6: Save preprocessed FIF option
+        self.app_ref.save_fif_var = tk.BooleanVar(value=False)
+        self.app_ref.save_fif_checkbox = ctk.CTkCheckBox(
+            self.app_ref.params_frame,
+            text="Save Preprocessed .fif",
+            variable=self.app_ref.save_fif_var,
+            corner_radius=CORNER_RADIUS
+        )
+        self.app_ref.save_fif_checkbox.grid(row=6, column=0, columnspan=4, sticky="w",
+                                            padx=PAD_X, pady=PAD_Y)

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -131,7 +131,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         self.file_mode = tk.StringVar(master=self, value="Single")
         self.file_type = tk.StringVar(master=self, value=".BDF")
         self.save_folder_path = tk.StringVar(master=self)
-        # self.save_preprocessed (BooleanVar) was REMOVED
+        self.save_fif_var = tk.BooleanVar(master=self, value=False)
 
         # --- Initialize Widget Attributes ---
         self.select_button = None
@@ -153,6 +153,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         self.ref_channel2_entry = None
         self.max_idx_keep_entry = None
         self.max_bad_channels_alert_entry = None
+        self.save_fif_checkbox = None
         self.event_map_outer_frame = None
         self.event_map_scroll_frame = None
         self.detect_button = None
@@ -205,7 +206,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
             self.low_pass_entry, self.high_pass_entry, self.downsample_entry,
             self.epoch_start_entry, self.epoch_end_entry, self.reject_thresh_entry,
             self.ref_channel1_entry, self.ref_channel2_entry, self.max_idx_keep_entry,
-            self.max_bad_channels_alert_entry,
+            self.max_bad_channels_alert_entry, self.save_fif_checkbox,
             self.detect_button,
             self.add_map_button,
         ]


### PR DESCRIPTION
## Summary
- extend preprocessing panel with Save Preprocessed .fif option
- store checkbox state in `FPVSApp`
- optionally save `.fif` files during processing

## Testing
- `python -m py_compile src/Main_App/ui_setup_panels.py src/fpvs_app.py src/Main_App/processing_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68596840be08832c8693fcee2dbd87c9