### PR TITLE
Fix frequency rounding in config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,8 @@ def _compute_freqs(odd: float, upper: float) -> np.ndarray:
         odd = 1.2
     if upper < odd:
         upper = 16.8
-    return np.arange(odd, upper + odd, odd)
+    steps = int(round(upper / odd))
+    return np.array([odd * i for i in range(1, steps + 1)])
 
 
 def update_target_frequencies(odd: float = None, upper: float = None) -> np.ndarray:

--- a/tests/test_config_freqs.py
+++ b/tests/test_config_freqs.py
@@ -1,0 +1,15 @@
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("numpy") is None:
+    pytest.skip("numpy not available", allow_module_level=True)
+else:
+    import numpy as np
+
+from config import update_target_frequencies
+
+
+def test_update_target_frequencies_full_range():
+    freqs = update_target_frequencies(1.2, 16.8)
+    expected = np.array([1.2 * i for i in range(1, 15)])
+    assert np.allclose(freqs, expected)


### PR DESCRIPTION
## Summary
- compute frequencies exactly up to the upper limit
- add regression test for update_target_frequencies

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871356df220832cb60d61cdd5a4f886