### PR TITLE
Remove redundant overview screenshot

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -478,8 +478,6 @@ def run_source_localization(
     for view, name in [("lat", "side"), ("rostral", "frontal"), ("dorsal", "top")]:
         brain.show_view(view)
         brain.save_image(os.path.join(output_dir, f"{name}.png"))
-    # Save the current view as an additional screenshot
-    brain.save_image(os.path.join(output_dir, "overview.png"))
     # Keep the brain window open so the user can interact with it
 
     if export_rois:


### PR DESCRIPTION
## Summary
- remove the overview screenshot export from the LORETA runner

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_685b15287180832c9d9cb1caaa66bb45