### PR TITLE
Implement eLORETA source localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The FPVS Toolbox is a GUI based application for preprocessing, cleaning, and ana
 - Built in Statistical analysis tool with repeated-measures ANOVA, linear mixed-effects models, and post-hoc pairwise tests to check for significant FPVS oddball responses in the Frontal, Central, Parietal, and Occipital lobes
 - Image Resizer tool for quickly resizing images for PsychoPy experiments
 - Averaging utility for combining epochs across files prior to post‑processing (useful if one needs to combine two similar FPVS experiments prior to calculating BCA)
+- Optional saving of preprocessed data as `.fif` files for advanced analyses
+- Interactive eLORETA/sLORETA source localization with 3‑D glass brain viewer
 
 ## Features currently under development:
 

--- a/src/Main_App/eloreta_launcher.py
+++ b/src/Main_App/eloreta_launcher.py
@@ -12,9 +12,9 @@ def open_eloreta_tool(app):
         Parent window from which the tool is launched.
     """
     # Import inside the function to avoid heavy dependencies at startup
-    from . import eloreta_gui
+    from Tools.SourceLocalization import SourceLocalizationWindow
 
-    tool = eloreta_gui.ELORETATool(master=app)
+    tool = SourceLocalizationWindow(master=app)
     try:
         # Respect any stored geometry settings if available
         geometry = app.settings.get("gui", "eloreta_size", "900x700")

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -74,6 +74,14 @@ def run_source_localization(
 
     # Visualise in a separate Brain window
     brain = stc.plot(subject=subject, subjects_dir=subjects_dir, time_viewer=False)
+    try:
+        labels = mne.read_labels_from_annot(subject, parc="aparc", subjects_dir=subjects_dir)
+        for label in labels:
+            brain.add_label(label, borders=True)
+    except Exception:
+        # If annotations aren't available just continue without borders
+        pass
+
     for view, name in [("lat", "side"), ("rostral", "frontal"), ("dorsal", "top")]:
         brain.show_view(view)
         brain.save_image(os.path.join(output_dir, f"{name}.png"))


### PR DESCRIPTION
## Summary
- hook SourceLocalization tool into menu launcher
- display atlas boundaries for eLORETA/sLORETA results and save screenshots
- document new FIF saving and source localization features in README

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_68595c1fc894832c93870af694b72518