### PR TITLE
Fix brain actor alpha refresh

### DIFF
--- a/src/Tools/SourceLocalization/brain_utils.py
+++ b/src/Tools/SourceLocalization/brain_utils.py
@@ -24,6 +24,7 @@ def _set_brain_alpha(brain: mne.viz.Brain, alpha: float) -> None:
     """Set the transparency of a Brain viewer in a version robust way."""
     logger.debug("_set_brain_alpha called with %s", alpha)
     success = False
+    actors: list = []
     actor_count = 0
     try:
         if hasattr(brain, "set_alpha"):
@@ -39,8 +40,6 @@ def _set_brain_alpha(brain: mne.viz.Brain, alpha: float) -> None:
 
     if not success:
         try:
-            actors = []
-            actor_count = 0
             for hemi in getattr(brain, "_hemi_data", {}).values():
                 mesh = getattr(hemi, "mesh", None)
                 if mesh is not None and hasattr(mesh, "actor"):
@@ -83,9 +82,9 @@ def _set_brain_alpha(brain: mne.viz.Brain, alpha: float) -> None:
         except Exception:
             logger.debug("Failed to set brain alpha via mesh actors", exc_info=True)
 
+    renderer = getattr(brain, "_renderer", None)
+    plotter = getattr(renderer, "plotter", None)
     try:
-        renderer = getattr(brain, "_renderer", None)
-        plotter = getattr(renderer, "plotter", None)
         if plotter is not None and hasattr(plotter, "render"):
             logger.debug("Triggering plotter.render()")
             plotter.render()

--- a/tests/test_brain_utils.py
+++ b/tests/test_brain_utils.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+import importlib.util
+
+
+def _import_brain_utils(monkeypatch):
+    dummy = types.SimpleNamespace(viz=types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, 'mne', dummy)
+    monkeypatch.setitem(sys.modules, 'mne.viz', dummy.viz)
+
+    path = os.path.join(
+        os.path.dirname(__file__), '..', 'src', 'Tools', 'SourceLocalization', 'brain_utils.py'
+    )
+    spec = importlib.util.spec_from_file_location('brain_utils', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyActor:
+    def __init__(self):
+        self.opacity = None
+
+    def GetProperty(self):
+        return self
+
+    def SetOpacity(self, val):
+        self.opacity = val
+
+
+class DummyPlotter:
+    def __init__(self):
+        self.render_calls = 0
+
+    def render(self):
+        self.render_calls += 1
+
+
+class DummyRenderer:
+    def __init__(self):
+        self.plotter = DummyPlotter()
+
+
+def test_set_brain_alpha_applies_and_renders(monkeypatch):
+    module = _import_brain_utils(monkeypatch)
+    brain = types.SimpleNamespace(
+        _renderer=DummyRenderer(),
+        _actors={"a": DummyActor(), "b": DummyActor()},
+    )
+
+    module._set_brain_alpha(brain, 0.25)
+
+    assert all(a.opacity == 0.25 for a in brain._actors.values())
+    assert brain._renderer.plotter.render_calls == 1
+
+
+def test_save_brain_screenshots(tmp_path, monkeypatch):
+    module = _import_brain_utils(monkeypatch)
+    views, saved = [], []
+    brain = types.SimpleNamespace(
+        _renderer=DummyRenderer(),
+        _actors={"a": DummyActor()},
+        show_view=lambda view: views.append(view),
+        save_image=lambda path: saved.append(path),
+    )
+
+    module._set_brain_alpha(brain, 0.5)
+    module.save_brain_screenshots(brain, str(tmp_path))
+
+    assert views == ["lat", "rostral", "dorsal"]
+    assert len(saved) == 4
+    assert all(path.startswith(str(tmp_path)) for path in saved)


### PR DESCRIPTION
## Summary
- update `_set_brain_alpha` to apply opacity on all actors before rendering
- call `plotter.render()` after each alpha update
- add regression tests for alpha application and screenshot saving

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d649a498c832cb1fba30faa654b92