### PR TITLE
Add adjustable LORETA timing

### DIFF
--- a/src/Main_App/settings_manager.py
+++ b/src/Main_App/settings_manager.py
@@ -53,14 +53,14 @@ DEFAULTS = {
         'auto_oddball_localization': 'False',
         'baseline_tmin': '-0.2',
         'baseline_tmax': '0.0',
-        'time_window_start_ms': '10',
-        'time_window_end_ms': '100',
+        'time_window_start_ms': '-1000',
+        'time_window_end_ms': '1000',
         'n_jobs': '2'
     },
     'visualization': {
         'threshold': '0.0',
         'surface_opacity': '0.5',
-        'time_index_ms': '50'
+        'time_index_ms': '100'
     },
     'debug': {
         'enabled': 'False'

--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -215,6 +215,11 @@ class SettingsWindow(ctk.CTkToplevel):
         self.t_start_var = t_start_var
         self.t_end_var = t_end_var
 
+        ctk.CTkLabel(loreta_tab, text="Display Time (ms)").grid(row=7, column=0, sticky="w", padx=pad)
+        disp_var = tk.StringVar(value=self.manager.get('visualization', 'time_index_ms', '100'))
+        ctk.CTkEntry(loreta_tab, textvariable=disp_var, width=80).grid(row=7, column=1, sticky="w", padx=pad)
+        self.disp_var = disp_var
+
         auto_loc_default = self.manager.get('loreta', 'auto_oddball_localization', 'False').lower() == 'true'
         self.auto_loc_var = tk.BooleanVar(value=auto_loc_default)
         ctk.CTkCheckBox(
@@ -264,6 +269,7 @@ class SettingsWindow(ctk.CTkToplevel):
         self.manager.set('loreta', 'time_window_start_ms', self.t_start_var.get())
         self.manager.set('loreta', 'time_window_end_ms', self.t_end_var.get())
         self.manager.set('loreta', 'n_jobs', self.jobs_var.get())
+        self.manager.set('visualization', 'time_index_ms', self.disp_var.get())
         self.manager.set(
             'loreta',
             'auto_oddball_localization',

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -256,6 +256,11 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
             try:
                 script = Path(__file__).with_name("pyqt_viewer.py")
                 args = [sys.executable, str(script), "--stc", path]
+                try:
+                    time_ms = float(self.time_index_var.get())
+                    args.extend(["--time-ms", str(time_ms)])
+                except Exception:
+                    pass
                 subprocess.Popen(args)
             except Exception as err:
                 log_func(f"STC viewer failed: {err}")


### PR DESCRIPTION
## Summary
- update default LORETA crop window and display time
- expose display time in the settings window
- allow STC viewer to open at a selected time
- pass the selected time from the LORETA GUI when launching the viewer

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e4c62b98832c99ce0a3a65c28ea1