### PR TITLE
Improve fsaverage download feedback

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -10,7 +10,7 @@ import os
 import tkinter as tk
 from tkinter import filedialog
 import customtkinter as ctk
-from mne.datasets import fetch_fsaverage
+from Tools.SourceLocalization.eloreta_runner import fetch_fsaverage_with_progress
 
 from config import init_fonts, FONT_MAIN
 from .settings_manager import SettingsManager
@@ -155,7 +155,7 @@ class SettingsWindow(ctk.CTkToplevel):
 
 
         install_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        fs_default = fetch_fsaverage(subjects_dir=install_base, verbose=False)
+        fs_default = fetch_fsaverage_with_progress(install_base, log_func=print)
 
         ctk.CTkLabel(loreta_tab, text="MRI Directory").grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, 0))
         mri_var = tk.StringVar(value=self.manager.get('loreta', 'mri_path', fs_default))

--- a/src/source_model.py
+++ b/src/source_model.py
@@ -6,6 +6,7 @@ import os
 from typing import Dict, List, Optional
 
 import mne
+from Tools.SourceLocalization.eloreta_runner import fetch_fsaverage_with_progress
 
 
 def prepare_head_model(raw: mne.io.BaseRaw, template: str = "fsaverage") -> tuple[mne.Forward, str, str]:
@@ -22,7 +23,7 @@ def prepare_head_model(raw: mne.io.BaseRaw, template: str = "fsaverage") -> tupl
     tuple
         forward solution, subject name, subjects_dir
     """
-    subjects_dir = mne.datasets.fetch_fsaverage(verbose=False)
+    subjects_dir = fetch_fsaverage_with_progress(os.getcwd(), log_func=print)
     src = mne.setup_source_space(template, spacing="oct6", subjects_dir=subjects_dir, add_dist=False)
     model = mne.make_bem_model(subject=template, subjects_dir=subjects_dir, ico=4)
     bem = mne.make_bem_solution(model)


### PR DESCRIPTION
## Summary
- add a helper to show progress while downloading `fsaverage`
- use progress helper when fetching MRI template in settings window
- use progress helper in source model utilities

## Testing
- `find src -name '*.py' ! -name 'Compiler Script.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685ab3f82724832c8d730d1a765f414b