### PR TITLE
Make event map remove buttons red

### DIFF
--- a/src/Main_App/event_map_utils.py
+++ b/src/Main_App/event_map_utils.py
@@ -47,11 +47,16 @@ class EventMapMixin:
         id_entry._entry.bind("<KP_Enter>", self._add_row_and_focus_label)
 
         # Create Remove Button
-        remove_btn = ctk.CTkButton(entry_frame, text="✕",  # Use a clear 'X' symbol
-                                   width=28, height=28,
-                                   corner_radius=CORNER_RADIUS,
-                                   # Pass the specific frame to remove
-                                   command=lambda ef=entry_frame: self.remove_event_map_entry(ef))
+        remove_btn = ctk.CTkButton(
+            entry_frame,
+            text="✕",  # Use a clear 'X' symbol
+            width=28,
+            height=28,
+            corner_radius=CORNER_RADIUS,
+            text_color="red",  # Show remove buttons in red for clarity
+            # Pass the specific frame to remove
+            command=lambda ef=entry_frame: self.remove_event_map_entry(ef),
+        )
         remove_btn.pack(side="right")
 
         # Store references to the widgets for this row

--- a/src/Main_App/ui_event_map_manager.py
+++ b/src/Main_App/ui_event_map_manager.py
@@ -133,10 +133,16 @@ class EventMapManager:
         id_entry.insert(0, id_text)
         id_entry.grid(row=0, column=1, sticky="w", padx=(0, PAD_X))  # Sticky west, fixed width
 
-        remove_btn = ctk.CTkButton(entry_frame, text="✕", width=REMOVE_BUTTON_WIDTH, height=REMOVE_BUTTON_WIDTH,
-                                   # Consistent size
-                                   corner_radius=CORNER_RADIUS,
-                                   command=lambda ef=entry_frame: self.remove_event_map_entry_from_manager(ef))
+        remove_btn = ctk.CTkButton(
+            entry_frame,
+            text="✕",
+            width=REMOVE_BUTTON_WIDTH,
+            height=REMOVE_BUTTON_WIDTH,
+            # Consistent size
+            corner_radius=CORNER_RADIUS,
+            text_color="red",  # Make the remove buttons red
+            command=lambda ef=entry_frame: self.remove_event_map_entry_from_manager(ef),
+        )
         remove_btn.grid(row=0, column=2, sticky="e", padx=(0, PAD_X))  # Add padx to not touch edge
         self.app_ref.debug(f"[EventMapManager] Widgets for new row created and gridded.")
 


### PR DESCRIPTION
## Summary
- show remove buttons in the Event Map in red so they're easy to see
- ensure red color applies to existing and newly added entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab8c0daa8832cbaeb57420f816a5f