### PR TITLE
Implement eLORETA source localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The FPVS Toolbox is a GUI based application for preprocessing, cleaning, and ana
 - Built in Statistical analysis tool with repeated-measures ANOVA, linear mixed-effects models, and post-hoc pairwise tests to check for significant FPVS oddball responses in the Frontal, Central, Parietal, and Occipital lobes
 - Image Resizer tool for quickly resizing images for PsychoPy experiments
 - Averaging utility for combining epochs across files prior to post‑processing (useful if one needs to combine two similar FPVS experiments prior to calculating BCA)
+- Optional saving of preprocessed data as `.fif` files for advanced analyses
+- Interactive eLORETA/sLORETA source localization with 3‑D glass brain viewer
 
 ## Features currently under development:
 

--- a/src/Main_App/eloreta_launcher.py
+++ b/src/Main_App/eloreta_launcher.py
@@ -12,9 +12,9 @@ def open_eloreta_tool(app):
         Parent window from which the tool is launched.
     """
     # Import inside the function to avoid heavy dependencies at startup
-    from . import eloreta_gui
+    from Tools.SourceLocalization import SourceLocalizationWindow
 
-    tool = eloreta_gui.ELORETATool(master=app)
+    tool = SourceLocalizationWindow(master=app)
     try:
         # Respect any stored geometry settings if available
         geometry = app.settings.get("gui", "eloreta_size", "900x700")

--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -360,12 +360,43 @@ class ProcessingMixin:
                         finally:
                             self.data_paths = temp_original_data_paths
                             self.preprocessed_data = temp_original_preprocessed_data
+
+                        # === Source localization ===
+                        try:
+                            import source_model
+
+                            fwd, subj, subj_dir = source_model.prepare_head_model(raw_proc)
+                            noise_cov = source_model.estimate_noise_cov(raw_proc)
+                            inv = source_model.make_inverse_operator(raw_proc, fwd, noise_cov)
+                            stc_dict = source_model.apply_sloreta(file_epochs, inv)
+
+                            for cond_label, stc in stc_dict.items():
+                                cond_folder = os.path.join(save_folder, cond_label.replace(' ', '_'))
+                                os.makedirs(cond_folder, exist_ok=True)
+                                stc_base = os.path.join(cond_folder, os.path.splitext(f_name)[0] + '_' + cond_label.replace(' ', '_'))
+                                stc.save(stc_base)
+
+                                brain = stc.plot(subject=subj, subjects_dir=subj_dir, time_viewer=False)
+                                for view, name in [('dorsal', 'top'), ('rostral', 'frontal'), ('lat', 'side')]:
+                                    brain.show_view(view)
+                                    brain.save_image(f"{stc_base}_{name}.png")
+                                brain.close()
+
+                                excel_name = f"{extracted_pid_for_flagging}_{cond_label.replace(' ', '_')}_Results.xlsx"
+                                excel_path = os.path.join(cond_folder, excel_name)
+                                try:
+                                    df = source_model.source_to_dataframe(stc)
+                                    source_model.append_source_to_excel(excel_path, f"{cond_label}_Source", df)
+                                except Exception as e_xl:
+                                    gui_queue.put({'type': 'log', 'message': f"Error appending source results: {e_xl}"})
+                        except Exception as e_src:
+                            gui_queue.put({'type': 'log', 'message': f"Source localization error for {f_name}: {e_src}"})
                     if raw_proc is not None and getattr(self, 'save_fif_var', None) and getattr(self.save_fif_var, 'get', lambda: False)():
                         try:
                             fif_dir = os.path.join(save_folder, ".fif files")
                             os.makedirs(fif_dir, exist_ok=True)
                             fif_path = os.path.join(fif_dir, os.path.splitext(f_name)[0] + '.fif')
-                            mne.io.write_raw_fif(raw_proc, fif_path, overwrite=True)
+                            raw_proc.save(fif_path, overwrite=True)
                             gui_queue.put({'type': 'log', 'message': f"Preprocessed FIF saved to: {fif_path}"})
                         except Exception as e_save:
                             gui_queue.put({'type': 'log', 'message': f"Error saving FIF for {f_name}: {e_save}"})

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -74,6 +74,14 @@ def run_source_localization(
 
     # Visualise in a separate Brain window
     brain = stc.plot(subject=subject, subjects_dir=subjects_dir, time_viewer=False)
+    try:
+        labels = mne.read_labels_from_annot(subject, parc="aparc", subjects_dir=subjects_dir)
+        for label in labels:
+            brain.add_label(label, borders=True)
+    except Exception:
+        # If annotations aren't available just continue without borders
+        pass
+
     for view, name in [("lat", "side"), ("rostral", "frontal"), ("dorsal", "top")]:
         brain.show_view(view)
         brain.save_image(os.path.join(output_dir, f"{name}.png"))

--- a/src/source_model.py
+++ b/src/source_model.py
@@ -1,0 +1,74 @@
+"""Utility functions for sLORETA source localization."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional
+
+import mne
+
+
+def prepare_head_model(raw: mne.io.BaseRaw, template: str = "fsaverage") -> tuple[mne.Forward, str, str]:
+    """Compute a forward model using the provided raw data.
+
+    Parameters
+    ----------
+    raw : mne.io.BaseRaw
+        Preprocessed raw data with correct montage.
+    template : str
+        Template subject name to use when no individual MRI is available.
+    Returns
+    -------
+    tuple
+        forward solution, subject name, subjects_dir
+    """
+    subjects_dir = mne.datasets.fetch_fsaverage(verbose=False)
+    src = mne.setup_source_space(template, spacing="oct6", subjects_dir=subjects_dir, add_dist=False)
+    model = mne.make_bem_model(subject=template, subjects_dir=subjects_dir, ico=4)
+    bem = mne.make_bem_solution(model)
+    trans = "fsaverage"  # template transformation
+    fwd = mne.make_forward_solution(raw.info, trans=trans, src=src, bem=bem, eeg=True)
+    return fwd, template, subjects_dir
+
+
+def estimate_noise_cov(raw: mne.io.BaseRaw, tmin: float = 0.0, tmax: Optional[float] = None) -> mne.Covariance:
+    """Estimate noise covariance from a segment of raw data."""
+    return mne.compute_raw_covariance(raw, tmin=tmin, tmax=tmax)
+
+
+def make_inverse_operator(raw: mne.io.BaseRaw, fwd: mne.Forward, noise_cov: mne.Covariance) -> mne.minimum_norm.InverseOperator:
+    """Build an inverse operator configured for sLORETA."""
+    return mne.minimum_norm.make_inverse_operator(raw.info, fwd, noise_cov, loose=0.2, depth=0.8)
+
+
+def apply_sloreta(epochs_dict: Dict[str, List[mne.Epochs]], inv: mne.minimum_norm.InverseOperator, snr: float = 3.0) -> Dict[str, mne.SourceEstimate]:
+    """Apply sLORETA to each condition's epochs and return SourceEstimates."""
+    lambda2 = 1.0 / snr ** 2
+    stcs: Dict[str, mne.SourceEstimate] = {}
+    for label, ep_list in epochs_dict.items():
+        if not ep_list:
+            continue
+        ep = ep_list[0]
+        if isinstance(ep, mne.Epochs):
+            evoked = ep.average()
+        else:
+            evoked = ep
+        stc = mne.minimum_norm.apply_inverse(evoked, inv, lambda2=lambda2, method="sLORETA")
+        stcs[label] = stc
+    return stcs
+
+
+def source_to_dataframe(stc: mne.SourceEstimate):
+    """Convert a SourceEstimate to a simple DataFrame of vertex amplitudes."""
+    import pandas as pd
+
+    peak = stc.data.max(axis=1)
+    return pd.DataFrame({"Vertex": range(len(peak)), "Amplitude": peak})
+
+
+def append_source_to_excel(excel_path: str, sheet_name: str, df):
+    """Append DataFrame ``df`` to ``excel_path`` under ``sheet_name``."""
+    import pandas as pd
+
+    with pd.ExcelWriter(excel_path, engine="openpyxl", mode="a", if_sheet_exists="replace") as writer:
+        df.to_excel(writer, sheet_name=sheet_name, index=False)


### PR DESCRIPTION
## Summary
- hook SourceLocalization tool into menu launcher
- display atlas boundaries for eLORETA/sLORETA results and save screenshots
- document new FIF saving and source localization features in README
- save preprocessed FIF files correctly
- add sLORETA modeling step that saves images and appends to Excel

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`


------
https://chatgpt.com/codex/tasks/task_e_68595c1fc894832c93870af694b72518