### PR TITLE
Fix resizer reopen error and use light theme

### DIFF
--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -267,10 +267,16 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         def run():
             from PySide6.QtWidgets import QApplication
 
-            app = QApplication([])
+            app = QApplication.instance()
+            created = False
+            if app is None:
+                app = QApplication([])
+                created = True
             win = FPVSImageResizer()
             win.show()
             app.exec()
+            if created:
+                app.deleteLater()
 
         import threading
 


### PR DESCRIPTION
## Summary
- ensure QApplication is reused to avoid errors when reopening resizer
- simplify Image Resizer theme logic to always use light mode

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686574647ab8832c908919872b443613