### PR TITLE
Fix auto 3D viewer

### DIFF
--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -227,8 +227,6 @@ class ProcessingMixin:
         original_app_data_paths = list(self.data_paths)
         original_app_preprocessed_data = dict(self.preprocessed_data)
 
-        batch_mode = len(data_paths) > 1
-
         quality_flagged_files_info_for_run = []
 
         try:
@@ -550,7 +548,7 @@ class ProcessingMixin:
                                             stc_basename=_stc_basename_from_fif(cond_path),
                                             log_func=lambda m: gui_queue.put({'type': 'log', 'message': m}),
                                             progress_cb=lambda f: gui_queue.put({'type': 'log', 'message': f"Localization {cond_label}: {int(f*100)}%"}),
-                                            show_brain=not batch_mode,
+                                            show_brain=False,
                                             epochs=epoch_list[0],
                                             threshold=thr_val,
                                             time_window=t_window,

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -80,6 +80,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
 
 
         self.brain = None
+        self.last_stc_path: Optional[str] = None
 
         self.progress_var = tk.DoubleVar(master=self, value=0.0)
         self.remaining_var = tk.StringVar(master=self, value="")
@@ -457,12 +458,7 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
 
             try:
                 _stc_path, _ = future.result()
-                self.after(
-                    0,
-                    lambda: self._open_brain(
-                        _stc_path, thr, alpha, os.path.basename(_stc_path)
-                    ),
-                )
+                self.last_stc_path = _stc_path
                 self.after(0, self._on_finish, None)
             except Exception as e:
                 self.after(0, self._on_finish, e)


### PR DESCRIPTION
## Summary
- stop opening the 3D viewer during standard processing
- keep last LORETA result path without showing the viewer

## Testing
- `ruff check src/Main_App/processing_utils.py src/Tools/SourceLocalization/eloreta_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685db2da741c832ca18b7b4038799f5c