### PR TITLE
Enhance logging through logger usage

### DIFF
--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -1,26 +1,37 @@
-"""Mixin that timestamps and routes messages to the on-screen log
-and the console. It also exposes a tiny debug wrapper that respects
-the application's settings."""
+"""Mixin that timestamps and routes messages to the GUI and ``logging``.
+
+The mixin writes messages to a Tk ``Text`` widget if present while also
+forwarding them through :mod:`logging` for console output. Debug messages
+are only shown when the global logging level allows them, which is
+controlled via ``debug_utils.configure_logging``.
+"""
+import logging
 import tkinter as tk
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 class LoggingMixin:
     """Adds a timestamped logging function used across the toolbox."""
 
-    def log(self, message: str) -> None:
+    def log(self, message: str, level: int = logging.INFO) -> None:
+        """Write ``message`` to the GUI log widget and :mod:`logging`."""
         ts = pd.Timestamp.now().strftime('%H:%M:%S.%f')[:-3]
         formatted = f"{ts} [GUI]: {message}\n"
+
         try:
             if hasattr(self, 'log_text') and self.log_text and self.log_text.winfo_exists():
-                self.log_text.configure(state="normal")
-                self.log_text.insert(tk.END, formatted)
-                self.log_text.see(tk.END)
-                self.log_text.configure(state="disabled")
+                if level != logging.DEBUG or logger.isEnabledFor(logging.DEBUG):
+                    self.log_text.configure(state="normal")
+                    self.log_text.insert(tk.END, formatted)
+                    self.log_text.see(tk.END)
+                    self.log_text.configure(state="disabled")
         except Exception as e:  # pragma: no cover - best effort logging
-            print(f"[Log Error] {e}. Message: {message}")
-        print(formatted, end="")
+            logger.exception("Error writing log message to GUI: %s", e)
+
+        logger.log(level, message)
 
     def debug(self, message: str) -> None:
-        if hasattr(self, 'settings') and getattr(self, 'settings').debug_enabled():
-            self.log(f"[DEBUG] {message}")
+        if logger.isEnabledFor(logging.DEBUG):
+            self.log(f"[DEBUG] {message}", level=logging.DEBUG)


### PR DESCRIPTION
## Summary
- use Python's logging facilities in `LoggingMixin`
- log debug messages only when the configured level allows it
- keep GUI textbox updates while routing messages through `logging`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d495c9d60832c838c0d76c2120d5b