### PR TITLE
Switch 3-D viewer to PySide6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ openpyxl
 XlsxWriter
 requests
 packaging
-PyQt5
 PySide6

--- a/src/Tools/SourceLocalization/backend_utils.py
+++ b/src/Tools/SourceLocalization/backend_utils.py
@@ -20,7 +20,7 @@ def _log_backend_imports() -> None:
     if not SettingsManager().debug_enabled():
         return
 
-    for mod_name in ("pyvistaqt", "pyvista", "PyQt5", "PySide6"):
+    for mod_name in ("pyvistaqt", "pyvista", "PySide6"):
         try:
             module = importlib.import_module(mod_name)
             version = getattr(module, "__version__", "unknown")


### PR DESCRIPTION
## Summary
- convert the STC viewer from PyQt5 to PySide6
- log backend details and widget creation for easier debugging
- remove the unused PyQt5 dependency

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750ca1e0c8832c98188f173197e9b7