### PR TITLE
Fix LORETA noise covariance

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -157,7 +157,12 @@ def run_source_localization(
     fwd, subject, subjects_dir = _prepare_forward(evoked, settings, log_func)
     log_func(f"Forward model ready. subjects_dir={subjects_dir}, subject={subject}")
 
-    noise_cov = mne.compute_covariance([evoked], tmax=0.0)
+    try:
+        noise_cov = mne.compute_covariance([evoked], tmax=0.0)
+    except AttributeError:
+        # ``compute_covariance`` expects an Epochs object. Fall back to
+        # an ad-hoc estimate when only Evoked data are available.
+        noise_cov = mne.make_ad_hoc_cov(evoked.info)
     inv = mne.minimum_norm.make_inverse_operator(evoked.info, fwd, noise_cov)
 
     method = method.lower()


### PR DESCRIPTION
## Summary
- handle running source localization on Evoked files
- fall back to an ad hoc covariance when `compute_covariance` can't use event info

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py`
- `git ls-files '*.py' | grep -v 'Compiler Script.py' | sed -e 's/.*/"&"/' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685abb7b2508832cb28b767388e41b75