### PR TITLE
Fix PyVista warning by updating mesh scalar updates

### DIFF
--- a/src/Tools/SourceLocalization/pyqt_viewer.py
+++ b/src/Tools/SourceLocalization/pyqt_viewer.py
@@ -119,8 +119,10 @@ class STCViewer(QtWidgets.QMainWindow):
         arr_rh = np.full(self.heat_rh.n_points, np.nan)
         arr_lh[self.stc.vertices[0]] = data[:n_lh]
         arr_rh[self.stc.vertices[1]] = data[n_lh:]
-        self.plotter.update_scalars(arr_lh, mesh=self.heat_lh, render=False)
-        self.plotter.update_scalars(arr_rh, mesh=self.heat_rh, render=False)
+
+        # Modern PyVista approach: modify mesh scalars in-place
+        self.heat_lh.point_data["activation"] = arr_lh
+        self.heat_rh.point_data["activation"] = arr_rh
         self.plotter.render()
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `update_scalars` in `STCViewer` with direct point data assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e143b74c832c8a2e0e757b438aa8