### PR TITLE
Fix FullSNR ROI averaging

### DIFF
--- a/src/Main_App/post_process.py
+++ b/src/Main_App/post_process.py
@@ -240,7 +240,7 @@ def post_process(app: Any, condition_labels_present: List[str]) -> None:
 
         if valid_data_count > 0 and final_electrode_names_ordered:
             avg_metrics = {k: v / valid_data_count for k, v in accum.items()}
-            freq_column_names = [f"{f:.1f}_Hz" for f in TARGET_FREQUENCIES]
+            freq_column_names = [f"{f:.4f}_Hz" for f in TARGET_FREQUENCIES]
             full_snr_avg = full_snr_accum / valid_data_count if full_snr_accum is not None else None
             dataframes_to_save = {
                 'FFT Amplitude (uV)': pd.DataFrame(
@@ -257,9 +257,16 @@ def post_process(app: Any, condition_labels_present: List[str]) -> None:
                 ),
             }
             if full_snr_avg is not None:
-                freq_cols_full = [f"{f:.1f}_Hz" for f in fft_frequencies]
+                try:
+                    upper_limit = float(app.settings.get('analysis', 'bca_upper_limit', '16.8'))
+                except Exception:
+                    upper_limit = 16.8
+                mask = fft_frequencies <= upper_limit
+                freq_cols_full = [f"{f:.4f}_Hz" for f in fft_frequencies[mask]]
                 dataframes_to_save['FullSNR'] = pd.DataFrame(
-                    full_snr_avg, index=final_electrode_names_ordered, columns=freq_cols_full
+                    full_snr_avg[:, mask],
+                    index=final_electrode_names_ordered,
+                    columns=freq_cols_full,
                 )
             for df_name_iter in dataframes_to_save:
                 dataframes_to_save[df_name_iter].insert(0, 'Electrode', dataframes_to_save[df_name_iter].index)

--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -128,8 +128,19 @@ class _Worker(QObject):
                 self._emit(f"No freq columns in {excel_path.name}")
                 continue
 
+            freq_pairs: List[tuple[float, str]] = []
+            for col in freq_cols:
+                try:
+                    freq = float(col.split("_")[0])
+                except ValueError:
+                    continue
+                freq_pairs.append((freq, col))
+
+            freq_pairs.sort(key=lambda x: x[0])
+            ordered_freqs = [f for f, _ in freq_pairs]
+            ordered_cols = [c for _, c in freq_pairs]
             if freqs is None:
-                freqs = [float(c.split("_")[0]) for c in freq_cols]
+                freqs = ordered_freqs
 
             for roi in roi_names:
                 chans = [c.upper() for c in self.roi_map.get(roi, [])]
@@ -138,7 +149,7 @@ class _Worker(QObject):
                     self._emit(f"No electrodes for ROI {roi} in {excel_path.name}")
                     continue
 
-                means = df_roi[freq_cols].mean().tolist()
+                means = df_roi[ordered_cols].mean().tolist()
                 roi_data[roi].append(means)
 
         if not freqs:

--- a/tests/test_plot_generator_full_snr_roi.py
+++ b/tests/test_plot_generator_full_snr_roi.py
@@ -1,0 +1,84 @@
+import importlib.util
+import os
+import pytest
+
+if importlib.util.find_spec("matplotlib") is None:
+    pytest.skip("matplotlib not available", allow_module_level=True)
+
+import pandas as pd
+
+
+def _import_module():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "plot_generator.py",
+    )
+    spec = importlib.util.spec_from_file_location("plot_generator", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_full_snr_roi_averaging(tmp_path, monkeypatch):
+    module = _import_module()
+
+    cond_dir = tmp_path / "Cond"
+    cond_dir.mkdir()
+
+    df1 = pd.DataFrame(
+        {
+            "Electrode": ["Cz", "Pz"],
+            "1.0000_Hz": [1, 3],
+            "1.0001_Hz": [2, 4],
+            "2.0000_Hz": [4, 6],
+            "2.0001_Hz": [5, 7],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "Electrode": ["Cz", "Pz"],
+            "1.0000_Hz": [5, 7],
+            "1.0001_Hz": [6, 8],
+            "2.0000_Hz": [7, 9],
+            "2.0001_Hz": [8, 10],
+        }
+    )
+    with pd.ExcelWriter(cond_dir / "sub1.xlsx") as writer:
+        df1.to_excel(writer, sheet_name="FullSNR", index=False)
+    with pd.ExcelWriter(cond_dir / "sub2.xlsx") as writer:
+        df2.to_excel(writer, sheet_name="FullSNR", index=False)
+
+    captured = {}
+
+    def dummy_plot(self, freqs, roi_data):
+        captured["freqs"] = freqs
+        captured["roi_data"] = roi_data
+
+    monkeypatch.setattr(module._Worker, "_plot", dummy_plot)
+    monkeypatch.setattr(module._Worker, "_emit", lambda *a, **k: None)
+
+    worker = module._Worker(
+        folder=str(tmp_path),
+        condition="Cond",
+        metric="SNR",
+        roi_map={"All": ["Cz", "Pz"]},
+        selected_roi="All",
+        oddballs=[],
+        title="t",
+        xlabel="x",
+        ylabel="y",
+        x_min=0.0,
+        x_max=2.0,
+        y_min=-1.0,
+        y_max=1.0,
+        out_dir=str(tmp_path),
+    )
+
+    worker._run()
+
+    assert captured["freqs"] == [1.0, 1.0001, 2.0, 2.0001]
+    assert captured["roi_data"] == {"All": [4.0, 5.0, 6.5, 7.5]}


### PR DESCRIPTION
## Summary
- handle duplicate frequency columns in FullSNR sheets
- regression test for ROI averaging with duplicate columns
- limit FullSNR export to BCA upper limit

## Testing
- `ruff check src/Tools/Plot_Generator/plot_generator.py tests/test_plot_generator_full_snr_roi.py src/Main_App/post_process.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875504a2fec832cae55c9eaf382405c