### PR TITLE
Add baseline support for oddball localization

### DIFF
--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -49,7 +49,9 @@ DEFAULTS = {
         'loreta_high_freq': '40.0',
         'oddball_harmonics': '1,2,3',
         'loreta_snr': '3.0',
-        'auto_oddball_localization': 'False'
+        'auto_oddball_localization': 'False',
+        'baseline_tmin': '-0.2',
+        'baseline_tmax': '0.0'
     },
     'debug': {
         'enabled': 'False'
@@ -91,6 +93,8 @@ class SettingsManager:
                 'oddball_harmonics',
                 'loreta_snr',
                 'auto_oddball_localization',
+                'baseline_tmin',
+                'baseline_tmax',
             ):
                 if not existing.has_option('loreta', opt):
                     missing_loreta = True

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -292,6 +292,13 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
                 harmonics.append(float(h))
             except ValueError:
                 pass
+        settings = SettingsManager()
+        try:
+            b_start = float(settings.get('loreta', 'baseline_tmin', '0'))
+            b_end = float(settings.get('loreta', 'baseline_tmax', '0'))
+            baseline = (b_start, b_end)
+        except ValueError:
+            baseline = None
         self.processing_thread = threading.Thread(
             target=self._run_thread,
             args=(
@@ -307,6 +314,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
                 self.snr_var.get(),
                 self.oddball_var.get(),
                 False,
+                baseline,
             ),
             daemon=True
         )
@@ -328,6 +336,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
         snr,
         oddball,
         export_rois,
+        baseline,
     ):
         log_func = getattr(self.master, "log", print)
         q = mp.Queue()
@@ -347,6 +356,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
                 snr=snr,
                 oddball=oddball,
                 export_rois=export_rois,
+                baseline=baseline,
                 queue=q,
             )
 

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -31,6 +31,8 @@ loreta_high_freq = 40.0
 oddball_harmonics = 1,2,3
 loreta_snr = 3.0
 auto_oddball_localization = False
+baseline_tmin = -0.2
+baseline_tmax = 0.0
 
 [debug]
 enabled = False

--- a/tests/test_covariance_helper.py
+++ b/tests/test_covariance_helper.py
@@ -20,5 +20,5 @@ def test_estimate_epochs_covariance_two_epochs():
     data = runner.np.random.RandomState(0).randn(2, 3, 4)
     info = runner.mne.create_info(3, 1000.0, ch_types='eeg')
     epochs = runner.mne.EpochsArray(data, info, verbose=False)
-    cov = func(epochs, log_func=lambda x: None)
+    cov = func(epochs, log_func=lambda x: None, baseline=(None, 0))
     assert isinstance(cov, runner.mne.Covariance)


### PR DESCRIPTION
## Summary
- add baseline time window settings
- compute covariance using baseline range
- allow optional baseline in source localization run
- propagate baseline from settings through GUI

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_685d64810668832caf8e0ec8e4748eb2