### PR TITLE
Fix STC averaging name and smoothing warnings

### DIFF
--- a/src/Tools/SourceLocalization/visualization.py
+++ b/src/Tools/SourceLocalization/visualization.py
@@ -8,19 +8,12 @@ from typing import Callable, Optional, Tuple
 
 import mne
 
-from .backend_utils import (
-    _ensure_pyvista_backend,
-    get_current_backend,
-    is_pyvistaqt_backend,
-    is_pyvista_backend,
-)
+from .backend_utils import _ensure_pyvista_backend, get_current_backend
 from .brain_utils import (
     _set_brain_title,
     _set_brain_alpha,
     _plot_with_alpha,
     _set_colorbar_label,
-    _add_brain_labels,
-    save_brain_screenshots,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_average_stc_directory.py
+++ b/tests/test_average_stc_directory.py
@@ -83,3 +83,23 @@ def test_average_stc_directory_two_files(tmp_path, monkeypatch):
     subjects = {call[0] for call in runner._morph_calls}
     assert subjects == {"sub1", "sub2"}
     assert all(call[2] == 5.0 for call in runner._morph_calls)
+
+
+def test_average_stc_directory_infer_name(tmp_path, monkeypatch):
+    runner = _import_runner(monkeypatch)
+
+    stc = DummyStc([[1]])
+    stc.save(os.path.join(tmp_path, "SC_P1_Green_Fruit_vs_Green_Veg"))
+    stc.save(os.path.join(tmp_path, "SC_P2_Green_Fruit_vs_Green_Veg"))
+
+    out = runner.average_stc_directory(str(tmp_path), log_func=lambda x: None)
+
+    expected = os.path.join(
+        str(tmp_path), "Average Green Fruit vs Green Veg Response"
+    )
+    assert out == expected
+    avg_files = sorted(p.name for p in tmp_path.glob("Average*"))
+    assert avg_files == [
+        "Average Green Fruit vs Green Veg Response-lh.stc",
+        "Average Green Fruit vs Green Veg Response-rh.stc",
+    ]


### PR DESCRIPTION
## Summary
- infer output names for averaged STC files from input names
- increase smoothing iterations when morphing to fsaverage
- clean up unused imports
- test inferred naming for STC averages

## Testing
- `ruff check . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6dd6bf24832ca7050d884b2e722a