### PR TITLE
Add right-click delete option in settings

### DIFF
--- a/src/Main_App/settings_window.py
+++ b/src/Main_App/settings_window.py
@@ -359,6 +359,32 @@ class SettingsWindow(ctk.CTkToplevel):
             listbox.insert("end", n)
         listbox.pack(fill="both", expand=True, padx=10, pady=(10, 0))
 
+        # Context menu for right click actions on the saved configurations
+        menu = tk.Menu(
+            win,
+            tearoff=0,
+            bg="#f1f1f1",
+            fg="#000000",
+            activebackground="#cce6ff",
+            activeforeground="#000000",
+        )
+        menu.add_command(
+            label="Delete Selected Configuration", command=lambda: _delete_selected()
+        )
+
+        def _show_menu(event: tk.Event) -> None:
+            # Select the item under the cursor before showing the menu
+            index = listbox.nearest(event.y)
+            if index >= 0:
+                listbox.selection_clear(0, "end")
+                listbox.selection_set(index)
+                menu.tk_popup(event.x_root, event.y_root)
+                menu.grab_release()
+
+        # Bind right click for Windows/Linux and middle click for macOS
+        listbox.bind("<Button-3>", _show_menu)
+        listbox.bind("<Button-2>", _show_menu)
+
         btn_frame = ctk.CTkFrame(win, fg_color="transparent")
         btn_frame.pack(pady=10)
 


### PR DESCRIPTION
## Summary
- add context menu for saved configuration list
- allow deleting configs through right-click menu

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876598493c0832c9f6c76d42477c426