### PR TITLE
Expose helper to check PyVista backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ adjust the brain transparency. A hemisphere selector lets you view the left
 hemisphere, right hemisphere, both together, or a split layout. Activity is
 displayed with a red heatmap so you can easily spot the peak response.
 
-The underlying module exposes an `is_pyvista_backend()` helper which
+The underlying module exposes an `is_pyvistaqt_backend()` helper which
 returns ``True`` when the viewer will use the interactive PyVistaQt
 backend. This can be queried before opening any 3‑D windows to ensure
 that PyVistaQt is active.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ adjust the brain transparency. A hemisphere selector lets you view the left
 hemisphere, right hemisphere, both together, or a split layout. Activity is
 displayed with a red heatmap so you can easily spot the peak response.
 
+The underlying module exposes an `is_pyvista_backend()` helper which
+returns ``True`` when the viewer will use the interactive PyVistaQt
+backend. This can be queried before opening any 3‑D windows to ensure
+that PyVistaQt is active.
+
 Additional parameters for band‑pass filtering and oddball cycle localisation can be
 configured under the **LORETA** tab in the Settings window. Here you may define
 the low and high filter bounds, choose which oddball harmonics to reconstruct and

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -94,6 +94,24 @@ def _ensure_pyvista_backend() -> None:
     raise RuntimeError(msg)
 
 
+def get_current_backend() -> str:
+    """Return the currently active MNE 3D backend."""
+    backend = None
+    if hasattr(mne.viz, "get_3d_backend"):
+        try:
+            backend = mne.viz.get_3d_backend()
+        except Exception:
+            backend = None
+    if not backend:
+        backend = os.environ.get("MNE_3D_BACKEND", "")
+    return str(backend).lower()
+
+
+def is_pyvista_backend() -> bool:
+    """Check if the PyVistaQt backend is active."""
+    return get_current_backend() == "pyvistaqt"
+
+
 def _set_brain_title(brain: mne.viz.Brain, title: str) -> None:
     """Safely set the window title of a Brain viewer."""
     try:

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -107,9 +107,14 @@ def get_current_backend() -> str:
     return str(backend).lower()
 
 
-def is_pyvista_backend() -> bool:
+def is_pyvistaqt_backend() -> bool:
     """Check if the PyVistaQt backend is active."""
     return get_current_backend() == "pyvistaqt"
+
+
+def is_pyvista_backend() -> bool:
+    """Alias for :func:`is_pyvistaqt_backend`."""
+    return is_pyvistaqt_backend()
 
 
 def _set_brain_title(brain: mne.viz.Brain, title: str) -> None:


### PR DESCRIPTION
## Summary
- add helper functions `get_current_backend` and `is_pyvista_backend` to check the 3‑D backend
- document `is_pyvista_backend` usage in README

## Testing
- `find . -name '*.py' ! -name 'Compiler Script.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685c0e16b844832cb69ec76f43572866