### PR TITLE
Use config module for default stim channel

### DIFF
--- a/src/Main_App/app_logic.py
+++ b/src/Main_App/app_logic.py
@@ -10,7 +10,7 @@ import mne
 import numpy as np
 from scipy.stats import kurtosis
 
-from config import DEFAULT_STIM_CHANNEL
+import config
 
 
 
@@ -24,7 +24,7 @@ def preprocess_raw(app, raw, **params):
     ref1 = params.get('ref_channel1')
     ref2 = params.get('ref_channel2')
     max_keep = params.get('max_idx_keep')
-    stim_ch = params.get('stim_channel', DEFAULT_STIM_CHANNEL)
+    stim_ch = params.get('stim_channel', config.DEFAULT_STIM_CHANNEL)
 
     current_filename = "UnknownFile"
     if raw.filenames and raw.filenames[0]:

--- a/src/Main_App/eeg_preprocessing.py
+++ b/src/Main_App/eeg_preprocessing.py
@@ -8,19 +8,16 @@ import numpy as np
 from scipy.stats import kurtosis
 import traceback
 
-# Import DEFAULT_STIM_CHANNEL from config, assuming config.py is accessible
-# If config.py is in src, and Main_App is in src, this import needs adjustment
-# Assuming Main_App is a package, and config is at the same level as Main_App's parent (src)
-# For direct execution or if PYTHONPATH is set to include src:
+# Import configuration with a graceful fallback when run standalone
 try:
-    from config import DEFAULT_STIM_CHANNEL
-except ImportError:
-    # Fallback if run in a context where config isn't directly on path
-    # This might happen if eeg_preprocessing.py is tested standalone without proper path setup.
-    # For the app, the import from fpvs_app.py (which calls this) should work if config is importable there.
-    DEFAULT_STIM_CHANNEL = "Status"  # Sensible fallback
+    import config
+except ImportError:  # pragma: no cover - fallback for isolated execution
+    class _DummyConfig:
+        DEFAULT_STIM_CHANNEL = "Status"
+
+    config = _DummyConfig()
     print(
-        f"Warning [eeg_preprocessing.py]: Could not import DEFAULT_STIM_CHANNEL from config. Using '{DEFAULT_STIM_CHANNEL}'.")
+        f"Warning [eeg_preprocessing.py]: Could not import config. Using '{config.DEFAULT_STIM_CHANNEL}'.")
 
 
 def perform_preprocessing(raw_input: mne.io.BaseRaw,
@@ -54,7 +51,7 @@ def perform_preprocessing(raw_input: mne.io.BaseRaw,
     ref1 = params.get('ref_channel1')
     ref2 = params.get('ref_channel2')
     max_keep = params.get('max_idx_keep')
-    stim_ch = params.get('stim_channel', DEFAULT_STIM_CHANNEL)
+    stim_ch = params.get('stim_channel', config.DEFAULT_STIM_CHANNEL)
 
     num_kurtosis_bads_identified = 0
 

--- a/src/Main_App/event_detection.py
+++ b/src/Main_App/event_detection.py
@@ -9,7 +9,7 @@ import traceback
 import numpy as np
 import mne
 from tkinter import messagebox
-from config import DEFAULT_STIM_CHANNEL
+import config
 
 class EventDetectionMixin:
     def detect_and_show_event_ids(self):
@@ -24,7 +24,7 @@ class EventDetectionMixin:
             self.log("Detection failed: No data selected.")
             return
 
-        stim_channel_name = DEFAULT_STIM_CHANNEL
+        stim_channel_name = config.DEFAULT_STIM_CHANNEL
         self.log(f"Using stim channel: {stim_channel_name}")
         representative_file = self.data_paths[0]
         self.busy = True

--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -15,7 +15,7 @@ import pandas as pd
 import re
 from tkinter import messagebox
 import tkinter as tk
-from config import DEFAULT_STIM_CHANNEL
+import config
 from Tools.SourceLocalization import runner as eloreta_runner
 from Main_App.post_process import post_process as _external_post_process
 from Main_App.eeg_preprocessing import perform_preprocessing
@@ -218,7 +218,7 @@ class ProcessingMixin:
         import gc
 
         event_id_map_from_gui = params.get('event_id_map', {})
-        stim_channel_name = params.get('stim_channel', DEFAULT_STIM_CHANNEL)
+        stim_channel_name = params.get('stim_channel', config.DEFAULT_STIM_CHANNEL)
         save_folder = self.save_folder_path.get()
         max_bad_channels_alert_thresh = params.get('max_bad_channels_alert_thresh', 9999)
 

--- a/src/Main_App/validation_mixins.py
+++ b/src/Main_App/validation_mixins.py
@@ -6,7 +6,7 @@ doesn't run with invalid settings."""
 import os
 import traceback
 from tkinter import messagebox
-from config import DEFAULT_STIM_CHANNEL
+import config
 
 class ValidationMixin:
     def _validate_inputs(self):
@@ -98,7 +98,7 @@ class ValidationMixin:
             if params['max_idx_keep'] is not None:
                 assert params['max_idx_keep'] > 0, "Max Chan Idx Keep must be positive."
 
-            params['stim_channel'] = DEFAULT_STIM_CHANNEL
+            params['stim_channel'] = config.DEFAULT_STIM_CHANNEL
             self.log(f"Using Stimulus Channel: '{params['stim_channel']}' (from configuration)")
             self.debug(f"DEBUG_VALIDATE: Using Stimulus Channel: '{params['stim_channel']}'")
 

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -53,6 +53,7 @@ from config import (
     FPVS_TOOLBOX_REPO_PAGE,
     DEFAULT_STIM_CHANNEL
 )
+import config
 
 from Main_App.post_process import post_process as _external_post_process
 
@@ -519,6 +520,7 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         # Stim channel override
         global DEFAULT_STIM_CHANNEL
         DEFAULT_STIM_CHANNEL = self.settings.get('stim', 'channel', DEFAULT_STIM_CHANNEL)
+        config.DEFAULT_STIM_CHANNEL = DEFAULT_STIM_CHANNEL
 
     def open_settings_window(self):
         SettingsWindow(self, self.settings)


### PR DESCRIPTION
## Summary
- import the config module in several processing modules
- reference config.DEFAULT_STIM_CHANNEL instead of a module-level constant
- keep `_apply_loaded_settings` updating `config.DEFAULT_STIM_CHANNEL`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4952c468832ca01e61a019c031c6