### PR TITLE
Fix fsaverage path handling

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -21,9 +21,13 @@ def _find_fsaverage_dir() -> str:
     """Return the fsaverage directory if it exists locally."""
     try:
         import mne
-        subjects_dir = mne.get_config('SUBJECTS_DIR', os.getenv('SUBJECTS_DIR'))
+        subjects_dir = mne.get_config("SUBJECTS_DIR", os.getenv("SUBJECTS_DIR"))
         if subjects_dir:
-            path = os.path.join(subjects_dir, 'fsaverage')
+            subjects_dir = os.path.expanduser(subjects_dir)
+            if os.path.basename(subjects_dir) == "fsaverage":
+                path = subjects_dir
+            else:
+                path = os.path.join(subjects_dir, "fsaverage")
             if os.path.isdir(path):
                 return path
     except Exception:


### PR DESCRIPTION
## Summary
- avoid double-appending `fsaverage` when locating the default template
- revert installation directory back to repo root

## Testing
- `ruff check --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d9dc636c8832ca2413bb3e0ce3959