### PR TITLE
Fix fsaverage path handling

### DIFF
--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -91,6 +91,8 @@ def _prepare_forward(
 ) -> tuple[mne.Forward, str, str]:
     """Construct a forward model using MRI info from settings or fsaverage."""
     stored_dir = settings.get("loreta", "mri_path", "")
+    if stored_dir:
+        stored_dir = os.path.normpath(stored_dir)
     subject = "fsaverage"
 
     log_func(f"Initial stored MRI directory: {stored_dir}")

--- a/src/Tools/SourceLocalization/viewer.py
+++ b/src/Tools/SourceLocalization/viewer.py
@@ -47,6 +47,8 @@ def view_source_estimate(
 
     settings = SettingsManager()
     stored_dir = settings.get("loreta", "mri_path", "")
+    if stored_dir:
+        stored_dir = os.path.normpath(stored_dir)
     subject = "fsaverage"
     if os.path.basename(stored_dir) == subject:
         subjects_dir = os.path.dirname(stored_dir)

--- a/src/Tools/SourceLocalization/visualization.py
+++ b/src/Tools/SourceLocalization/visualization.py
@@ -280,6 +280,8 @@ def view_source_estimate(
 
     settings = SettingsManager()
     stored_dir = settings.get("loreta", "mri_path", "")
+    if stored_dir:
+        stored_dir = os.path.normpath(stored_dir)
     subject = "fsaverage"
     if os.path.basename(stored_dir) == subject:
         subjects_dir = os.path.dirname(stored_dir)

--- a/tests/test_subjects_dir_normalization.py
+++ b/tests/test_subjects_dir_normalization.py
@@ -1,0 +1,42 @@
+import importlib
+import importlib.util
+import os
+import types
+from unittest import mock
+import pytest
+
+
+def _import_data_utils():
+    path = os.path.join(os.path.dirname(__file__), '..', 'src', 'Tools', 'SourceLocalization', 'data_utils.py')
+    spec = importlib.util.spec_from_file_location('data_utils', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _check_deps():
+    for mod in ('numpy', 'mne'):
+        if importlib.util.find_spec(mod) is None:
+            pytest.skip(f"{mod} not available", allow_module_level=True)
+
+
+def test_prepare_forward_trailing_slash(tmp_path):
+    _check_deps()
+    module = _import_data_utils()
+    SettingsManager = importlib.import_module('Main_App.settings_manager').SettingsManager
+    settings = SettingsManager()
+    fs_dir = tmp_path / 'fsaverage'
+    fs_dir.mkdir()
+    settings.set('loreta', 'mri_path', str(fs_dir) + os.sep)
+
+    dummy_evoked = types.SimpleNamespace(info={}, data=[], times=[])
+
+    with mock.patch.object(module.mne, 'setup_source_space', return_value='src'), \
+         mock.patch.object(module.mne, 'make_bem_model', return_value='model'), \
+         mock.patch.object(module.mne, 'make_bem_solution', return_value='bem'), \
+         mock.patch.object(module.mne, 'make_forward_solution', return_value='fwd'), \
+         mock.patch.object(module.mne, 'write_forward_solution'), \
+         mock.patch('os.path.isfile', return_value=False):
+        _, _, subjects_dir = module._prepare_forward(dummy_evoked, settings, lambda x: None)
+
+    assert subjects_dir == str(tmp_path)


### PR DESCRIPTION
## Summary
- sanitize stored MRI paths to avoid duplicated `fsaverage` subdirectories
- add regression test for correct subjects_dir computation

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d49a321e0832c97577036b02f9c6c