### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The application can also be launched from source on Windows. Clone the repositor
 - `scipy`
 - `customtkinter`
 - `statsmodels` (for statistical analyses)
+- `nibabel` (required for source localization)
 
 After installing the dependencies, start the GUI with:
 


### PR DESCRIPTION
## Summary
- note that `nibabel` is required when running from source

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aba045248832cb5e071e6bb959173