### PR TITLE
Fix dark background in PySide image resizer

### DIFF
--- a/src/Tools/Image_Resizer/pyside_resizer.py
+++ b/src/Tools/Image_Resizer/pyside_resizer.py
@@ -13,6 +13,7 @@ import sys
 from typing import List, Tuple
 
 from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -91,7 +92,25 @@ class FPVSImageResizerQt(QWidget):
         self._thread: QThread | None = None
         self._worker: _Worker | None = None
 
+        self._apply_light_theme()
         self._build_ui()
+
+    def _apply_light_theme(self) -> None:
+        app = QApplication.instance()
+        if not app:
+            return
+        app.setStyle("Fusion")
+        palette = app.palette()
+        palette.setColor(QPalette.Window, QColor("white"))
+        palette.setColor(QPalette.Base, QColor("white"))
+        palette.setColor(QPalette.AlternateBase, QColor(245, 245, 245))
+        palette.setColor(QPalette.Text, QColor("black"))
+        palette.setColor(QPalette.WindowText, QColor("black"))
+        palette.setColor(QPalette.Button, QColor(240, 240, 240))
+        palette.setColor(QPalette.ButtonText, QColor("black"))
+        palette.setColor(QPalette.Highlight, QColor(76, 163, 224))
+        palette.setColor(QPalette.HighlightedText, QColor("white"))
+        app.setPalette(palette)
 
     def _build_ui(self) -> None:
         layout = QGridLayout(self)


### PR DESCRIPTION
## Summary
- apply a light theme in the PySide image resizer GUI

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686579a1774c832cb7338503922f4408