### PR TITLE
Ignore default result folders when scanning for stats

### DIFF
--- a/src/Tools/Stats/stats_file_scanner.py
+++ b/src/Tools/Stats/stats_file_scanner.py
@@ -6,6 +6,10 @@ import re
 import traceback
 from tkinter import filedialog, messagebox
 
+# Folders that should always be ignored when scanning for condition
+# subdirectories.  Stored in lower case for case-insensitive matching.
+IGNORED_FOLDERS = {".fif files", "loreta results"}
+
 
 def browse_folder(self):
     current_folder = self.stats_data_folder_var.get()
@@ -41,6 +45,9 @@ def scan_folder(self):
         for item_name in os.listdir(parent_folder):  # These are expected to be condition subfolders
             item_path = os.path.join(parent_folder, item_name)
             if os.path.isdir(item_path):
+                if item_name.lower() in IGNORED_FOLDERS:
+                    self.log_to_main_app(f"  Skipping ignored folder '{item_name}'.")
+                    continue
                 condition_name_raw = item_name
                 # Clean condition name (remove leading numbers/hyphens/spaces if any)
                 condition_name = re.sub(r'^\d+\s*[-_]*\s*', '', condition_name_raw).strip()

--- a/tests/test_stats_file_scanner.py
+++ b/tests/test_stats_file_scanner.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+
+
+def _import_scanner_module():
+    path = os.path.join(os.path.dirname(__file__), '..', 'src', 'Tools', 'Stats', 'stats_file_scanner.py')
+    spec = importlib.util.spec_from_file_location('stats_file_scanner', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+stats_file_scanner = _import_scanner_module()
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+    def get(self):
+        return self.value
+    def set(self, value):
+        self.value = value
+
+
+class DummyStats:
+    def __init__(self, folder):
+        self.stats_data_folder_var = DummyVar(folder)
+        self.detected_info_var = DummyVar()
+        self.condition_A_var = DummyVar()
+        self.condition_B_var = DummyVar()
+        self.subject_data = {}
+        self.subjects = []
+        self.conditions = []
+        self.all_subject_data = {}
+        self.rm_anova_results_data = None
+        self.harmonic_check_results_data = []
+        self.condA_menu = None
+        self.condB_menu = None
+        self.logs = []
+
+    def log_to_main_app(self, msg):
+        self.logs.append(msg)
+
+
+DummyStats.scan_folder = stats_file_scanner.scan_folder
+DummyStats.update_condition_menus = stats_file_scanner.update_condition_menus
+DummyStats.update_condition_B_options = stats_file_scanner.update_condition_B_options
+
+
+def test_scan_folder_ignores_default_dirs(tmp_path):
+    cond1 = tmp_path / "CondA"
+    cond1.mkdir()
+    cond2 = tmp_path / "CondB"
+    cond2.mkdir()
+    ignore1 = tmp_path / ".FIF FILES"
+    ignore1.mkdir()
+    ignore2 = tmp_path / "LoReTA RESULTS"
+    ignore2.mkdir()
+
+    for folder in [cond1, cond2, ignore1, ignore2]:
+        with open(folder / "P01_data.xlsx", "w") as f:
+            f.write("test")
+
+    dummy = DummyStats(str(tmp_path))
+    dummy.scan_folder()
+
+    assert set(dummy.conditions) == {"CondA", "CondB"}


### PR DESCRIPTION
## Summary
- skip default results folders when scanning for stats conditions
- add regression test for ignoring `.fif files` and `LORETA RESULTS`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6acb8fe0832c826861f855bdc7c6