### PR TITLE
Switch plot generator to use bars

### DIFF
--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -158,7 +158,22 @@ class _Worker(QObject):
 
         for roi, amps in roi_data.items():
             fig, ax = plt.subplots(figsize=(8, 3), dpi=300)
-            ax.plot(freqs, amps, linewidth=1.0, color="black")
+
+            freq_amp = dict(zip(freqs, amps))
+            bar_x = []
+            bar_y = []
+            for odd in self.oddballs:
+                amp = freq_amp.get(odd)
+                if amp is None:
+                    continue
+                bar_x.append(odd)
+                bar_y.append(amp)
+
+            if not bar_x:
+                self._emit(f"Oddball frequencies not found for ROI {roi}")
+                continue
+
+            ax.bar(bar_x, bar_y, width=0.05, color="black", align="center")
             ax.set_xticks(self.oddballs)
             ax.set_xticklabels([f"{odd:.1f} Hz" for odd in self.oddballs])
             ax.set_xlim(self.x_min, self.x_max)


### PR DESCRIPTION
## Summary
- render bars at oddball frequencies instead of plotting a continuous line

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68713dfef4c4832ca4615aecc216a55c