### PR TITLE
Fix import error in plot generator

### DIFF
--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -35,7 +35,7 @@ from Tools.Stats.stats_helpers import load_rois_from_settings
 from Tools.Stats.stats_analysis import ALL_ROIS_OPTION
 
 from Main_App.settings_manager import SettingsManager
-from .plot_settings import PlotSettingsManager
+from Tools.Plot_Generator.plot_settings import PlotSettingsManager
 from config import update_target_frequencies
 
 


### PR DESCRIPTION
## Summary
- fix `ImportError` when running plot generator directly

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715facdcd8832cb08d3dbe1978e60d