### PR TITLE
Improve 3D brain transparency control

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -36,10 +36,10 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
         # values don't raise TclError
         self.threshold_str = tk.StringVar(master=self, value="0.0")
 
-        # Default to 60% transparency (alpha = 0.4)
-        self.alpha_var = tk.DoubleVar(master=self, value=0.4)
+        # Default to 50% transparency (alpha = 0.5)
+        self.alpha_var = tk.DoubleVar(master=self, value=0.5)
         # similarly, the entry uses a StringVar to avoid invalid double strings
-        self.alpha_str = tk.StringVar(master=self, value="0.4")
+        self.alpha_str = tk.StringVar(master=self, value="0.5")
 
         self.hemi_var = tk.StringVar(master=self, value="both")
 

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -401,7 +401,7 @@ def run_source_localization(
     output_dir: str,
     method: str = "eLORETA",
     threshold: Optional[float] = None,
-    alpha: float = 0.4,
+    alpha: float = 0.5,
 
 
     low_freq: Optional[float] = None,
@@ -424,7 +424,7 @@ def run_source_localization(
     ----------
     alpha : float
         Initial transparency for the brain surface where ``1.0`` is opaque.
-        Defaults to ``0.4`` (60% transparent).
+        Defaults to ``0.5`` (50% transparent).
     hemi : {"lh", "rh", "both", "split"}
         Which hemisphere(s) to display in the interactive viewer.
     export_rois : bool
@@ -611,6 +611,7 @@ def run_source_localization(
                 subjects_dir=subjects_dir,
                 time_viewer=False,
                 hemi=hemi,
+                brain_alpha=alpha,
             )
             logger.debug("stc.plot succeeded")
         except Exception as err:
@@ -625,6 +626,7 @@ def run_source_localization(
                 subject=subject,
                 subjects_dir=subjects_dir,
                 time_viewer=False,
+                brain_alpha=alpha,
             )
             logger.debug("stc.plot succeeded on retry")
         _set_brain_alpha(brain, alpha)
@@ -674,7 +676,7 @@ def run_source_localization(
 def view_source_estimate(
     stc_path: str,
     threshold: Optional[float] = None,
-    alpha: float = 0.4,
+    alpha: float = 0.5,
     window_title: Optional[str] = None,
 
 ) -> mne.viz.Brain:
@@ -684,7 +686,7 @@ def view_source_estimate(
     ----------
     alpha : float
         Transparency for the brain surface where ``1.0`` is opaque.
-        Defaults to ``0.4`` (60% transparent).
+        Defaults to ``0.5`` (50% transparent).
 
     Notes
     -----
@@ -740,6 +742,7 @@ def view_source_estimate(
             subjects_dir=subjects_dir,
             time_viewer=False,
             hemi="split",
+            brain_alpha=alpha,
         )
         logger.debug("stc.plot succeeded in view_source_estimate")
     except Exception as err:
@@ -752,6 +755,7 @@ def view_source_estimate(
             subject=subject,
             subjects_dir=subjects_dir,
             time_viewer=False,
+            brain_alpha=alpha,
         )
         logger.debug("stc.plot succeeded on fallback in view_source_estimate")
 
@@ -777,7 +781,7 @@ def compare_source_estimates(
     stc_a: str,
     stc_b: str,
     threshold: Optional[float] = None,
-    alpha: float = 0.4,
+    alpha: float = 0.5,
     window_title: str = "Compare STCs",
 ) -> Tuple[mne.viz.Brain, mne.viz.Brain]:
     """Open two :class:`~mne.SourceEstimate` files side by side for comparison."""


### PR DESCRIPTION
## Summary
- default brain transparency is now 50%
- pass alpha directly to `stc.plot()` with `brain_alpha` so PyVista honors transparency

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Compiler Script.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c23c3f6e8832cb09baf25610db489