### PR TITLE
Fix time index entry and update alpha setter

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -83,6 +83,13 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
             master=self, value=settings.get('loreta', 'time_window_end_ms', '')
         )
 
+        try:
+            ti_ms = float(settings.get('visualization', 'time_index_ms', '50'))
+        except ValueError:
+            ti_ms = 50.0
+        self.time_index_var = tk.DoubleVar(master=self, value=ti_ms)
+        self.time_index_str = tk.StringVar(master=self, value=str(ti_ms))
+
         self.avg_mode_var = tk.StringVar(master=self, value="Raw amplitudes")
 
 


### PR DESCRIPTION
## Summary
- add missing time index variables in SourceLocalization GUI
- make `_set_brain_alpha` support additional fallback attributes

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68606e09a398832c868a8311fc67f486