### PR TITLE
Add separator in Help menu

### DIFF
--- a/src/Main_App/menu_bar.py
+++ b/src/Main_App/menu_bar.py
@@ -63,4 +63,5 @@ class AppMenuBar:
             label="Relevant Publications",
             command=self.app_ref.show_relevant_publications,
         )
+        help_menu.add_separator()
         help_menu.add_command(label="About...", command=self.app_ref.show_about_dialog)


### PR DESCRIPTION
## Summary
- insert separator between "Relevant Publications" and "About" menu options

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py' | while read -r file; do python -m py_compile "$file"; done)`

------
https://chatgpt.com/codex/tasks/task_e_685ab899ba2c832cb82e84abcf5d1dee