### PR TITLE
Fix wrong worker call in LoRETA GUI

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -15,7 +15,7 @@ from Main_App.settings_manager import SettingsManager
 import customtkinter as ctk
 
 from config import PAD_X, PAD_Y, CORNER_RADIUS, init_fonts, FONT_MAIN
-from . import runner, visualization
+from . import runner, worker, visualization
 
 
 class SourceLocalizationWindow(ctk.CTkToplevel):
@@ -426,7 +426,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
 
         with ProcessPoolExecutor(max_workers=1) as ex:
             future = ex.submit(
-                runner.run_localization_worker,
+                worker.run_localization_worker,
                 fif_path,
                 out_dir,
                 method=method,


### PR DESCRIPTION
## Summary
- update eloreta GUI to use `worker.run_localization_worker`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9c84d60c832c8e78b753c155bcbb