### PR TITLE
Fix image resizer standalone launch

### DIFF
--- a/src/Tools/Image_Resizer/pyside_resizer.py
+++ b/src/Tools/Image_Resizer/pyside_resizer.py
@@ -29,7 +29,10 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from .image_resize_core import process_images_in_folder
+try:  # pragma: no cover - fallback for running as a script
+    from .image_resize_core import process_images_in_folder  # type: ignore
+except ImportError:
+    from image_resize_core import process_images_in_folder  # type: ignore
 
 
 class _Worker(QObject):


### PR DESCRIPTION
## Summary
- fix relative import when running the Qt image resizer as a script

## Testing
- `ruff check src/Tools/Image_Resizer/pyside_resizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658e51478c832c852218c4ba2c6e0d