### PR TITLE
Fix LORETA harmonics retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ directly from the GUI.
 
 Additional parameters for band‑pass filtering and oddball cycle localisation can be
 configured under the **LORETA** tab in the Settings window. Here you may define
-the low and high filter bounds, choose which oddball harmonics to reconstruct and
-set the SNR value used when applying sLORETA. These values are populated in the
-Source Localization dialog so they can be tweaked per analysis.
+the low and high filter bounds, choose which oddball harmonics to reconstruct
+(specified in Hz, e.g. ``1.2, 2.4, 3.6``) and set the SNR value used when
+applying sLORETA. These values are populated in the Source Localization dialog
+so they can be tweaked per analysis.
 
 
 

--- a/src/Tools/SourceLocalization/eloreta_runner.py
+++ b/src/Tools/SourceLocalization/eloreta_runner.py
@@ -513,7 +513,9 @@ def run_source_localization(
         )
         evoked = source_localization.average_cycles(cycle_epochs)
         log_func("Averaged cycles into Evoked")
-        harmonic_freqs = [h * oddball_freq for h in harmonics]
+        # harmonics are specified in Hz in the settings dialog. Use them
+        # directly rather than scaling by the oddball frequency.
+        harmonic_freqs = harmonics
         if harmonic_freqs:
             log_func(
                 "Reconstructing harmonics: "


### PR DESCRIPTION
## Summary
- respect oddball harmonics exactly as saved in settings
- document that harmonics should be specified in Hz

## Testing
- `python -m py_compile src/Tools/SourceLocalization/eloreta_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_685c25efd928832ca36c4d4977ac59c6