### PR TITLE
Add debug lines for MNE backend detection

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -546,6 +546,13 @@ def run_source_localization(
                 subjects_dir,
                 subject,
             )
+            logger.debug(
+                "Backend before stc.plot: %s (MNE_3D_BACKEND=%s QT_API=%s QT_QPA_PLATFORM=%s)",
+                mne.viz.get_3d_backend(),
+                os.environ.get("MNE_3D_BACKEND"),
+                os.environ.get("QT_API"),
+                os.environ.get("QT_QPA_PLATFORM"),
+            )
             brain = stc.plot(
                 subject=subject,
                 subjects_dir=subjects_dir,
@@ -555,9 +562,10 @@ def run_source_localization(
             logger.debug("stc.plot succeeded")
         except Exception as err:
             logger.warning(
-                "hemi=%s failed: %s; falling back to default",
+                "hemi=%s failed: %s; backend=%s; falling back to default",
                 hemi,
                 err,
+                mne.viz.get_3d_backend(),
             )
             logger.debug("Retrying stc.plot with default hemisphere")
             brain = stc.plot(
@@ -668,6 +676,13 @@ def view_source_estimate(
             subjects_dir,
             subject,
         )
+        logger.debug(
+            "Backend before stc.plot: %s (MNE_3D_BACKEND=%s QT_API=%s QT_QPA_PLATFORM=%s)",
+            mne.viz.get_3d_backend(),
+            os.environ.get("MNE_3D_BACKEND"),
+            os.environ.get("QT_API"),
+            os.environ.get("QT_QPA_PLATFORM"),
+        )
         brain = stc.plot(
             subject=subject,
             subjects_dir=subjects_dir,
@@ -676,7 +691,11 @@ def view_source_estimate(
         )
         logger.debug("stc.plot succeeded in view_source_estimate")
     except Exception as err:
-        logger.warning("hemi='split' failed: %s; falling back to default", err)
+        logger.warning(
+            "hemi='split' failed: %s; backend=%s; falling back to default",
+            err,
+            mne.viz.get_3d_backend(),
+        )
         brain = stc.plot(
             subject=subject,
             subjects_dir=subjects_dir,


### PR DESCRIPTION
## Summary
- add debug logging for active 3D backend
- include environment variables in the log message
- show backend in warning messages when `stc.plot` fallback occurs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0c8034f8832c9838f539bfe23a50