### PR TITLE
Update default CPU core count

### DIFF
--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -55,7 +55,7 @@ DEFAULTS = {
         'baseline_tmax': '0.0',
         'time_window_start_ms': '10',
         'time_window_end_ms': '100',
-        'n_jobs': '1'
+        'n_jobs': '2'
     },
     'debug': {
         'enabled': 'False'

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -133,7 +133,7 @@ class SettingsWindow(ctk.CTkToplevel):
             gen_tab,
             text="Number of CPU cores to use for processing",
         ).grid(row=12, column=0, sticky="w", padx=pad, pady=(pad, 0))
-        jobs_var = tk.StringVar(value=self.manager.get("loreta", "n_jobs", "1"))
+        jobs_var = tk.StringVar(value=self.manager.get("loreta", "n_jobs", "2"))
         ctk.CTkEntry(gen_tab, textvariable=jobs_var).grid(
             row=12, column=1, columnspan=2, sticky="ew", padx=pad, pady=(pad, 0)
         )

--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -92,7 +92,7 @@ def _estimate_epochs_covariance(
     epochs: mne.Epochs,
     log_func: Callable[[str], None] = logger.info,
     baseline: Optional[Tuple[float | None, float | None]] = None,
-    n_jobs: int = 1,
+    n_jobs: int = 2,
 ) -> mne.Covariance:
     """Return a noise covariance estimated from ``epochs``.
 

--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -161,9 +161,9 @@ def run_source_localization(
     settings = SettingsManager()
     if n_jobs is None:
         try:
-            n_jobs = int(settings.get("loreta", "n_jobs", "1"))
+            n_jobs = int(settings.get("loreta", "n_jobs", "2"))
         except ValueError:
-            n_jobs = 1
+            n_jobs = 2
     if threshold is None:
         try:
             threshold = float(settings.get("loreta", "loreta_threshold", "0.0"))

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -33,7 +33,7 @@ loreta_snr = 3.0
 auto_oddball_localization = False
 baseline_tmin = -0.2
 baseline_tmax = 0.0
-n_jobs = 1
+n_jobs = 2
 
 [debug]
 enabled = False


### PR DESCRIPTION
## Summary
- default to using two CPU cores
- maintain user setting for CPU cores

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eabada9dc832c8effe1ae5d6e509c