### PR TITLE
Add UI constants helper

### DIFF
--- a/src/Main_App/ui_event_map_manager.py
+++ b/src/Main_App/ui_event_map_manager.py
@@ -11,21 +11,16 @@ import warnings
 from typing import Optional, Dict
 
 try:
-    # When running ``main.py`` directly, relative imports like ``..config``
-    # fail because the package hierarchy is not established. Importing from
-    # ``config`` ensures the constants are available regardless of how the app
-    # is launched.
-    from config import PAD_X, PAD_Y, CORNER_RADIUS, LABEL_ID_ENTRY_WIDTH
-    # ``LABEL_ID_ENTRY_WIDTH`` is used for the Condition Label entry.
-except ImportError:
+    from config import get_ui_constants
+    PAD_X, PAD_Y, CORNER_RADIUS, ENTRY_WIDTH, LABEL_ID_ENTRY_WIDTH = get_ui_constants()
+except Exception:
     warnings.warn(
         "Warning [ui_event_map_manager.py]: Could not import from config. "
         "Using fallback UI constants."
     )
-    PAD_X = 5
-    PAD_Y = 5
-    CORNER_RADIUS = 6
-    LABEL_ID_ENTRY_WIDTH = 100  # Fallback for Condition Label, ID entry will have its own width
+    PAD_X, PAD_Y, CORNER_RADIUS = 5, 5, 6
+    ENTRY_WIDTH = 100
+    LABEL_ID_ENTRY_WIDTH = 100  # Condition Label width fallback
 
 NUMERICAL_ID_ENTRY_FIXED_WIDTH = 140  # Fixed width for the ID entry box
 REMOVE_BUTTON_WIDTH = 28

--- a/src/Main_App/ui_setup_panels.py
+++ b/src/Main_App/ui_setup_panels.py
@@ -8,30 +8,16 @@ import tkinter as tk
 import customtkinter as ctk
 import warnings
 
-# Attempt to import constants from config.py
+# Attempt to import UI constants from config via helper
 try:
-    # When ``main.py`` is executed directly the package hierarchy is not
-    # recognised, so ``..config`` cannot be resolved.  Importing from
-    # ``config`` allows the app to run both as ``python src/main.py`` and
-    # ``python -m src.main``.
-    from config import (
-        ENTRY_WIDTH,
-        PAD_X,
-        PAD_Y,
-        CORNER_RADIUS,
-        # ``DEFAULT_STIM_CHANNEL`` and ``STIM_CHANNEL_ENTRY_WIDTH`` are no
-        # longer needed here. ``LABEL_ID_ENTRY_WIDTH`` is only used in the
-        # event map manager.
-    )
-except ImportError:
+    from config import get_ui_constants
+    PAD_X, PAD_Y, CORNER_RADIUS, ENTRY_WIDTH, _ = get_ui_constants()
+except Exception:
     warnings.warn(
         "Warning [ui_setup_panels.py]: Could not import from config. "
         "Using fallback UI constants."
     )
-    ENTRY_WIDTH = 80
-    PAD_X = 5
-    PAD_Y = 5
-    CORNER_RADIUS = 6
+    PAD_X, PAD_Y, CORNER_RADIUS, ENTRY_WIDTH = 5, 5, 6, 80
 
 
 class SetupPanelManager:

--- a/src/config.py
+++ b/src/config.py
@@ -103,3 +103,8 @@ def init_fonts() -> None:
     if FONT_HEADING is None:
         FONT_HEADING = ctk.CTkFont(family=FONT_FAMILY, size=14, weight="bold")
 
+
+def get_ui_constants() -> tuple[int, int, int, int, int]:
+    """Return the common UI dimension constants used throughout the app."""
+    return PAD_X, PAD_Y, CORNER_RADIUS, ENTRY_WIDTH, LABEL_ID_ENTRY_WIDTH
+

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -386,15 +386,17 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         delegating panel creation to respective managers."""
 
 
-        # Attempt to import UI constants from config, with fallbacks
+        # Attempt to obtain UI constants from config via helper
         try:
-            from config import PAD_X, PAD_Y, CORNER_RADIUS
-            # LABEL_ID_ENTRY_WIDTH is now primarily used within EventMapManager
-        except ImportError:
+            from config import get_ui_constants
+            PAD_X, PAD_Y, CORNER_RADIUS, _, _ = get_ui_constants()
+        except Exception:
             PAD_X = 5
             PAD_Y = 5
             CORNER_RADIUS = 6
-            print("Warning [FPVSApp.create_widgets]: Could not import UI constants from config. Using fallbacks.")
+            print(
+                "Warning [FPVSApp.create_widgets]: Could not import UI constants from config. Using fallbacks."
+            )
 
         # Main container
         main_frame = ctk.CTkFrame(self, corner_radius=0)


### PR DESCRIPTION
## Summary
- add `get_ui_constants` helper in `config.py`
- use the helper in `ui_setup_panels`, `ui_event_map_manager`, and `fpvs_app`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d49624148832c84d8b858dd3508b4