### PR TITLE
Add CPU core option in settings

### DIFF
--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -54,7 +54,8 @@ DEFAULTS = {
         'baseline_tmin': '-0.2',
         'baseline_tmax': '0.0',
         'time_window_start_ms': '10',
-        'time_window_end_ms': '100'
+        'time_window_end_ms': '100',
+        'n_jobs': '1'
     },
     'debug': {
         'enabled': 'False'
@@ -101,6 +102,7 @@ class SettingsManager:
                 'baseline_tmax',
                 'time_window_start_ms',
                 'time_window_end_ms',
+                'n_jobs',
             ):
                 if not existing.has_option('loreta', opt):
                     missing_loreta = True

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -129,6 +129,16 @@ class SettingsWindow(ctk.CTkToplevel):
         ctk.CTkLabel(gen_tab, text="Debug Mode").grid(row=11, column=0, sticky="w", padx=pad, pady=(pad, 0))
         ctk.CTkCheckBox(gen_tab, text="Enable", variable=self.debug_var).grid(row=11, column=1, sticky="w", padx=pad, pady=(pad, 0))
 
+        ctk.CTkLabel(
+            gen_tab,
+            text="Number of CPU cores to use for processing",
+        ).grid(row=12, column=0, sticky="w", padx=pad, pady=(pad, 0))
+        jobs_var = tk.StringVar(value=self.manager.get("loreta", "n_jobs", "1"))
+        ctk.CTkEntry(gen_tab, textvariable=jobs_var).grid(
+            row=12, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0)
+        )
+        self.jobs_var = jobs_var
+
         # --- Stats Tab ---
         ctk.CTkLabel(stats_tab, text="FPVS Base Frequency (Hz)").grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, 0))
         base_var = tk.StringVar(value=self.manager.get('analysis', 'base_freq', '6.0'))
@@ -253,6 +263,7 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('loreta', 'loreta_threshold', self.thr_var.get())
         self.manager.set('loreta', 'time_window_start_ms', self.t_start_var.get())
         self.manager.set('loreta', 'time_window_end_ms', self.t_end_var.get())
