### PR TITLE
Log 3D backend before viewer opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ current density and is labeled **Source amplitude** for clarity.
 The underlying module exposes an `is_pyvistaqt_backend()` helper which
 returns ``True`` when the viewer will use the interactive PyVistaQt
 backend. This can be queried before opening any 3‑D windows to ensure
-that PyVistaQt is active.
+that PyVistaQt is active. The selected backend is also printed to the
+on‑screen log whenever a 3‑D viewer is opened so you can verify it
+directly from the GUI.
 
 Additional parameters for band‑pass filtering and oddball cycle localisation can be
 configured under the **LORETA** tab in the Settings window. Here you may define

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -191,6 +191,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
                     threshold=self.threshold_var.get(),
                     alpha=self.alpha_var.get(),
                     window_title=title,
+                    log_func=log_func,
                 )
                 self.brain = brain
             except Exception as err:
@@ -415,6 +416,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
                 threshold=thr,
                 alpha=alpha,
                 window_title=title,
+                log_func=log_func,
             )
         except Exception as err:
             log_func(f"STC viewer failed: {err}")

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -587,6 +587,7 @@ def run_source_localization(
     brain = None
     if show_brain:
         _ensure_pyvista_backend()
+        log_func(f"Using 3D backend: {get_current_backend()}")
         # Visualise in a separate Brain window
         logger.debug(
             "Plotting STC with subjects_dir=%s, subject=%s", subjects_dir, subject
@@ -676,6 +677,7 @@ def view_source_estimate(
     threshold: Optional[float] = None,
     alpha: float = 0.4,
     window_title: Optional[str] = None,
+    log_func: Optional[Callable[[str], None]] = None,
 
 ) -> mne.viz.Brain:
     """Open a saved :class:`~mne.SourceEstimate` in an interactive viewer.
@@ -685,6 +687,9 @@ def view_source_estimate(
     alpha : float
         Transparency for the brain surface where ``1.0`` is opaque.
         Defaults to ``0.4`` (60% transparent).
+    log_func : Callable[[str], None] | None
+        Logging callback used to print messages to the GUI and console.
+        ``logger.info`` is used when not provided.
 
     Notes
     -----
@@ -720,7 +725,11 @@ def view_source_estimate(
         )
     logger.debug("subjects_dir resolved to %s", subjects_dir)
 
+    if log_func is None:
+        log_func = logger.info
+
     _ensure_pyvista_backend()
+    log_func(f"Using 3D backend: {get_current_backend()}")
 
     try:
         logger.debug(


### PR DESCRIPTION
## Summary
- log which 3D backend is active before opening the viewer
- surface these messages in the GUI
- document that the backend is printed when the viewer opens

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py src/Tools/SourceLocalization/eloreta_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685c2361ee08832c9b01e2b1b7b733f3