### PR TITLE
Fix SourceLocalization config path type

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -46,7 +46,8 @@ def _prepare_forward(
             subjects_dir = mne.datasets.fetch_fsaverage(subjects_dir=install_parent, verbose=True)
         except Exception:
             subjects_dir = mne.datasets.fetch_fsaverage(verbose=True)
-        settings.set("loreta", "mri_path", subjects_dir)
+        # ``configparser.ConfigParser`` requires string values
+        settings.set("loreta", "mri_path", str(subjects_dir))
         try:
             settings.save()
         except Exception:


### PR DESCRIPTION
## Summary
- ensure fsaverage directory saved as string in SourceLocalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab4d94280832cad63f19428cef4d5