### PR TITLE
Fix fsaverage download message

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -155,7 +155,9 @@ class SettingsWindow(ctk.CTkToplevel):
 
 
         install_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        fs_default = fetch_fsaverage_with_progress(install_base, log_func=print)
+        fs_default = _find_fsaverage_dir()
+        if not fs_default:
+            fs_default = fetch_fsaverage_with_progress(install_base, log_func=print)
 
         ctk.CTkLabel(loreta_tab, text="MRI Directory").grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, 0))
         mri_var = tk.StringVar(value=self.manager.get('loreta', 'mri_path', fs_default))


### PR DESCRIPTION
## Summary
- avoid repeated download log in settings window by checking for existing `fsaverage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0e72e44c832caacc4fcc9150e9f9