### PR TITLE
Fix baseline cropping and fsaverage path

### DIFF
--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -156,7 +156,9 @@ def _prepare_forward(
         subjects_dir_path = _default_template_location().parent
     else:
         stored_dir_path = stored_dir_path.resolve()
-        if stored_dir_path.name == subject:
+        if stored_dir_path.parts[-2:] == (subject, subject):
+            subjects_dir_path = stored_dir_path.parent.parent
+        elif stored_dir_path.name.lower() == subject.lower():
             subjects_dir_path = stored_dir_path.parent
         elif (stored_dir_path / subject).is_dir():
             subjects_dir_path = stored_dir_path


### PR DESCRIPTION
## Summary
- fix baseline handling in oddball workflow so covariance is computed before cropping
- remove redundant baseline correction step after harmonic reconstruction
- normalize `subjects_dir` path handling to avoid nested `fsaverage` directories

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da27b2a20832ca77c38f55eb8bc77