### PR TITLE
Add divider between Stats Toolbox and Source Localization

### DIFF
--- a/src/Main_App/menu_bar.py
+++ b/src/Main_App/menu_bar.py
@@ -43,6 +43,7 @@ class AppMenuBar:
         tools_menu = tk.Menu(menubar_widget, tearoff=0)
         menubar_widget.add_cascade(label="Tools", menu=tools_menu)
         tools_menu.add_command(label="Stats Toolbox", command=self.app_ref.open_stats_analyzer)
+        tools_menu.add_separator()
         tools_menu.add_command(
             label="Source Localization (eLORETA/sLORETA)",
             command=lambda: open_eloreta_tool(self.app_ref),


### PR DESCRIPTION
## Summary
- separate the "Stats Toolbox" entry from "Source Localization" with a separator line in the Tools menu

## Testing
- `python -m py_compile src/Main_App/menu_bar.py`

------
https://chatgpt.com/codex/tasks/task_e_685ab73c08d0832cba4de6375fded930