### PR TITLE
Add alpha control and split-hemi viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The FPVS Toolbox is a GUI based application for preprocessing, cleaning, and ana
 - Averaging utility for combining epochs across files prior to post‑processing (useful if one needs to combine two similar FPVS experiments prior to calculating BCA)
 - Optional saving of preprocessed data as `.fif` files for advanced analyses
 - Interactive eLORETA/sLORETA source localization with 3‑D glass brain viewer
-  (automatically downloads the `fsaverage` template if no MRI is specified)
+  (automatically downloads the `fsaverage` template if no MRI is specified) and
+  a viewer tool to open saved results with adjustable transparency
 
 
 ## Features currently under development:
@@ -65,8 +66,11 @@ source localization tool.
 
 Choose **Source Localization (eLORETA/sLORETA)** from the Tools menu to run an
 inverse solution on a preprocessed `.fif` file. Select the desired method and an
-output folder. An interactive 3‑D viewer will open with anatomical labels, and
-side, frontal and top screenshots are automatically saved in the chosen folder.
+output folder. An interactive 3‑D viewer will open showing both hemispheres with
+anatomical labels. Side, frontal and top screenshots are automatically saved in
+the chosen folder. You can also open any saved `source-lh.stc`/`source-rh.stc`
+pair later using the **View STC** button to inspect the results interactively and
+adjust the brain transparency.
 
 
 

--- a/src/Tools/SourceLocalization/__init__.py
+++ b/src/Tools/SourceLocalization/__init__.py
@@ -1,6 +1,6 @@
 """Source localization tools using (s/e)LORETA."""
 
 from .eloreta_gui import SourceLocalizationWindow
-from .eloreta_runner import run_source_localization
+from .eloreta_runner import run_source_localization, view_source_estimate
 
-__all__ = ["SourceLocalizationWindow", "run_source_localization"]
+__all__ = ["SourceLocalizationWindow", "run_source_localization", "view_source_estimate"]

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -6,7 +6,7 @@ import os
 import logging
 import threading
 import time
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 import mne
@@ -165,12 +165,23 @@ def run_source_localization(
     output_dir: str,
     method: str = "eLORETA",
     threshold: Optional[float] = None,
+    alpha: float = 1.0,
     log_func: Optional[Callable[[str], None]] = None,
     progress_cb: Optional[Callable[[float], None]] = None,
-) -> str:
+
+) -> Tuple[str, mne.viz.Brain]:
     """Run source localization on ``fif_path`` and save results to ``output_dir``.
 
-    Returns the path to the saved :class:`~mne.SourceEstimate` file.
+    Parameters
+    ----------
+    alpha : float
+        Initial transparency for the brain surface where ``1.0`` is opaque.
+
+    Returns
+    -------
+    Tuple[str, :class:`mne.viz.Brain`]
+        Path to the saved :class:`~mne.SourceEstimate` (without hemisphere
+        suffix) and the interactive brain window.
     """
     if log_func is None:
         log_func = logger.info
@@ -235,7 +246,13 @@ def run_source_localization(
         progress_cb(step / total)
 
     # Visualise in a separate Brain window
-    brain = stc.plot(subject=subject, subjects_dir=subjects_dir, time_viewer=False)
+    brain = stc.plot(
+        subject=subject,
+        subjects_dir=subjects_dir,
+        time_viewer=False,
+        hemi="split",
+    )
+    brain.set_alpha(alpha)
     try:
         labels = mne.read_labels_from_annot(
             subject, parc="aparc", subjects_dir=subjects_dir
@@ -251,7 +268,7 @@ def run_source_localization(
         brain.save_image(os.path.join(output_dir, f"{name}.png"))
     # Save the current view as an additional screenshot
     brain.save_image(os.path.join(output_dir, "overview.png"))
-    brain.close()
+    # Keep the brain window open so the user can interact with it
     step += 1
     if progress_cb:
         progress_cb(step / total)
@@ -259,4 +276,37 @@ def run_source_localization(
     log_func(f"Results saved to {output_dir}")
     if progress_cb:
         progress_cb(1.0)
-    return stc_path
+    return stc_path, brain
+
+
+def view_source_estimate(
+    stc_path: str, threshold: Optional[float] = None, alpha: float = 1.0
+) -> mne.viz.Brain:
+    """Open a saved :class:`~mne.SourceEstimate` in an interactive viewer.
+
+    Parameters
+    ----------
+    alpha : float
+        Transparency for the brain surface where ``1.0`` is opaque.
+    """
+
+    stc = mne.read_source_estimate(stc_path)
+    if threshold:
+        stc = _threshold_stc(stc, threshold)
+
+    settings = SettingsManager()
+    stored_dir = settings.get("loreta", "mri_path", "")
+    subject = "fsaverage"
+    if os.path.basename(stored_dir) == subject:
+        subjects_dir = os.path.dirname(stored_dir)
+    else:
+        subjects_dir = stored_dir if stored_dir else os.path.dirname(_default_template_location())
+
+    brain = stc.plot(
+        subject=subject,
+        subjects_dir=subjects_dir,
+        time_viewer=False,
+        hemi="split",
+    )
+    brain.set_alpha(alpha)
+    return brain


### PR DESCRIPTION
## Summary
- document viewer transparency controls
- show both hemispheres and return the Brain object when running source localization
- expose alpha parameter when loading an STC file
- add Transparency slider to Source Localization GUI

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py src/Tools/SourceLocalization/eloreta_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ac8e8f644832c9886f8fe65e218f5