### PR TITLE
Improve ImportError logging in stats modules

### DIFF
--- a/src/Tools/Stats/mixed_effects_model.py
+++ b/src/Tools/Stats/mixed_effects_model.py
@@ -48,11 +48,14 @@ def run_mixed_effects_model(data: pd.DataFrame, dv_col: str, group_col: str, fix
     )
 
     try:
+        # statsmodels provides the MixedLM function required for this analysis
         import statsmodels.formula.api as smf
-    except ImportError:
+    except ImportError as e:
+        # Log the actual exception so users can see why the import failed
+        logger.error("Failed to import statsmodels: %s", e)
         raise ImportError(
             "statsmodels is required for mixed effects modeling. Please install it via `pip install statsmodels`."
-        )
+        ) from e
 
     parsed_vars = sorted({var for term in fixed_effects for var in _extract_variables(term)})
     required_cols = [dv_col, group_col] + parsed_vars

--- a/src/Tools/Stats/stats_runners.py
+++ b/src/Tools/Stats/stats_runners.py
@@ -282,10 +282,11 @@ def run_mixed_model(self):
         else:
             output_text += "Mixed effects model did not return any results or the result was empty.\n"
             self.log_to_main_app("Mixed effects model returned no results or empty table.")
-    except ImportError:
+    except ImportError as e:
         output_text += "Error: The `statsmodels` package is required for mixed effects modeling.\n"
         output_text += "Please install it via `pip install statsmodels`.\n"
-        self.log_to_main_app("ImportError during mixed model execution.")
+        output_text += f"Original error: {e}\n"
+        self.log_to_main_app(f"ImportError during mixed model execution: {e}")
     except Exception as e:
         output_text += f"Mixed effects model failed unexpectedly: {e}\n"
         self.log_to_main_app(f"!!! Mixed Model Error: {e}\n{traceback.format_exc()}")


### PR DESCRIPTION
## Summary
- improve error handling when statsmodels is missing in mixed-effects model helper
- expose original ImportError message in stats runner for better logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752830a2a0832cb17dac639d3d063f