### PR TITLE
Fix fsaverage path handling in LORETA

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -77,28 +77,34 @@ def _prepare_forward(
 ) -> tuple[mne.Forward, str, str]:
 
     """Construct a forward model using MRI info from settings or fsaverage."""
-    subjects_dir = settings.get("loreta", "mri_path", "")
+    stored_dir = settings.get("loreta", "mri_path", "")
     subject = "fsaverage"
-    if not subjects_dir or not os.path.isdir(subjects_dir):
+    if not stored_dir or not os.path.isdir(stored_dir):
         log_func(
             "Default MRI template not found. Downloading 'fsaverage'. This may take a few minutes..."
         )
 
         install_parent = os.path.dirname(_default_template_location())
         try:
-            subjects_dir = fetch_fsaverage_with_progress(install_parent, log_func)
+            fs_path = fetch_fsaverage_with_progress(install_parent, log_func)
         except Exception:
-
-            subjects_dir = mne.datasets.fetch_fsaverage(verbose=True)
+            fs_path = mne.datasets.fetch_fsaverage(subjects_dir=install_parent, verbose=True)
         # ``configparser.ConfigParser`` requires string values
-        settings.set("loreta", "mri_path", str(subjects_dir))
+        settings.set("loreta", "mri_path", str(fs_path))
 
         try:
             settings.save()
         except Exception:
             pass
 
-        log_func(f"Template downloaded to: {subjects_dir}")
+        log_func(f"Template downloaded to: {fs_path}")
+
+        stored_dir = fs_path
+
+    if os.path.basename(stored_dir) == subject:
+        subjects_dir = os.path.dirname(stored_dir)
+    else:
+        subjects_dir = stored_dir
 
     # Use fsaverage transformation if no custom trans file is specified
     trans = settings.get("paths", "trans_file", "fsaverage")


### PR DESCRIPTION
## Summary
- fix directory handling when downloading fsaverage dataset for LORETA

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py`
- `python -m py_compile src/Main_App/settings_window.py`
- `python -m compileall -q -x 'Compiler Script\.py' src`

------
https://chatgpt.com/codex/tasks/task_e_685ab6b3e7c4832cb5dd4a0b488abd77