### PR TITLE
Avoid duplicate settings windows

### DIFF
--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -157,6 +157,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         self._current_progress = 0.0
         self._target_progress = 0.0
         self._animating_progress = False
+        self._settings_win = None
 
         # --- Register Validation Commands ---
         self.validate_num_cmd = (self.register(self._validate_numeric_input), '%P')
@@ -521,4 +522,16 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         DEFAULT_STIM_CHANNEL = self.settings.get('stim', 'channel', DEFAULT_STIM_CHANNEL)
 
     def open_settings_window(self):
-        SettingsWindow(self, self.settings)
+        """Open the Settings window if not already open."""
+        if self._settings_win and self._settings_win.winfo_exists():
+            self._settings_win.lift()
+            self._settings_win.focus_force()
+            return
+
+        self._settings_win = SettingsWindow(self, self.settings)
+        self._settings_win.protocol("WM_DELETE_WINDOW", self._on_settings_closed)
+
+    def _on_settings_closed(self):
+        if self._settings_win and self._settings_win.winfo_exists():
+            self._settings_win.destroy()
+        self._settings_win = None


### PR DESCRIPTION
## Summary
- track the settings window instance
- focus the existing settings window if it's already open

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4945b92c832c860c8e6daf51789b