### PR TITLE
Add PyQt-based STC viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ displayed with a red heatmap so you can easily spot the peak response. The
 color bar at the bottom of the viewer shows the magnitude of the estimated
 current density and is labeled **Source amplitude** for clarity.
 
+Saved source estimates can also be opened directly from the command line using
+`pyqt_viewer.py`:
+
+```bash
+python src/Tools/SourceLocalization/pyqt_viewer.py --stc path/to/source
+```
+
+The viewer provides sliders for adjusting cortex opacity and selecting the time
+point displayed.
+
 The underlying module exposes an `is_pyvistaqt_backend()` helper which
 returns ``True`` when the viewer will use the interactive PyVistaQt
 backend. This can be queried before opening any 3‑D windows to ensure

--- a/src/Tools/SourceLocalization/__init__.py
+++ b/src/Tools/SourceLocalization/__init__.py
@@ -11,6 +11,7 @@ from .stc_utils import (
     morph_to_fsaverage,
 )
 from .visualization import view_source_estimate
+from .pyqt_viewer import STCViewer
 
 __all__ = [
     "SourceLocalizationWindow",
@@ -22,4 +23,5 @@ __all__ = [
     "average_conditions_to_fsaverage",
     "run_localization_worker",
     "morph_to_fsaverage",
+    "STCViewer",
 ]

--- a/src/Tools/SourceLocalization/brain_utils.py
+++ b/src/Tools/SourceLocalization/brain_utils.py
@@ -9,16 +9,6 @@ import mne
 logger = logging.getLogger(__name__)
 
 
-def _set_brain_title(brain: mne.viz.Brain, title: str) -> None:
-    """Safely set the window title of a Brain viewer."""
-    try:
-        plotter = brain._renderer.plotter
-        if hasattr(plotter, "app_window"):
-            plotter.app_window.setWindowTitle(title)
-    except Exception:
-        logger.debug("Could not set brain title.", exc_info=True)
-
-
 def _set_brain_alpha(brain: mne.viz.Brain, alpha: float) -> None:
     """Set the transparency of the brain surface meshes after plotting."""
     logger.debug("Attempting to set brain surface alpha to %s post-plot.", alpha)
@@ -117,19 +107,3 @@ def _plot_with_alpha(
 
     return brain
 
-
-def _set_colorbar_label(brain: mne.viz.Brain, label: str) -> None:
-    """Set the colorbar title in a robust way."""
-    try:
-        renderer = getattr(brain, "_renderer", None)
-        cbar = None
-        if renderer is not None:
-            plotter = getattr(renderer, "plotter", None)
-            cbar = getattr(plotter, "scalar_bar", None)
-        if cbar is not None:
-            if hasattr(cbar, "SetTitle"):
-                cbar.SetTitle(label)
-            elif hasattr(cbar, "title"):
-                cbar.title = label
-    except Exception:
-        logger.debug("Failed to set colorbar label", exc_info=True)

--- a/src/Tools/SourceLocalization/pyqt_viewer.py
+++ b/src/Tools/SourceLocalization/pyqt_viewer.py
@@ -1,0 +1,121 @@
+import os
+import sys
+import argparse
+from pathlib import Path
+
+# ruff: noqa: E402
+
+import numpy as np
+import pyvista as pv
+from pyvistaqt import QtInteractor
+from PyQt5 import QtWidgets, QtCore
+import mne
+
+SRC_PATH = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(SRC_PATH))
+
+from Tools.SourceLocalization.data_utils import _resolve_subjects_dir
+from Main_App.settings_manager import SettingsManager
+
+
+class STCViewer(QtWidgets.QMainWindow):
+    """Qt window for interactively viewing SourceEstimate files."""
+
+    def __init__(self, stc_path: str):
+        super().__init__()
+        self.setWindowTitle(os.path.basename(stc_path))
+        self.stc = mne.read_source_estimate(stc_path)
+        self._setup_subjects()
+        self._build_ui()
+        self._load_surfaces()
+        self._update_time(0)
+
+    def _setup_subjects(self) -> None:
+        settings = SettingsManager()
+        mri_dir = settings.get("loreta", "mri_path", fallback="")
+        stored = Path(mri_dir).resolve() if mri_dir else None
+        subjects_dir = _resolve_subjects_dir(stored, self.stc.subject or "fsaverage")
+        if not Path(subjects_dir).exists():
+            subjects_dir = Path(mne.datasets.fetch_fsaverage(verbose=False)).parent
+        self.subjects_dir = Path(subjects_dir)
+
+    def _build_ui(self) -> None:
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.plotter = QtInteractor(central)
+        layout.addWidget(self.plotter)
+
+        ctrl = QtWidgets.QWidget()
+        ctrl_layout = QtWidgets.QHBoxLayout(ctrl)
+        ctrl_layout.setContentsMargins(5, 5, 5, 5)
+
+        self.opacity_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.opacity_slider.setRange(0, 100)
+        self.opacity_slider.setValue(50)
+        self.opacity_slider.valueChanged.connect(self._update_opacity)
+
+        self.time_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.time_slider.setRange(0, self.stc.data.shape[1] - 1)
+        self.time_slider.valueChanged.connect(self._update_time)
+
+        ctrl_layout.addWidget(QtWidgets.QLabel("Opacity"))
+        ctrl_layout.addWidget(self.opacity_slider)
+        ctrl_layout.addSpacing(20)
+        ctrl_layout.addWidget(QtWidgets.QLabel("Time"))
+        ctrl_layout.addWidget(self.time_slider)
+
+        layout.addWidget(ctrl)
+        self.setCentralWidget(central)
+
+    def _load_surfaces(self) -> None:
+        subject = self.stc.subject or "fsaverage"
+        surf_dir = self.subjects_dir / subject / "surf"
+        lh = pv.read(surf_dir / "lh.pial")
+        rh = pv.read(surf_dir / "rh.pial")
+        self.cortex_lh = self.plotter.add_mesh(lh, color="lightgray", opacity=0.5, name="lh")
+        self.cortex_rh = self.plotter.add_mesh(rh, color="lightgray", opacity=0.5, name="rh")
+        self.heat_lh = lh.copy()
+        self.heat_rh = rh.copy()
+        self.heat_lh.point_data["activation"] = np.zeros(lh.n_points)
+        self.heat_rh.point_data["activation"] = np.zeros(rh.n_points)
+        self.act_lh = self.plotter.add_mesh(
+            self.heat_lh, scalars="activation", cmap="hot", nan_opacity=0.0, name="act_lh"
+        )
+        self.act_rh = self.plotter.add_mesh(
+            self.heat_rh, scalars="activation", cmap="hot", nan_opacity=0.0, name="act_rh"
+        )
+        self.plotter.add_scalar_bar(title="Source Amplitude", n_colors=8)
+
+    def _update_opacity(self, value: int) -> None:
+        alpha = max(0, min(100, int(value))) / 100
+        for actor in (self.cortex_lh, self.cortex_rh):
+            actor.GetProperty().SetOpacity(alpha)
+        self.plotter.render()
+
+    def _update_time(self, value: int) -> None:
+        idx = max(0, min(int(value), self.stc.data.shape[1] - 1))
+        data = self.stc.data[:, idx]
+        n_lh = len(self.stc.vertices[0])
+        arr_lh = np.full(self.heat_lh.n_points, np.nan)
+        arr_rh = np.full(self.heat_rh.n_points, np.nan)
+        arr_lh[self.stc.vertices[0]] = data[:n_lh]
+        arr_rh[self.stc.vertices[1]] = data[n_lh:]
+        self.plotter.update_scalars(arr_lh, mesh=self.heat_lh, render=False)
+        self.plotter.update_scalars(arr_rh, mesh=self.heat_rh, render=False)
+        self.plotter.render()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="View a source estimate file")
+    parser.add_argument("--stc", required=True, help="Base STC file path")
+    args = parser.parse_args(argv)
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv)
+    viewer = STCViewer(args.stc)
+    viewer.show()
+    app.exec_()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual UI
+    main()


### PR DESCRIPTION
## Summary
- implement `pyqt_viewer.py` for viewing STC files with PyVistaQt
- spawn new viewer from `eloreta_gui.py` instead of using `view_source_estimate`
- trim unused helpers and update imports
- expose `STCViewer` in package
- document viewer usage
- fix import path when running viewer as a script

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862b316ee18832cac396c4a62bbb721