### PR TITLE
Fix log_file NameError in logging setup

### DIFF
--- a/src/Main_App/debug_utils.py
+++ b/src/Main_App/debug_utils.py
@@ -6,7 +6,7 @@ import mne
 
 
 
-def configure_logging(debug_enabled: bool) -> None:
+def configure_logging(debug_enabled: bool, log_file: str | None = None) -> None:
     """Configure root logging and MNE log levels.
 
     Parameters
@@ -15,6 +15,9 @@ def configure_logging(debug_enabled: bool) -> None:
         When ``True`` the root logger is set to ``DEBUG`` and MNE logs are
         raised to ``INFO`` for verbose output. Otherwise only ``INFO`` messages
         are shown and MNE logs are restricted to ``WARNING``.
+    log_file : str | None, optional
+        Optional path to a log file. When provided, log messages will also be
+        written to this file using UTF-8 encoding.
     """
 
 


### PR DESCRIPTION
## Summary
- add optional `log_file` parameter to `configure_logging`
- document `log_file` parameter in the docstring

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d53ca2b44832ca345bc5885d2276a