### PR TITLE
Fix GUI exception handling in LORETA tool

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -93,4 +93,10 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
             )
             self.after(0, lambda: messagebox.showinfo("Done", "Source localization finished."))
         except Exception as e:
-            self.after(0, lambda: messagebox.showerror("Error", str(e)))
+            err_msg = str(e)
+
+            def _show_error(msg=err_msg, widget=self):
+                if widget.winfo_exists():
+                    messagebox.showerror("Error", msg, parent=widget)
+
+            self.after(0, _show_error)


### PR DESCRIPTION
## Summary
- handle _run_thread exceptions safely in eLORETA GUI

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6859a882603c832cb44d661c74b12da4