### PR TITLE
Add estimated time remaining and smoother progress bar

### DIFF
--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -8,6 +8,7 @@ import os
 import queue
 import threading
 import traceback
+import time
 import mne
 import numpy as np
 import pandas as pd
@@ -34,7 +35,14 @@ class ProcessingMixin:
 
         self.preprocessed_data = {}
         self.progress_bar.set(0)
+        self._current_progress = 0.0
+        self._target_progress = 0.0
         self._max_progress = len(self.data_paths)
+        self._start_time = time.time()
+        self._processed_count = 0
+        if hasattr(self, 'remaining_time_var') and self.remaining_time_var is not None:
+            self.remaining_time_var.set("")
+            self.after(0, self._update_time_remaining)
         self.busy = True
         self._set_controls_enabled(False)
 
@@ -55,9 +63,9 @@ class ProcessingMixin:
                     self.log(msg['message'])
 
                 elif t == 'progress':
+                    self._processed_count = msg['value']
                     frac = msg['value'] / self._max_progress
-                    self.progress_bar.set(frac)
-                    self.update_idletasks()
+                    self._animate_progress_to(frac)
 
                 elif t == 'post':
                     fname       = msg['file']
@@ -130,6 +138,12 @@ class ProcessingMixin:
         self.data_paths = []
         self._max_progress = 1
         self.progress_bar.set(0.0)
+        self._current_progress = 0.0
+        self._target_progress = 0.0
+        self._start_time = None
+        self._processed_count = 0
+        if hasattr(self, 'remaining_time_var') and self.remaining_time_var is not None:
+            self.remaining_time_var.set("")
         self.preprocessed_data = {}
 
         if hasattr(self, 'log_text') and self.log_text.winfo_exists():
@@ -146,6 +160,39 @@ class ProcessingMixin:
         gc.collect()
 
         self.log("--- State Reset. Ready for next run. ---")
+
+    def _animate_progress_to(self, target: float) -> None:
+        self._target_progress = max(0.0, min(1.0, target))
+        if not self._animating_progress:
+            self._animating_progress = True
+            self.after(0, self._animate_progress_step)
+
+    def _animate_progress_step(self):
+        diff = self._target_progress - self._current_progress
+        if abs(diff) < 0.005:
+            self._current_progress = self._target_progress
+            self.progress_bar.set(self._current_progress)
+            self._animating_progress = False
+            return
+        self._current_progress += 0.01 if diff > 0 else -0.01
+        self.progress_bar.set(self._current_progress)
+        self.after(20, self._animate_progress_step)
+
+    def _update_time_remaining(self) -> None:
+        if self._start_time is None:
+            return
+        elapsed = time.time() - self._start_time
+        if self._processed_count > 0:
+            avg = elapsed / self._processed_count
+            remaining = max(0.0, avg * (self._max_progress - self._processed_count))
+            mins, secs = divmod(int(remaining), 60)
+            text = f"Estimated time remaining: {mins:02d}:{secs:02d}"
+        else:
+            text = ""
+        if hasattr(self, 'remaining_time_var') and self.remaining_time_var is not None:
+            self.remaining_time_var.set(text)
+        if self.processing_thread and self.processing_thread.is_alive():
+            self.after(1000, self._update_time_remaining)
 
     def _processing_thread_func(self, data_paths, params, gui_queue):
         import os

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -42,6 +42,7 @@ import numpy as np
 import pandas as pd
 import customtkinter as ctk
 import mne
+import time
 import requests
 from packaging.version import parse as version_parse
 from Main_App.menu_bar import AppMenuBar
@@ -163,6 +164,14 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         self.progress_bar = None
         self.menubar = None
         self.debug_label = None
+        self.remaining_time_var = None
+        self.remaining_time_label = None
+
+        self._start_time = None
+        self._processed_count = 0
+        self._current_progress = 0.0
+        self._target_progress = 0.0
+        self._animating_progress = False
 
         # --- Register Validation Commands ---
         self.validate_num_cmd = (self.register(self._validate_numeric_input), '%P')
@@ -476,8 +485,16 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         prog_frame = ctk.CTkFrame(bottom_frame, fg_color="transparent")
         prog_frame.grid(row=1, column=0, sticky="ew", padx=0, pady=PAD_Y)
         prog_frame.grid_columnconfigure(0, weight=1)
-        self.progress_bar = ctk.CTkProgressBar(prog_frame, orientation="horizontal", height=20)
-        self.progress_bar.grid(row=0, column=0, sticky="ew", padx=0, pady=0)
+
+        self.remaining_time_var = tk.StringVar(value="")
+        self.remaining_time_label = ctk.CTkLabel(prog_frame, textvariable=self.remaining_time_var)
+        self.remaining_time_label.grid(row=0, column=0, sticky="w", padx=0, pady=(0, 2))
+
+        self.progress_bar = ctk.CTkProgressBar(
+            prog_frame, orientation="horizontal", height=20,
+            progress_color="#4caf50"
+        )
+        self.progress_bar.grid(row=1, column=0, sticky="ew", padx=0, pady=0)
         self.progress_bar.set(0)
 
         # Sync select button label initially


### PR DESCRIPTION
## Summary
- show estimated time remaining above the progress bar
- color the progress bar green
- animate progress updates for smoother display

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a4832e0c832c9e98ddf0dc516d37