### PR TITLE
Switch plot generator to use bars

### DIFF
--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+# Allow running this module directly by ensuring the package root is on sys.path
+if __package__ is None:  # pragma: no cover - executed when run as script
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 import os
 from pathlib import Path
 from typing import Dict, List, Iterable
@@ -158,7 +165,22 @@ class _Worker(QObject):
 
         for roi, amps in roi_data.items():
             fig, ax = plt.subplots(figsize=(8, 3), dpi=300)
-            ax.plot(freqs, amps, linewidth=1.0, color="black")
+
+            freq_amp = dict(zip(freqs, amps))
+            bar_x = []
+            bar_y = []
+            for odd in self.oddballs:
+                amp = freq_amp.get(odd)
+                if amp is None:
+                    continue
+                bar_x.append(odd)
+                bar_y.append(amp)
+
+            if not bar_x:
+                self._emit(f"Oddball frequencies not found for ROI {roi}")
+                continue
+
+            ax.bar(bar_x, bar_y, width=0.05, color="black", align="center")
             ax.set_xticks(self.oddballs)
             ax.set_xticklabels([f"{odd:.1f} Hz" for odd in self.oddballs])
             ax.set_xlim(self.x_min, self.x_max)


### PR DESCRIPTION
## Summary
- render bars at oddball frequencies instead of plotting a continuous line
- allow plot generator script to run directly by updating `sys.path`

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68713dfef4c4832ca4615aecc216a55c