### PR TITLE
Add configurable LORETA threshold and time window

### DIFF
--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -530,6 +530,20 @@ class ProcessingMixin:
                                     os.makedirs(out_folder, exist_ok=True)
                                     try:
                                         gui_queue.put({'type': 'log', 'message': f"Running oddball localization for {cond_label}..."})
+                                        thr_str = self.settings.get('loreta', 'loreta_threshold', '0.0')
+                                        try:
+                                            thr_val = float(thr_str)
+                                        except ValueError:
+                                            thr_val = None
+                                        start_ms = self.settings.get('loreta', 'time_window_start_ms', '')
+                                        end_ms = self.settings.get('loreta', 'time_window_end_ms', '')
+                                        try:
+                                            t_window = (
+                                                float(start_ms),
+                                                float(end_ms),
+                                            ) if start_ms and end_ms else None
+                                        except ValueError:
+                                            t_window = None
                                         eloreta_runner.run_source_localization(
                                             cond_path,
                                             out_folder,
@@ -539,6 +553,8 @@ class ProcessingMixin:
                                             progress_cb=lambda f: gui_queue.put({'type': 'log', 'message': f"Localization {cond_label}: {int(f*100)}%"}),
                                             show_brain=not batch_mode,
                                             epochs=epoch_list[0],
+                                            threshold=thr_val,
+                                            time_window=t_window,
                                         )
                                         gui_queue.put({'type': 'log', 'message': f"Localization complete for {cond_label}."})
                                     except Exception as e_loc:

--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -47,11 +47,14 @@ DEFAULTS = {
         'mri_path': '',
         'loreta_low_freq': '0.1',
         'loreta_high_freq': '40.0',
+        'loreta_threshold': '0.0',
         'oddball_harmonics': '1,2,3',
         'loreta_snr': '3.0',
         'auto_oddball_localization': 'False',
         'baseline_tmin': '-0.2',
-        'baseline_tmax': '0.0'
+        'baseline_tmax': '0.0',
+        'time_window_start_ms': '',
+        'time_window_end_ms': ''
     },
     'debug': {
         'enabled': 'False'
@@ -90,11 +93,14 @@ class SettingsManager:
             for opt in (
                 'loreta_low_freq',
                 'loreta_high_freq',
+                'loreta_threshold',
                 'oddball_harmonics',
                 'loreta_snr',
                 'auto_oddball_localization',
                 'baseline_tmin',
                 'baseline_tmax',
+                'time_window_start_ms',
+                'time_window_end_ms',
             ):
                 if not existing.has_option('loreta', opt):
                     missing_loreta = True

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -185,13 +185,26 @@ class SettingsWindow(ctk.CTkToplevel):
         ctk.CTkEntry(loreta_tab, textvariable=snr_var).grid(row=4, column=1, sticky="ew", padx=pad)
         self.snr_var = snr_var
 
+        ctk.CTkLabel(loreta_tab, text="Threshold").grid(row=5, column=0, sticky="w", padx=pad)
+        thr_var = tk.StringVar(value=self.manager.get('loreta', 'loreta_threshold', '0.0'))
+        ctk.CTkEntry(loreta_tab, textvariable=thr_var).grid(row=5, column=1, sticky="ew", padx=pad)
+        self.thr_var = thr_var
+
+        ctk.CTkLabel(loreta_tab, text="Time Window (ms)").grid(row=6, column=0, sticky="w", padx=pad)
+        t_start_var = tk.StringVar(value=self.manager.get('loreta', 'time_window_start_ms', ''))
+        t_end_var = tk.StringVar(value=self.manager.get('loreta', 'time_window_end_ms', ''))
+        ctk.CTkEntry(loreta_tab, textvariable=t_start_var, width=80).grid(row=6, column=1, sticky="w", padx=pad)
+        ctk.CTkEntry(loreta_tab, textvariable=t_end_var, width=80).grid(row=6, column=2, sticky="w", padx=pad)
+        self.t_start_var = t_start_var
+        self.t_end_var = t_end_var
+
         auto_loc_default = self.manager.get('loreta', 'auto_oddball_localization', 'False').lower() == 'true'
         self.auto_loc_var = tk.BooleanVar(value=auto_loc_default)
         ctk.CTkCheckBox(
             loreta_tab,
             text="Auto Oddball Localization",
             variable=self.auto_loc_var,
-        ).grid(row=5, column=0, columnspan=2, sticky="w", padx=pad)
+        ).grid(row=7, column=0, columnspan=2, sticky="w", padx=pad)
 
         btn_frame = ctk.CTkFrame(self, fg_color="transparent")
         btn_frame.grid(row=1, column=0, pady=(0, pad))
@@ -228,6 +241,9 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('loreta', 'loreta_high_freq', self.high_var.get())
         self.manager.set('loreta', 'oddball_harmonics', self.harm_var.get())
         self.manager.set('loreta', 'loreta_snr', self.snr_var.get())
