### PR TITLE
Fix LORETA multiprocessing queue

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -414,9 +414,10 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
         time_window,
     ):
         log_func = getattr(self.master, "log", print)
-        q = mp.Queue()
+        ctx = mp.get_context("spawn")
+        q = ctx.Queue()
 
-        with ProcessPoolExecutor(max_workers=1) as ex:
+        with ProcessPoolExecutor(max_workers=1, mp_context=ctx) as ex:
             future = ex.submit(
                 worker.run_localization_worker,
                 fif_path,


### PR DESCRIPTION
## Summary
- avoid passing `multiprocessing.Queue` between spawned processes
- create the queue from a spawn context and use it with the process pool

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659bb67158832c8d39ff7ea75d6761