### PR TITLE
Normalize MRI path usage

### DIFF
--- a/src/Tools/SourceLocalization/visualization.py
+++ b/src/Tools/SourceLocalization/visualization.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import logging
+from pathlib import Path
 from typing import Callable, Optional, Tuple
 
 import mne
@@ -15,6 +16,7 @@ from .brain_utils import (
     _plot_with_alpha,
     _set_colorbar_label,
 )
+from .data_utils import _resolve_subjects_dir
 
 logger = logging.getLogger(__name__)
 
@@ -62,15 +64,10 @@ def view_source_estimate(
 
     settings = SettingsManager()
     stored_dir = settings.get("loreta", "mri_path", "")
-    if stored_dir:
-        stored_dir = os.path.normpath(stored_dir)
+    stored_path = Path(stored_dir).resolve() if stored_dir else None
     subject = "fsaverage"
-    if os.path.basename(stored_dir) == subject:
-        subjects_dir = os.path.dirname(stored_dir)
-    else:
-        subjects_dir = (
-            stored_dir if stored_dir else os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        )
+    subjects_dir = _resolve_subjects_dir(stored_path, subject)
+    subjects_dir = str(subjects_dir)
     logger.debug("subjects_dir resolved to %s", subjects_dir)
 
     if log_func is None:

--- a/tests/test_subjects_dir_normalization.py
+++ b/tests/test_subjects_dir_normalization.py
@@ -40,3 +40,26 @@ def test_prepare_forward_trailing_slash(tmp_path):
         _, _, subjects_dir = module._prepare_forward(dummy_evoked, settings, lambda x: None)
 
     assert subjects_dir == str(tmp_path)
+
+
+def test_prepare_forward_double_fsaverage(tmp_path):
+    _check_deps()
+    module = _import_data_utils()
+    SettingsManager = importlib.import_module('Main_App.settings_manager').SettingsManager
+    settings = SettingsManager()
+
+    nested = tmp_path / 'fsaverage' / 'fsaverage'
+    nested.mkdir(parents=True)
+    settings.set('loreta', 'mri_path', str(nested))
+
+    dummy_evoked = types.SimpleNamespace(info={}, data=[], times=[])
+
+    with mock.patch.object(module.mne, 'setup_source_space', return_value='src'), \
+         mock.patch.object(module.mne, 'make_bem_model', return_value='model'), \
+         mock.patch.object(module.mne, 'make_bem_solution', return_value='bem'), \
+         mock.patch.object(module.mne, 'make_forward_solution', return_value='fwd'), \
+         mock.patch.object(module.mne, 'write_forward_solution'), \
+         mock.patch('os.path.isfile', return_value=False):
+        _, _, subjects_dir = module._prepare_forward(dummy_evoked, settings, lambda x: None)
+
+    assert subjects_dir == str(tmp_path)

--- a/tests/test_visualization_subjects_dir.py
+++ b/tests/test_visualization_subjects_dir.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+import sys
+import types
+from unittest import mock
+import pytest
+
+
+def _import_visualization():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "SourceLocalization",
+        "visualization.py",
+    )
+    spec = importlib.util.spec_from_file_location("visualization", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _check_deps():
+    for mod in ("numpy", "mne"):
+        if importlib.util.find_spec(mod) is None:
+            pytest.skip(f"{mod} not available", allow_module_level=True)
+
+
+def test_view_source_estimate_normalizes_subjects_dir(tmp_path, monkeypatch):
+    _check_deps()
+    module = _import_visualization()
+
+    SettingsManager = importlib.import_module("Main_App.settings_manager").SettingsManager
+    settings = SettingsManager()
+    nested = tmp_path / "fsaverage" / "fsaverage"
+    nested.mkdir(parents=True)
+    settings.set("loreta", "mri_path", str(nested))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Main_App.settings_manager",
+        types.SimpleNamespace(SettingsManager=lambda: settings),
+    )
+
+    captured = {}
+
+    class DummyBrain:
+        def add_label(self, *a, **k):
+            pass
+
+    def dummy_plot(stc, hemi, subjects_dir, subject, alpha):
+        captured["subjects_dir"] = subjects_dir
+        return DummyBrain()
+
+    monkeypatch.setattr(module, "_plot_with_alpha", dummy_plot)
+    monkeypatch.setattr(module, "_ensure_pyvista_backend", lambda: None)
+    monkeypatch.setattr(module, "_set_brain_alpha", lambda *a, **k: None)
+    monkeypatch.setattr(module, "_set_brain_title", lambda *a, **k: None)
+    monkeypatch.setattr(module, "_set_colorbar_label", lambda *a, **k: None)
+    monkeypatch.setattr(module.mne, "read_source_estimate", lambda p: types.SimpleNamespace(data=[], subject="fsaverage"))
+    monkeypatch.setattr(module.mne, "read_labels_from_annot", lambda *a, **k: [])
+
+    module.view_source_estimate(str(tmp_path / "dummy"), log_func=lambda x: None)
+
+    assert captured["subjects_dir"] == str(tmp_path)
+


### PR DESCRIPTION
## Summary
- normalize fsaverage directory handling with `_resolve_subjects_dir`
- update visualization to use the new helper
- test normalization in `_prepare_forward` and `view_source_estimate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685daec30ef8832cb20b3cd53aa3d53b