### PR TITLE
Add interactive viewer and STC loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The FPVS Toolbox is a GUI based application for preprocessing, cleaning, and ana
 - Averaging utility for combining epochs across files prior to post‑processing (useful if one needs to combine two similar FPVS experiments prior to calculating BCA)
 - Optional saving of preprocessed data as `.fif` files for advanced analyses
 - Interactive eLORETA/sLORETA source localization with 3‑D glass brain viewer
-  (automatically downloads the `fsaverage` template if no MRI is specified)
+  (automatically downloads the `fsaverage` template if no MRI is specified) and
+  a viewer tool to open saved results
 
 
 ## Features currently under development:
@@ -67,6 +68,8 @@ Choose **Source Localization (eLORETA/sLORETA)** from the Tools menu to run an
 inverse solution on a preprocessed `.fif` file. Select the desired method and an
 output folder. An interactive 3‑D viewer will open with anatomical labels, and
 side, frontal and top screenshots are automatically saved in the chosen folder.
+You can also open any saved `source-lh.stc`/`source-rh.stc` pair later using the
+**View STC** button to inspect the results interactively.
 
 
 

--- a/src/Tools/SourceLocalization/__init__.py
+++ b/src/Tools/SourceLocalization/__init__.py
@@ -1,6 +1,6 @@
 """Source localization tools using (s/e)LORETA."""
 
 from .eloreta_gui import SourceLocalizationWindow
-from .eloreta_runner import run_source_localization
+from .eloreta_runner import run_source_localization, view_source_estimate
 
-__all__ = ["SourceLocalizationWindow", "run_source_localization"]
+__all__ = ["SourceLocalizationWindow", "run_source_localization", "view_source_estimate"]

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -72,11 +72,14 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
         run_btn = ctk.CTkButton(frame, text="Run", command=self._run)
         run_btn.grid(row=4, column=0, columnspan=3, pady=(PAD_Y * 2, PAD_Y))
 
+        view_btn = ctk.CTkButton(frame, text="View STC", command=self._view_stc)
+        view_btn.grid(row=5, column=0, columnspan=3, pady=(0, PAD_Y))
+
         self.progress_bar = ctk.CTkProgressBar(frame, orientation="horizontal", variable=self.progress_var)
-        self.progress_bar.grid(row=5, column=0, columnspan=3, sticky="ew", padx=PAD_X, pady=(0, PAD_Y))
+        self.progress_bar.grid(row=6, column=0, columnspan=3, sticky="ew", padx=PAD_X, pady=(0, PAD_Y))
         self.progress_bar.set(0)
 
-        ctk.CTkLabel(frame, textvariable=self.remaining_var).grid(row=6, column=0, columnspan=3, sticky="w", padx=PAD_X, pady=(0, PAD_Y))
+        ctk.CTkLabel(frame, textvariable=self.remaining_var).grid(row=7, column=0, columnspan=3, sticky="w", padx=PAD_X, pady=(0, PAD_Y))
 
     def _browse_file(self):
         path = filedialog.askopenfilename(title="Select FIF file", filetypes=[("FIF files", "*.fif")], parent=self)
@@ -87,6 +90,21 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
         folder = filedialog.askdirectory(title="Select Output Folder", parent=self)
         if folder:
             self.output_var.set(folder)
+
+    def _view_stc(self):
+        path = filedialog.askopenfilename(
+            title="Select SourceEstimate file",
+            filetypes=[("SourceEstimate", "*-lh.stc"), ("All files", "*")],
+            parent=self,
+        )
+        if not path:
+            return
+        if path.endswith("-lh.stc") or path.endswith("-rh.stc"):
+            path = path[:-7]
+        try:
+            eloreta_runner.view_source_estimate(path, threshold=self.threshold_var.get())
+        except Exception as err:
+            messagebox.showerror("Error", str(err))
 
     def _run(self):
         fif_path = self.input_var.get()

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -251,7 +251,7 @@ def run_source_localization(
         brain.save_image(os.path.join(output_dir, f"{name}.png"))
     # Save the current view as an additional screenshot
     brain.save_image(os.path.join(output_dir, "overview.png"))
-    brain.close()
+    # Keep the brain window open so the user can interact with it
     step += 1
     if progress_cb:
         progress_cb(step / total)
@@ -260,3 +260,22 @@ def run_source_localization(
     if progress_cb:
         progress_cb(1.0)
     return stc_path
+
+
+def view_source_estimate(stc_path: str, threshold: Optional[float] = None) -> mne.viz.Brain:
+    """Open a saved :class:`~mne.SourceEstimate` in an interactive viewer."""
+
+    stc = mne.read_source_estimate(stc_path)
+    if threshold:
+        stc = _threshold_stc(stc, threshold)
+
+    settings = SettingsManager()
+    stored_dir = settings.get("loreta", "mri_path", "")
+    subject = "fsaverage"
+    if os.path.basename(stored_dir) == subject:
+        subjects_dir = os.path.dirname(stored_dir)
+    else:
+        subjects_dir = stored_dir if stored_dir else os.path.dirname(_default_template_location())
+
+    brain = stc.plot(subject=subject, subjects_dir=subjects_dir, time_viewer=False)
+    return brain


### PR DESCRIPTION
## Summary
- keep 3D viewer open after running source localization
- expose new API to view saved STC files
- add `View STC` button in source localization GUI
- document how to load saved STC results

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py src/Tools/SourceLocalization/eloreta_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac8e8f644832c9886f8fe65e218f5