### PR TITLE
Skip duplicate fsaverage downloads

### DIFF
--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -122,6 +122,14 @@ def fetch_fsaverage_with_progress(
     directory holding the actual template files.
     """
     subjects_dir = Path(subjects_dir)
+    dest = subjects_dir / "fsaverage"
+
+    if (dest / "fsaverage" / "surf" / "lh.white").exists() and (
+        dest / "fsaverage" / "bem" / "fsaverage-5120-bem.fif"
+    ).exists():
+        _wrap_fsaverage(subjects_dir, subject="fsaverage")
+        return str(dest / "fsaverage")
+
     stop_event = threading.Event()
 
     def _report():


### PR DESCRIPTION
## Summary
- avoid fetching fsaverage if core files exist

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbcf19df4832c83cc45eab5ba00f6