### PR TITLE
Handle layered meshes with no values

### DIFF
--- a/src/Tools/SourceLocalization/brain_utils.py
+++ b/src/Tools/SourceLocalization/brain_utils.py
@@ -52,7 +52,12 @@ def _set_brain_alpha(brain: mne.viz.Brain, alpha: float) -> None:
                         actors.append(actor)
 
             for hemi_layers in getattr(brain, "_layered_meshes", {}).values():
-                for layer in hemi_layers.values():
+                layers = (
+                    hemi_layers.values()
+                    if hasattr(hemi_layers, "values")
+                    else [hemi_layers]
+                )
+                for layer in layers:
                     actor = getattr(layer, "actor", None)
                     if actor is not None:
                         actors.append(actor)

--- a/tests/test_brain_utils.py
+++ b/tests/test_brain_utils.py
@@ -71,3 +71,22 @@ def test_save_brain_screenshots(tmp_path, monkeypatch):
     assert views == ["lat", "rostral", "dorsal"]
     assert len(saved) == 4
     assert all(path.startswith(str(tmp_path)) for path in saved)
+
+
+class DummyLayeredMesh:
+    def __init__(self):
+        self.actor = DummyActor()
+
+
+def test_set_brain_alpha_no_values(monkeypatch):
+    module = _import_brain_utils(monkeypatch)
+    mesh = DummyLayeredMesh()
+    brain = types.SimpleNamespace(
+        _renderer=DummyRenderer(),
+        _layered_meshes={"lh": mesh},
+    )
+
+    module._set_brain_alpha(brain, 0.75)
+
+    assert mesh.actor.opacity == 0.75
+    assert brain._renderer.plotter.render_calls == 1


### PR DESCRIPTION
## Summary
- ensure `_set_brain_alpha` handles objects without `values`
- test `_set_brain_alpha` with a `_LayeredMesh` lacking `values`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da7517464832c9970582f875be7b7