### PR TITLE
Fix labels placement in split viewer

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -108,8 +108,16 @@ def _add_brain_labels(brain: mne.viz.Brain, left: str, right: str) -> None:
     """
 
     try:
-        brain.add_text(0.25, 0.95, left, name="lh_label", font_size=10)
-        brain.add_text(0.75, 0.95, right, name="rh_label", font_size=10)
+        plotter = brain._renderer.plotter  # type: ignore[attr-defined]
+        # Add the left label in the left subplot
+        if hasattr(plotter, "subplot"):
+            plotter.subplot(0, 0)
+        brain.add_text(0.5, 0.95, left, name="lh_label", font_size=10)
+
+        # Add the right label in the right subplot
+        if hasattr(plotter, "subplot"):
+            plotter.subplot(0, 1)
+        brain.add_text(0.5, 0.95, right, name="rh_label", font_size=10)
     except Exception:
         logger.debug("Failed to add hemisphere labels", exc_info=True)
 


### PR DESCRIPTION
## Summary
- adjust label placement for split STC viewer

## Testing
- `python -m py_compile $(git ls-files '*.py')` (except the compiler script)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf84cbde0832ca75ff8d2ca3557ea