### PR TITLE
Fix fsaverage import path

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -10,7 +10,7 @@ import os
 import tkinter as tk
 from tkinter import filedialog
 import customtkinter as ctk
-from Tools.SourceLocalization.runner import fetch_fsaverage_with_progress
+from Tools.SourceLocalization.data_utils import fetch_fsaverage_with_progress
 
 from config import init_fonts, FONT_MAIN
 from .settings_manager import SettingsManager

--- a/src/source_model.py
+++ b/src/source_model.py
@@ -6,7 +6,7 @@ import os
 from typing import Dict, List, Optional
 
 import mne
-from Tools.SourceLocalization.runner import fetch_fsaverage_with_progress
+from Tools.SourceLocalization.data_utils import fetch_fsaverage_with_progress
 
 
 def prepare_head_model(raw: mne.io.BaseRaw, template: str = "fsaverage") -> tuple[mne.Forward, str, str]:


### PR DESCRIPTION
## Summary
- update SettingsWindow to import `fetch_fsaverage_with_progress` from data_utils
- update source_model to use the same import

## Testing
- `ruff check .`
- `pytest -q` *(tests skipped: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c28473c832c8bdf6aed7c0cad4a