### PR TITLE
Fix color fallback in advanced themed listbox

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -76,11 +76,12 @@ def create_themed_listbox(parent: ctk.CTkBaseClass, **kwargs) -> tk.Listbox:
                 property_key,
                 appearance,
             )
-            default_bg = "white" if appearance == "Light" else "#2B2B2B"
-            default_fg = "black" if appearance == "Light" else "white"
+
+        default_bg = "white" if appearance == "Light" else "#2B2B2B"
+        default_fg = "black" if appearance == "Light" else "white"
         if "background" in property_key or "fg_color" in property_key:
             return default_bg
-            return default_fg
+        return default_fg
 
     return tk.Listbox(
         parent,


### PR DESCRIPTION
## Summary
- ensure the fallback color logic in `create_themed_listbox` works correctly
- always return a string when theme colors aren't found

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68653d80f654832cb908d6bd7877c24e