### PR TITLE
Remove PNG screenshot generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ source localization tool.
 Choose **Source Localization (eLORETA/sLORETA)** from the Tools menu to run an
 inverse solution on a preprocessed `.fif` file. Select the desired method and an
 output folder. An interactive 3‑D viewer will open showing both hemispheres with
-anatomical labels. Side, frontal and top screenshots are automatically saved in
-the chosen folder. You can also open any saved `source-lh.stc`/`source-rh.stc`
+anatomical labels. You can open any saved `source-lh.stc`/`source-rh.stc`
 pair later using the **View STC** button to inspect the results interactively and
 adjust the brain transparency. A hemisphere selector lets you view the left
 hemisphere, right hemisphere, both together, or a split layout. Activity is

--- a/src/Main_App/processing_utils.py
+++ b/src/Main_App/processing_utils.py
@@ -498,11 +498,6 @@ class ProcessingMixin:
                                     stc_base = os.path.join(cond_folder, base_name)
                                     stc.save(stc_base)
 
-                                    brain = stc.plot(subject=subj, subjects_dir=subj_dir, time_viewer=False)
-                                    for view, name in [('dorsal', 'top'), ('rostral', 'frontal'), ('lat', 'side')]:
-                                        brain.show_view(view)
-                                        brain.save_image(f"{stc_base}_{name}.png")
-                                    brain.close()
 
                                     excel_name = f"{extracted_pid_for_flagging}_{cond_label.replace(' ', '_')}_Results.xlsx"
                                     excel_path = os.path.join(cond_folder, excel_name)

--- a/src/Tools/SourceLocalization/brain_utils.py
+++ b/src/Tools/SourceLocalization/brain_utils.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import logging
 import inspect
-import os
-from typing import Optional, Tuple
+
 
 import mne
 
@@ -159,31 +158,3 @@ def _set_colorbar_label(brain: mne.viz.Brain, label: str) -> None:
         logger.debug("Failed to set colorbar label", exc_info=True)
 
 
-def save_brain_screenshots(
-    brain: mne.viz.Brain,
-    output_dir: str,
-    time: Optional[Tuple[float, float] | float] = None,
-) -> None:
-    """Save standard view screenshots to ``output_dir``.
-
-    If ``time`` is provided, a suffix containing the time information is added
-    to the output file names.
-    """
-    if time is not None:
-        if isinstance(time, (tuple, list)):
-            tmin, tmax = float(time[0]), float(time[1])
-            suffix = f"_{tmin:.3f}-{tmax:.3f}s"
-        else:
-            tmin = float(time)
-            suffix = f"_{tmin:.3f}s"
-    else:
-        suffix = ""
-
-    for view, name in [
-        ("lat", "side"),
-        ("rostral", "frontal"),
-        ("dorsal", "top"),
-    ]:
-        brain.show_view(view)
-        brain.save_image(os.path.join(output_dir, f"{name}{suffix}.png"))
-    brain.save_image(os.path.join(output_dir, f"overview{suffix}.png"))

--- a/tests/test_brain_utils.py
+++ b/tests/test_brain_utils.py
@@ -62,23 +62,6 @@ def test_set_brain_alpha_applies_and_renders(monkeypatch):
     assert brain._renderer.plotter.render_calls == 1
 
 
-def test_save_brain_screenshots(tmp_path, monkeypatch):
-    module = _import_brain_utils(monkeypatch)
-    views, saved = [], []
-    brain = types.SimpleNamespace(
-        _renderer=DummyRenderer(),
-        _actors={"a": DummyActor()},
-        show_view=lambda view: views.append(view),
-        save_image=lambda path: saved.append(path),
-    )
-
-    module._set_brain_alpha(brain, 0.5)
-    module.save_brain_screenshots(brain, str(tmp_path))
-
-    assert views == ["lat", "rostral", "dorsal"]
-    assert len(saved) == 4
-    assert all(path.startswith(str(tmp_path)) for path in saved)
-
 
 def test_set_brain_alpha_no_values(monkeypatch):
     module = _import_brain_utils(monkeypatch)


### PR DESCRIPTION
## Summary
- stop saving brain screenshots during processing
- remove obsolete helper and test
- update docs to reflect no screenshot files

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e99652e6c832ca2b0d35ea93fe5ae