+        self.manager.set('loreta', 'loreta_threshold', self.thr_var.get())
+        self.manager.set('loreta', 'time_window_start_ms', self.t_start_var.get())
+        self.manager.set('loreta', 'time_window_end_ms', self.t_end_var.get())
         self.manager.set(
             'loreta',
             'auto_oddball_localization',

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -34,10 +34,16 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
         self.input_var = tk.StringVar(master=self)
         self.output_var = tk.StringVar(master=self)
         self.method_var = tk.StringVar(master=self, value="eLORETA")
-        self.threshold_var = tk.DoubleVar(master=self, value=0.0)
+
+        settings = SettingsManager()
+        try:
+            thr = float(settings.get('loreta', 'loreta_threshold', '0.0'))
+        except ValueError:
+            thr = 0.0
+        self.threshold_var = tk.DoubleVar(master=self, value=thr)
         # use a separate StringVar for the entry widget so partially typed
         # values don't raise TclError
-        self.threshold_str = tk.StringVar(master=self, value="0.0")
+        self.threshold_str = tk.StringVar(master=self, value=str(thr))
 
         # Default to 50% transparency (alpha = 0.5)
         self.alpha_var = tk.DoubleVar(master=self, value=0.5)
@@ -46,7 +52,6 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
 
         self.hemi_var = tk.StringVar(master=self, value="both")
 
-        settings = SettingsManager()
         try:
             low = float(settings.get('loreta', 'loreta_low_freq', '0.1'))
         except ValueError:
@@ -64,8 +69,12 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
             snr = 3.0
         self.snr_var = tk.DoubleVar(master=self, value=snr)
         self.oddball_var = tk.BooleanVar(master=self, value=False)
-        self.time_start_var = tk.StringVar(master=self, value="")
-        self.time_end_var = tk.StringVar(master=self, value="")
+        self.time_start_var = tk.StringVar(
+            master=self, value=settings.get('loreta', 'time_window_start_ms', '')
+        )
+        self.time_end_var = tk.StringVar(
+            master=self, value=settings.get('loreta', 'time_window_end_ms', '')
+        )
 
         self.avg_mode_var = tk.StringVar(master=self, value="Raw amplitudes")
 

--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -141,8 +141,6 @@ def run_source_localization(
         },
     )
 
-    if time_window is not None:
-        time_window = (time_window[0] / 1000.0, time_window[1] / 1000.0)
     logger.debug(
         "QT_API=%s QT_QPA_PLATFORM=%s",
         os.environ.get("QT_API"),
@@ -158,6 +156,21 @@ def run_source_localization(
     else:
         log_func(f"Loading data from {fif_path}")
     settings = SettingsManager()
+    if threshold is None:
+        try:
+            threshold = float(settings.get("loreta", "loreta_threshold", "0.0"))
+        except ValueError:
+            threshold = None
+    if time_window is None:
+        start_ms = settings.get("loreta", "time_window_start_ms", "")
+        end_ms = settings.get("loreta", "time_window_end_ms", "")
+        try:
+            if start_ms and end_ms:
+                time_window = (float(start_ms), float(end_ms))
+        except ValueError:
+            time_window = None
+    if time_window is not None:
+        time_window = (time_window[0] / 1000.0, time_window[1] / 1000.0)
     if low_freq is None:
         try:
             low_freq = float(settings.get("loreta", "loreta_low_freq", "0.1"))

--- a/tests/test_loreta_defaults.py
+++ b/tests/test_loreta_defaults.py
@@ -1,0 +1,103 @@
+import importlib.util
+import os
+import sys
+import types
+import pytest
+
+
+if importlib.util.find_spec("numpy") is None:
+    pytest.skip("numpy not available", allow_module_level=True)
+
+
+def _import_runner(monkeypatch):
+    dummy = types.SimpleNamespace()
+    dummy.__version__ = "0"
+    dummy.viz = types.SimpleNamespace(
+        get_3d_backend=lambda: "pyvistaqt",
+        set_3d_backend=lambda *a, **k: None,
+    )
+    dummy.combine_evoked = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "mne", dummy)
+    monkeypatch.setitem(sys.modules, "mne.viz", dummy.viz)
+
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "SourceLocalization",
+        "runner.py",
+    )
+    spec = importlib.util.spec_from_file_location("runner", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyEvoked:
+    def __init__(self):
+        self.crop_calls = []
+
+    def copy(self):
+        new = DummyEvoked()
+        new.crop_calls = self.crop_calls
+        return new
+
+    def filter(self, *a, **k):
+        return self
+
+    def crop(self, tmin=None, tmax=None):
+        self.crop_calls.append((tmin, tmax))
+        return self
+
+
+class DummyEpochs:
+    def copy(self):
+        return self
+
+    def filter(self, *a, **k):
+        return self
+
+    def apply_baseline(self, *a, **k):
+        pass
+
+    def average(self):
+        return DummyEvoked()
+
+
+def test_defaults_from_settings(monkeypatch):
+    runner = _import_runner(monkeypatch)
+
+    captured = {}
+
+    def _dummy_prepare_forward(evoked, settings, log_func):
+        captured["evoked"] = evoked
+        raise RuntimeError("stop")
+
+    def _dummy_threshold(stc, thr):
+        captured["thr"] = thr
+        return stc
+
+    monkeypatch.setattr(runner, "_estimate_epochs_covariance", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "_prepare_forward", _dummy_prepare_forward)
+    monkeypatch.setattr(runner, "_threshold_stc", _dummy_threshold)
+
+    def fake_get(section, option, fallback=""):
+        values = {
+            "loreta_threshold": "0.5",
+            "time_window_start_ms": "100",
+            "time_window_end_ms": "200",
+            "loreta_low_freq": "0.1",
+            "loreta_high_freq": "40.0",
+            "oddball_harmonics": "1,2,3",
+            "loreta_snr": "3.0",
+        }
+        return values.get(option, fallback)
+
+    monkeypatch.setattr(runner, "SettingsManager", lambda *a, **k: types.SimpleNamespace(get=fake_get))
+
+    with pytest.raises(RuntimeError):
+        runner.run_source_localization(None, "out", epochs=DummyEpochs())
+
+    assert captured["thr"] == 0.5
+    assert captured["evoked"].crop_calls == [(0.1, 0.2)]


### PR DESCRIPTION
## Summary
- allow settings for LORETA threshold and time window
- expose new options in settings GUI
- use these defaults when launching the GUI and during auto localization
- test that defaults from settings are honoured

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d91e8e150832c8fea949477aa44b9