### PR TITLE
Forward SourceLocalization logs to GUI

### DIFF
--- a/src/Tools/SourceLocalization/logging_utils.py
+++ b/src/Tools/SourceLocalization/logging_utils.py
@@ -1,0 +1,24 @@
+"""Logging helpers for the source localization module."""
+
+from __future__ import annotations
+
+import logging
+from multiprocessing import Queue
+
+
+class QueueLogHandler(logging.Handler):
+    """Forward log messages to a ``multiprocessing.Queue``."""
+
+    def __init__(self, queue: Queue, level: int = logging.INFO) -> None:
+        super().__init__(level=level)
+        self.queue = queue
+        self.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - best effort
+        try:
+            msg = self.format(record)
+            self.queue.put({"type": "log", "message": msg})
+        except Exception:
+            pass
+
+__all__ = ["QueueLogHandler"]


### PR DESCRIPTION
## Summary
- add `QueueLogHandler` utility to forward logging output via multiprocessing queues
- forward logging in `worker.run_localization_worker`
- forward logging in batch processing when calling LORETA

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbbd58704832ca52bb35b4f0f2dcb