### PR TITLE
Initialize logging in STC viewer

### DIFF
--- a/src/Tools/SourceLocalization/runner.py
+++ b/src/Tools/SourceLocalization/runner.py
@@ -371,6 +371,13 @@ def run_source_localization(
             np.max(stc.data),
             np.count_nonzero(stc.data),
         )
+        logger.debug(
+            "STC time info: tmin=%.4f tmax=%.4f tstep=%.4f n_times=%s",
+            float(stc.tmin),
+            float(stc.times[-1]),
+            float(stc.tstep),
+            stc.data.shape[1],
+        )
     if threshold:
         if 0 < threshold < 1:
             thr_val = threshold * np.max(np.abs(stc.data))


### PR DESCRIPTION
## Summary
- configure logging in the standalone STC viewer
- clamp viewer slider to 0–500 ms range and step in 10 ms increments
- log STC timing info during generation for easier debugging

## Testing
- `ruff check src/Tools/SourceLocalization/pyqt_viewer.py src/Tools/SourceLocalization/runner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686596dd36c0832c80febf27c293e355