+        self.manager.set('loreta', 'n_jobs', self.jobs_var.get())
         self.manager.set(
             'loreta',
             'auto_oddball_localization',

--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -92,6 +92,7 @@ def _estimate_epochs_covariance(
     epochs: mne.Epochs,
     log_func: Callable[[str], None] = logger.info,
     baseline: Optional[Tuple[float | None, float | None]] = None,
+    n_jobs: int = 1,
 ) -> mne.Covariance:
     """Return a noise covariance estimated from ``epochs``.
 
@@ -99,14 +100,17 @@ def _estimate_epochs_covariance(
     When ``baseline`` is provided the same time window is passed to
     :func:`mne.compute_covariance` via ``tmin``/``tmax``. Otherwise ``tmax=0.0``
     is used. If only a single epoch is present an ad-hoc covariance is returned
-    and a message logged via ``log_func``.
+    and a message logged via ``log_func``. ``n_jobs`` controls how many CPU
+    cores are used during covariance estimation.
     """
 
     if len(epochs) > 1:
         if baseline is not None:
             tmin, tmax = baseline
-            return mne.compute_covariance(epochs, tmin=tmin, tmax=tmax)
-        return mne.compute_covariance(epochs, tmax=0.0)
+            return mne.compute_covariance(
+                epochs, tmin=tmin, tmax=tmax, n_jobs=n_jobs
+            )
+        return mne.compute_covariance(epochs, tmax=0.0, n_jobs=n_jobs)
 
     log_func("Only one epoch available. Using ad-hoc covariance.")
     return mne.make_ad_hoc_cov(epochs.info)

--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -107,6 +107,7 @@ def run_source_localization(
     progress_cb: Optional[Callable[[float], None]] = None,
     export_rois: bool = False,
     show_brain: bool = True,
+    n_jobs: Optional[int] = None,
 
 ) -> Tuple[str, Optional[mne.viz.Brain]]:
     """Run source localization on ``fif_path`` and save results to ``output_dir``.
@@ -118,6 +119,9 @@ def run_source_localization(
         evoked response to analyze **in milliseconds**. When provided, the
         evoked data will be cropped to this window after filtering, baselining
         and harmonic reconstruction but before computing the inverse solution.
+    n_jobs
+        Number of CPU cores to use for processing. If ``None`` (default) the
+        value is read from the ``loreta`` section of ``settings.ini``.
     """
     if log_func is None:
         log_func = logger.info
@@ -155,6 +159,11 @@ def run_source_localization(
     else:
         log_func(f"Loading data from {fif_path}")
     settings = SettingsManager()
+    if n_jobs is None:
+        try:
+            n_jobs = int(settings.get("loreta", "n_jobs", "1"))
+        except ValueError:
+            n_jobs = 1
     if threshold is None:
         try:
             threshold = float(settings.get("loreta", "loreta_threshold", "0.0"))
@@ -216,12 +225,16 @@ def run_source_localization(
     if epochs is not None:
         if oddball:
             if low_freq or high_freq:
-                epochs = epochs.copy().filter(l_freq=low_freq, h_freq=high_freq)
+                epochs = epochs.copy().filter(
+                    l_freq=low_freq, h_freq=high_freq, n_jobs=n_jobs
+                )
             if baseline is not None:
                 epochs.apply_baseline(baseline)
 
             # compute covariance before cropping away the baseline interval
-            noise_cov = _estimate_epochs_covariance(epochs, log_func, baseline)
+            noise_cov = _estimate_epochs_covariance(
+                epochs, log_func, baseline, n_jobs=n_jobs
+            )
 
             cycle_epochs = source_localization.extract_cycles(epochs, oddball_freq)
             log_func(
@@ -245,10 +258,14 @@ def run_source_localization(
                 evoked = evoked.copy().crop(tmin=tmin, tmax=tmax)
             evoked = combine_evoked([evoked], weights="equal")
         else:
-            noise_cov = _estimate_epochs_covariance(epochs, log_func, baseline)
+            noise_cov = _estimate_epochs_covariance(
+                epochs, log_func, baseline, n_jobs=n_jobs
+            )
             evoked = epochs.average()
             if low_freq or high_freq:
-                evoked = evoked.copy().filter(l_freq=low_freq, h_freq=high_freq)
+                evoked = evoked.copy().filter(
+                    l_freq=low_freq, h_freq=high_freq, n_jobs=n_jobs
+                )
             if time_window is not None:
                 tmin, tmax = time_window
                 evoked = evoked.copy().crop(tmin=tmin, tmax=tmax)
@@ -257,11 +274,15 @@ def run_source_localization(
         epochs = mne.read_epochs(fif_path, preload=True)
         log_func(f"Loaded {len(epochs)} epoch(s)")
         if low_freq or high_freq:
-            epochs = epochs.copy().filter(l_freq=low_freq, h_freq=high_freq)
+            epochs = epochs.copy().filter(
+                l_freq=low_freq, h_freq=high_freq, n_jobs=n_jobs
+            )
         if baseline is not None:
             epochs.apply_baseline(baseline)
         # estimate covariance before segmenting into cycles
-        noise_cov = _estimate_epochs_covariance(epochs, log_func, baseline)
+        noise_cov = _estimate_epochs_covariance(
+            epochs, log_func, baseline, n_jobs=n_jobs
+        )
 
         cycle_epochs = source_localization.extract_cycles(epochs, oddball_freq)
         log_func(
@@ -288,7 +309,9 @@ def run_source_localization(
             raise ValueError("fif_path must be provided if epochs is None")
         evoked = _load_data(fif_path)
         if low_freq or high_freq:
-            evoked = evoked.copy().filter(l_freq=low_freq, h_freq=high_freq)
+            evoked = evoked.copy().filter(
+                l_freq=low_freq, h_freq=high_freq, n_jobs=n_jobs
+            )
         if time_window is not None:
             tmin, tmax = time_window
             evoked = evoked.copy().crop(tmin=tmin, tmax=tmax)
@@ -299,7 +322,9 @@ def run_source_localization(
                 tmin=evoked.times[0],
                 verbose=False,
             )
-            noise_cov = mne.compute_covariance(temp_epochs, tmax=0.0)
+            noise_cov = mne.compute_covariance(
+                temp_epochs, tmax=0.0, n_jobs=n_jobs
+            )
         except Exception as err:
             log_func(
                 f"Noise covariance estimation failed ({err}). Using ad-hoc covariance."
@@ -339,7 +364,9 @@ def run_source_localization(
 
         log_func(f"Applying {method_lower} ...")
         mne_method = "eLORETA" if method_lower == "eloreta" else "sLORETA"
-        stc = mne.minimum_norm.apply_inverse(evoked, inv, method=mne_method)
+        stc = mne.minimum_norm.apply_inverse(
+            evoked, inv, method=mne_method, n_jobs=n_jobs
+        )
     if threshold:
         stc = _threshold_stc(stc, threshold)
     step += 1

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -26,13 +26,14 @@ bca_upper_limit = 16.8
 
 [loreta]
 mri_path =
-loreta_low_freq = 0.1
-loreta_high_freq = 40.0
+loreta_low_freq = 1.1
+loreta_high_freq = 1.3
 oddball_harmonics = 1.2,2.4,3.6,4.8,7.2,8.4,9.6,10.8
 loreta_snr = 3.0
 auto_oddball_localization = False
 baseline_tmin = -0.2
 baseline_tmax = 0.0
+n_jobs = 1
 
 [debug]
 enabled = False


### PR DESCRIPTION
## Summary
- update `settings.ini` default oddball filter band to 1.1–1.3 Hz
- show CPU core count setting in General tab
- save the value back to settings

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea6d2e69c832cb3fc61f6e895f6c0