### PR TITLE
Improve debug logging for STC processing

### DIFF
--- a/src/Tools/SourceLocalization/data_utils.py
+++ b/src/Tools/SourceLocalization/data_utils.py
@@ -85,6 +85,14 @@ def _threshold_stc(stc: mne.SourceEstimate, thr: float) -> mne.SourceEstimate:
     else:
         thr_val = thr
     stc.data[np.abs(stc.data) < thr_val] = 0
+    if SettingsManager().debug_enabled():
+        active = int(np.count_nonzero(np.any(stc.data != 0, axis=1)))
+        logger.debug(
+            "threshold_stc: thr=%s cutoff=%.5f active_vertices=%s",
+            thr,
+            thr_val,
+            active,
+        )
     return stc
 
 
@@ -211,6 +219,13 @@ def _prepare_forward(
 
     surf_dir = subjects_dir_path / subject / "surf"
     log_func(f"Expecting surface files in: {surf_dir}")
+    for fname in ["lh.pial", "rh.pial", "lh.white", "rh.white"]:
+        path = surf_dir / fname
+        log_func(f"Surface file {path} {'found' if path.exists() else 'MISSING'}")
+    bem_file = subjects_dir_path / subject / "bem" / f"{subject}-5120-bem.fif"
+    log_func(
+        f"BEM file {bem_file} {'found' if bem_file.exists() else 'MISSING'}"
+    )
 
     trans = settings.get("paths", "trans_file", "fsaverage")
     log_func(f"Using trans file: {trans}")

--- a/src/Tools/SourceLocalization/pyqt_viewer.py
+++ b/src/Tools/SourceLocalization/pyqt_viewer.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import argparse
+import logging
 from pathlib import Path
 
 
@@ -18,6 +19,8 @@ SRC_PATH = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(SRC_PATH))
 
 from Tools.SourceLocalization.data_utils import _resolve_subjects_dir
+
+logger = logging.getLogger(__name__)
 
 from Main_App.settings_manager import SettingsManager
 
@@ -136,6 +139,13 @@ class STCViewer(QtWidgets.QMainWindow):
     def _update_time(self, value: int) -> None:
         idx = max(0, min(int(value), self.stc.data.shape[1] - 1))
         data = self.stc.data[:, idx]
+        if SettingsManager().debug_enabled():
+            logger.debug(
+                "update_time idx=%s range=(%.5f, %.5f)",
+                idx,
+                float(data.min()),
+                float(data.max()),
+            )
         n_lh = len(self.stc.vertices[0])
         arr_lh = np.full(self.heat_lh.n_points, np.nan)
         arr_rh = np.full(self.heat_rh.n_points, np.nan)

--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -362,6 +362,15 @@ def run_source_localization(
         stc = mne.minimum_norm.apply_inverse(
             evoked, inv, method=mne_method, n_jobs=n_jobs
         )
+    debug = SettingsManager().debug_enabled()
+    if debug:
+        logger.debug(
+            "STC computed: shape=%s min=%.5f max=%.5f nnz=%s",
+            stc.data.shape,
+            np.min(stc.data),
+            np.max(stc.data),
+            np.count_nonzero(stc.data),
+        )
     if threshold:
         if 0 < threshold < 1:
             thr_val = threshold * np.max(np.abs(stc.data))
@@ -372,6 +381,13 @@ def run_source_localization(
             "Applying threshold %s (cutoff %.5f)", threshold, thr_val
         )
         stc = _threshold_stc(stc, threshold)
+        if debug:
+            logger.debug(
+                "Post-threshold STC: min=%.5f max=%.5f nnz=%s",
+                np.min(stc.data),
+                np.max(stc.data),
+                np.count_nonzero(stc.data),
+            )
     else:
         logger.info("Skipping thresholding step")
 

--- a/src/Tools/SourceLocalization/visualization.py
+++ b/src/Tools/SourceLocalization/visualization.py
@@ -213,6 +213,13 @@ def view_source_estimate(
             logger.debug(
                 "Using time index %s of %s (time_ms=%s)", time_idx, stc.data.shape[1], time_ms
             )
+            vals = stc.data[:, time_idx]
+            logger.debug(
+                "Activation range at idx %s: min=%.5f max=%.5f",
+                time_idx,
+                float(vals.min()),
+                float(vals.max()),
+            )
 
 
         pl = view_source_estimate_pyvista(


### PR DESCRIPTION
## Summary
- add detailed debug output for STC stats in runner
- log thresholding details and surface file availability
- display activation range info in viewer modules

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865944d2148832c913ae333ab169e59