### PR TITLE
Improve plot generator settings persistence

### DIFF
--- a/src/Tools/Plot_Generator/plot_settings.py
+++ b/src/Tools/Plot_Generator/plot_settings.py
@@ -1,0 +1,38 @@
+import configparser
+import os
+from pathlib import Path
+
+INI_NAME = 'plot_settings.ini'
+
+
+def _default_ini_path() -> Path:
+    if os.name == 'nt':
+        base = Path(os.environ.get('APPDATA', Path.home()))
+    else:
+        base = Path(os.environ.get('XDG_CONFIG_HOME', Path.home() / '.config'))
+    return base / 'FPVS_Toolbox' / INI_NAME
+
+
+class PlotSettingsManager:
+    """Simple INI manager for storing plot tool defaults."""
+
+    def __init__(self, ini_path: Path | None = None) -> None:
+        self.ini_path = ini_path or _default_ini_path()
+        self.config = configparser.ConfigParser()
+        self.load()
+
+    def load(self) -> None:
+        self.config.read(self.ini_path)
+
+    def save(self) -> None:
+        self.ini_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.ini_path, 'w') as f:
+            self.config.write(f)
+
+    def get(self, section: str, option: str, fallback: str = '') -> str:
+        return self.config.get(section, option, fallback=fallback)
+
+    def set(self, section: str, option: str, value: str) -> None:
+        if not self.config.has_section(section):
+            self.config.add_section(section)
+        self.config.set(section, option, value)


### PR DESCRIPTION
## Summary
- keep plot generator usable for repeated runs by cleaning up worker thread
- add separate INI storage for plot generator defaults
- allow saving and reusing default input/output folders

## Testing
- `ruff check src/Tools/Plot_Generator/plot_generator.py`
- `ruff check src/Tools/Plot_Generator/plot_settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713cf84a84832cb08865dedc685209