### PR TITLE
Add normalization option for averaging LORETA

### DIFF
--- a/tests/test_average_stc_directory.py
+++ b/tests/test_average_stc_directory.py
@@ -86,6 +86,27 @@ def test_average_stc_directory_two_files(tmp_path, monkeypatch):
     assert all(call[2] == 5.0 for call in runner._morph_calls)
 
 
+def test_average_stc_directory_normalize_flag(tmp_path, monkeypatch):
+    runner = _import_runner(monkeypatch)
+
+    stc = DummyStc([[1]])
+    stc.save(os.path.join(tmp_path, "sub1"))
+
+    calls = []
+
+    def dummy_avg(stcs, *, normalize=False):
+        calls.append(normalize)
+        return DummyStc([[0]])
+
+    monkeypatch.setattr(runner, "average_stc_files", dummy_avg)
+
+    runner.average_stc_directory(
+        str(tmp_path), output_basename="avg", log_func=lambda x: None, normalize=True
+    )
+
+    assert calls == [True, True]
+
+
 def test_average_stc_directory_infer_name(tmp_path, monkeypatch):
     runner = _import_runner(monkeypatch)
 
@@ -125,4 +146,27 @@ def test_average_conditions_to_fsaverage_infer_name(tmp_path, monkeypatch):
         "Average Green Fruit vs Green Veg Response-lh.stc",
         "Average Green Fruit vs Green Veg Response-rh.stc",
     ]
+
+
+def test_average_conditions_to_fsaverage_normalize_flag(tmp_path, monkeypatch):
+    runner = _import_runner(monkeypatch)
+
+    cond = tmp_path / "Cond"
+    cond.mkdir()
+    stc = DummyStc([[1]])
+    stc.save(cond / "sub1")
+
+    calls = []
+
+    def dummy_avg(stcs, *, normalize=False):
+        calls.append(normalize)
+        return DummyStc([[0]])
+
+    monkeypatch.setattr(runner, "average_stc_files", dummy_avg)
+
+    runner.average_conditions_to_fsaverage(
+        str(tmp_path), str(tmp_path), normalize=True
+    )
+
+    assert calls == [True]
 

--- a/tests/test_average_stc_files.py
+++ b/tests/test_average_stc_files.py
@@ -31,3 +31,22 @@ def test_average_stc_files():
     result = avg_func([stc1, stc2])
     expected = module.np.array([[3, 4], [5, 6]])
     assert module.np.allclose(result.data, expected)
+
+
+def test_average_stc_files_normalized():
+    module = _import_eloreta_runner()
+    avg_func = getattr(module, 'average_stc_files', None)
+    if avg_func is None:
+        pytest.skip('average_stc_files not implemented')
+
+    class DummyStc:
+        def __init__(self, data):
+            self.data = module.np.array(data, dtype=float)
+        def copy(self):
+            return DummyStc(self.data.copy())
+
+    stc1 = DummyStc([[1, 2], [3, 4]])
+    stc2 = DummyStc([[5, 6], [7, 8]])
+    result = avg_func([stc1, stc2], normalize=True)
+    expected = module.np.array([[0.4375, 0.625], [0.8125, 1.0]])
+    assert module.np.allclose(result.data, expected)


### PR DESCRIPTION
## Summary
- add optional normalization to `average_stc_files` and propagate through all averaging helpers
- expose averaging mode selection in the Source Localization GUI
- pass the chosen mode when averaging STC results
- test normalized averaging and flag propagation

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_685d85d5e404832ca69007bb419178ca