### PR TITLE
Add baseline step after harmonic reconstruction

### DIFF
--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -188,6 +188,14 @@ def run_source_localization(
             snr = 3.0
     oddball_freq = float(settings.get("analysis", "oddball_freq", "1.2"))
 
+    if baseline is None:
+        try:
+            b_start = float(settings.get("loreta", "baseline_tmin", "0"))
+            b_end = float(settings.get("loreta", "baseline_tmax", "0"))
+            baseline = (b_start, b_end)
+        except ValueError:
+            baseline = None
+
     noise_cov = None
     if epochs is not None:
         if oddball:
@@ -209,6 +217,8 @@ def run_source_localization(
                     + ", ".join(f"{h:.2f}Hz" for h in harmonic_freqs)
                 )
                 evoked = source_localization.reconstruct_harmonics(evoked, harmonic_freqs)
+                if baseline is not None:
+                    evoked.apply_baseline(baseline)
             evoked = evoked.copy().crop(tmin=0.0, tmax=1.0 / oddball_freq)
             if time_window is not None:
                 tmin, tmax = time_window
@@ -244,6 +254,8 @@ def run_source_localization(
                 + ", ".join(f"{h:.2f}Hz" for h in harmonic_freqs)
             )
             evoked = source_localization.reconstruct_harmonics(evoked, harmonic_freqs)
+            if baseline is not None:
+                evoked.apply_baseline(baseline)
         evoked = evoked.copy().crop(tmin=0.0, tmax=1.0 / oddball_freq)
         if time_window is not None:
             tmin, tmax = time_window


### PR DESCRIPTION
## Summary
- read baseline window from settings when missing
- apply baseline to the reconstructed evoked signal before cropping

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d92ba6c20832c83bcef871214d314