### PR TITLE
Fix debug spam

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis.py
@@ -1087,8 +1087,8 @@ class AdvancedAnalysisWindow(ctk.CTkToplevel):
 
     def _check_processing_thread(self):
         if self.processing_thread and self.processing_thread.is_alive():
-            if self.debug_mode:
-                logger.debug("Processing thread still running")
+            # The processing thread can run for a long time, so avoid spamming
+            # the debug log on every check.
             self.after(100, self._check_processing_thread)
         else:
             if not self._stop_requested.is_set() and \


### PR DESCRIPTION
## Summary
- trim repeated log spam when advanced analysis thread is running

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68717617c4a8832cbaf3f23c2427c5c1