### PR TITLE
Fix Tkinter messagebox exception scope

### DIFF
--- a/src/Main_App/update_manager.py
+++ b/src/Main_App/update_manager.py
@@ -88,7 +88,7 @@ def _check_for_updates(app, silent=True, notify_if_no_update=True):
     except Exception as e:
         app.log(f"Update check failed: {e}")
         if not silent:
-            app.after(0, lambda: messagebox.showerror("Update Check Failed", str(e)))
+            app.after(0, lambda err=e: messagebox.showerror("Update Check Failed", str(err)))
 
 
 def _find_exe_asset(data):

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -105,7 +105,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
             self.after(0, lambda: messagebox.showinfo("Done", "Source localization finished."))
         except Exception as e:
 
-            self.after(0, lambda: messagebox.showerror("Error", str(e)))
+            self.after(0, lambda err=e: messagebox.showerror("Error", str(err)))
 
     def _on_threshold_slider(self, value: float) -> None:
         """Update variable when slider moves."""


### PR DESCRIPTION
## Summary
- capture exception variables in messagebox callbacks so they remain available when executed asynchronously

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ab580fc84832c84f4121c49073f36