### PR TITLE
Add covariance estimation helper and update source localization

### DIFF
--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -55,6 +55,23 @@ def _threshold_stc(stc: mne.SourceEstimate, thr: float) -> mne.SourceEstimate:
     return stc
 
 
+def _estimate_epochs_covariance(
+    epochs: mne.Epochs, log_func: Callable[[str], None] = logger.info
+) -> mne.Covariance:
+    """Return a noise covariance estimated from ``epochs``.
+
+    If more than one epoch is available, ``mne.compute_covariance`` is used
+    with ``tmax=0.0``. Otherwise an ad-hoc covariance is returned and a log
+    message is emitted.
+    """
+
+    if len(epochs) > 1:
+        return mne.compute_covariance(epochs, tmax=0.0)
+
+    log_func("Only one epoch available. Using ad-hoc covariance.")
+    return mne.make_ad_hoc_cov(epochs.info)
+
+
 def fetch_fsaverage_with_progress(
     subjects_dir: str, log_func: Callable[[str], None] = logger.info
 ) -> str:

--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -29,6 +29,7 @@ from .data_utils import (
     _load_data,
     _threshold_stc,
     _prepare_forward,
+    _estimate_epochs_covariance,
 )
 
 logger = logging.getLogger(__name__)
@@ -185,6 +186,7 @@ def run_source_localization(
             snr = 3.0
     oddball_freq = float(settings.get("analysis", "oddball_freq", "1.2"))
 
+    noise_cov = None
     if epochs is not None:
         if oddball:
             if low_freq or high_freq:
@@ -193,6 +195,7 @@ def run_source_localization(
             log_func(
                 f"Extracted {len(cycle_epochs)} cycles of {1.0 / oddball_freq:.3f}s each"
             )
+            noise_cov = _estimate_epochs_covariance(cycle_epochs, log_func)
             evoked = source_localization.average_cycles(cycle_epochs)
             log_func("Averaged cycles into Evoked")
             harmonic_freqs = harmonics
@@ -203,6 +206,7 @@ def run_source_localization(
                 )
                 evoked = source_localization.reconstruct_harmonics(evoked, harmonic_freqs)
         else:
+            noise_cov = _estimate_epochs_covariance(epochs, log_func)
             evoked = epochs.average()
             if low_freq or high_freq:
                 evoked = evoked.copy().filter(l_freq=low_freq, h_freq=high_freq)
@@ -216,6 +220,7 @@ def run_source_localization(
         log_func(
             f"Extracted {len(cycle_epochs)} cycles of {1.0 / oddball_freq:.3f}s each"
         )
+        noise_cov = _estimate_epochs_covariance(cycle_epochs, log_func)
         evoked = source_localization.average_cycles(cycle_epochs)
         log_func("Averaged cycles into Evoked")
         harmonic_freqs = harmonics
@@ -225,12 +230,35 @@ def run_source_localization(
                 + ", ".join(f"{h:.2f}Hz" for h in harmonic_freqs)
             )
             evoked = source_localization.reconstruct_harmonics(evoked, harmonic_freqs)
+    elif fif_path and fif_path.endswith("-epo.fif"):
+        log_func("Loading epochs ...")
+        epochs = mne.read_epochs(fif_path, preload=True)
+        log_func(f"Loaded {len(epochs)} epoch(s)")
+        if low_freq or high_freq:
+            epochs = epochs.copy().filter(l_freq=low_freq, h_freq=high_freq)
+        noise_cov = _estimate_epochs_covariance(epochs, log_func)
+        evoked = epochs.average()
+        if low_freq or high_freq:
+            evoked = evoked.copy().filter(l_freq=low_freq, h_freq=high_freq)
     else:
         if fif_path is None:
             raise ValueError("fif_path must be provided if epochs is None")
         evoked = _load_data(fif_path)
         if low_freq or high_freq:
             evoked = evoked.copy().filter(l_freq=low_freq, h_freq=high_freq)
+        try:
+            temp_epochs = mne.EpochsArray(
+                evoked.data[np.newaxis, ...],
+                evoked.info,
+                tmin=evoked.times[0],
+                verbose=False,
+            )
+            noise_cov = mne.compute_covariance(temp_epochs, tmax=0.0)
+        except Exception as err:
+            log_func(
+                f"Noise covariance estimation failed ({err}). Using ad-hoc covariance."
+            )
+            noise_cov = mne.make_ad_hoc_cov(evoked.info)
     step += 1
     if progress_cb:
         progress_cb(step / total)
@@ -242,22 +270,7 @@ def run_source_localization(
     if progress_cb:
         progress_cb(step / total)
 
-    try:
-        temp_epochs = mne.EpochsArray(
-            evoked.data[np.newaxis, ...],
-            evoked.info,
-            tmin=evoked.times[0],
-            verbose=False,
-        )
-        noise_cov = mne.compute_covariance(temp_epochs, tmax=0.0)
-    except Exception as err:
-        log_func(
-            f"Noise covariance estimation failed ({err}). Using ad-hoc covariance."
-        )
-        noise_cov = mne.make_ad_hoc_cov(evoked.info)
-    step += 1
-    if progress_cb:
-        progress_cb(step / total)
+
 
     if oddball:
         inv = source_localization.build_inverse_operator(evoked, subjects_dir)
@@ -266,7 +279,9 @@ def run_source_localization(
             progress_cb(step / total)
         stc = source_localization.apply_sloreta(evoked, inv, snr)
     else:
-        inv = mne.minimum_norm.make_inverse_operator(evoked.info, fwd, noise_cov)
+        inv = mne.minimum_norm.make_inverse_operator(
+            evoked.info, fwd, noise_cov, reg=0.05
+        )
         step += 1
         if progress_cb:
             progress_cb(step / total)

--- a/tests/test_covariance_helper.py
+++ b/tests/test_covariance_helper.py
@@ -1,0 +1,24 @@
+import importlib.util
+import os
+import pytest
+
+
+def _import_runner():
+    for mod in ("numpy", "mne"):
+        if importlib.util.find_spec(mod) is None:
+            pytest.skip(f"{mod} not available", allow_module_level=True)
+    path = os.path.join(os.path.dirname(__file__), '..', 'src', 'Tools', 'SourceLocalization', 'runner.py')
+    spec = importlib.util.spec_from_file_location('runner', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_estimate_epochs_covariance_two_epochs():
+    runner = _import_runner()
+    func = runner._estimate_epochs_covariance
+    data = runner.np.random.RandomState(0).randn(2, 3, 4)
+    info = runner.mne.create_info(3, 1000.0, ch_types='eeg')
+    epochs = runner.mne.EpochsArray(data, info, verbose=False)
+    cov = func(epochs, log_func=lambda x: None)
+    assert isinstance(cov, runner.mne.Covariance)


### PR DESCRIPTION
## Summary
- add `_estimate_epochs_covariance` helper in `data_utils`
- use helper in `run_source_localization` for epochs inputs and regularize inverse operator
- add unit test for the new helper

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4c008050832c915dabf6d30cfd53