### PR TITLE
Update saving locations for FIF and STC files

### DIFF
--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -21,6 +21,23 @@ from Main_App.post_process import post_process as _external_post_process
 from Main_App.eeg_preprocessing import perform_preprocessing
 from Main_App.load_utils import load_eeg_file
 
+
+def _sanitize_folder_name(label: str) -> str:
+    """Return a filesystem-safe folder name without underscores."""
+    sanitized = label.replace('_', ' ').replace('/', '-').replace('\\', '-')
+    sanitized = sanitized.strip()
+    sanitized = re.sub(r'^\d+\s*-\s*', '', sanitized)
+    return sanitized
+
+
+def _stc_basename_from_fif(path: str) -> str:
+    """Generate a SourceEstimate base filename from a FIF file path."""
+    name = os.path.splitext(os.path.basename(path))[0]
+    name = re.sub(r'[\s_-]*epo$', '', name, flags=re.IGNORECASE)
+    name = re.sub(r'\s+', '_', name.strip())
+    name = re.sub(r'_+', '_', name)
+    return name
+
 class ProcessingMixin:
     def start_processing(self):
         if self.processing_thread and self.processing_thread.is_alive():
@@ -449,9 +466,16 @@ class ProcessingMixin:
                             stc_dict = source_model.apply_sloreta(file_epochs, inv)
 
                             for cond_label, stc in stc_dict.items():
-                                cond_folder = os.path.join(save_folder, cond_label.replace(' ', '_'))
+                                cond_folder = os.path.join(
+                                    save_folder,
+                                    "LORETA RESULTS",
+                                    _sanitize_folder_name(cond_label),
+                                )
                                 os.makedirs(cond_folder, exist_ok=True)
-                                stc_base = os.path.join(cond_folder, os.path.splitext(f_name)[0] + '_' + cond_label.replace(' ', '_'))
+                                base_name = _stc_basename_from_fif(
+                                    f"{os.path.splitext(f_name)[0]} {cond_label}.fif"
+                                )
+                                stc_base = os.path.join(cond_folder, base_name)
                                 stc.save(stc_base)
 
                                 brain = stc.plot(subject=subj, subjects_dir=subj_dir, time_viewer=False)
@@ -476,22 +500,30 @@ class ProcessingMixin:
                             for cond_label, epoch_list in file_epochs.items():
                                 if not epoch_list or not isinstance(epoch_list[0], mne.Epochs):
                                     continue
-                                cond_subfolder = os.path.join(fif_dir, cond_label.replace(' ', '_'))
+                                cond_subfolder = os.path.join(
+                                    fif_dir, _sanitize_folder_name(cond_label)
+                                )
                                 os.makedirs(cond_subfolder, exist_ok=True)
-                                cond_fname = f"{os.path.splitext(f_name)[0]}_{cond_label.replace(' ', '_')}-epo.fif"
+                                cond_fname = (
+                                    f"{os.path.splitext(f_name)[0]}_{cond_label.replace(' ', '_')}-epo.fif"
+                                )
                                 cond_path = os.path.join(cond_subfolder, cond_fname)
                                 epoch_list[0].save(cond_path, overwrite=True)
                                 gui_queue.put({'type': 'log', 'message': f"Condition FIF saved to: {cond_path}"})
 
-                                auto_loc = self.settings.get(
-                                    'loreta',
-                                    'auto_oddball_localization',
-                                    'False',
-                                ).lower() == 'true'
+                                auto_loc = (
+                                    self.settings.get(
+                                        'loreta',
+                                        'auto_oddball_localization',
+                                        'False',
+                                    ).lower()
+                                    == 'true'
+                                )
                                 if auto_loc:
-                                    sanitized = cond_label.replace(' ', '_').replace('/', '-').replace('\\', '-').strip()
-                                    sanitized = re.sub(r'^\d+\s*-\s*', '', sanitized)
-                                    out_folder = os.path.join(save_folder, sanitized)
+                                    sanitized_folder = _sanitize_folder_name(cond_label)
+                                    out_folder = os.path.join(
+                                        save_folder, 'LORETA RESULTS', sanitized_folder
+                                    )
                                     os.makedirs(out_folder, exist_ok=True)
                                     try:
                                         gui_queue.put({'type': 'log', 'message': f"Running oddball localization for {cond_label}..."})
@@ -499,6 +531,7 @@ class ProcessingMixin:
                                             cond_path,
                                             out_folder,
                                             oddball=True,
+                                            stc_basename=_stc_basename_from_fif(cond_path),
                                             log_func=lambda m: gui_queue.put({'type': 'log', 'message': m}),
                                             progress_cb=lambda f: gui_queue.put({'type': 'log', 'message': f"Localization {cond_label}: {int(f*100)}%"}),
                                         )

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -309,6 +309,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
                 method=method,
                 threshold=thr,
                 alpha=alpha,
+                stc_basename=None,
 
                 hemi=hemi,
                 low_freq=low_freq,

--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -73,9 +73,11 @@ except Exception as err:  # pragma: no cover - optional
 def run_source_localization(
     fif_path: str,
     output_dir: str,
+    *,
     method: str = "eLORETA",
     threshold: Optional[float] = None,
     alpha: float = 0.5,
+    stc_basename: Optional[str] = None,
 
 
     low_freq: Optional[float] = None,
@@ -96,6 +98,9 @@ def run_source_localization(
 
     Parameters
     ----------
+    stc_basename : str | None
+        Base filename (without hemisphere suffix) for the saved ``.stc`` files.
+        Defaults to ``"source"``.
     alpha : float
         Initial transparency for the brain surface where ``1.0`` is opaque.
         Defaults to ``0.5`` (50% transparent).
@@ -254,7 +259,8 @@ def run_source_localization(
         progress_cb(step / total)
 
     os.makedirs(output_dir, exist_ok=True)
-    stc_path = os.path.join(output_dir, "source")
+    base_name = stc_basename or "source"
+    stc_path = os.path.join(output_dir, base_name)
     stc.save(stc_path)
     step += 1
     if progress_cb:


### PR DESCRIPTION
## Summary
- allow saving LORETA results into `LORETA RESULTS/<condition>` folders
- keep condition FIF files in `.fif files` subfolders and remove underscores from folder names
- support specifying STC base name when running LORETA
- update GUI to pass new parameter

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6041a1d0832ca183447fe224a789