### PR TITLE
Fix LORETA queue inheritance issue

### DIFF
--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -415,27 +415,28 @@ class SourceLocalizationWindow(ctk.CTkToplevel):
     ):
         log_func = getattr(self.master, "log", print)
         ctx = mp.get_context("spawn")
-        q = ctx.Queue()
+        with ctx.Manager() as manager:
+            q = manager.Queue()
 
-        with ProcessPoolExecutor(max_workers=1, mp_context=ctx) as ex:
-            future = ex.submit(
-                worker.run_localization_worker,
-                fif_path,
-                out_dir,
-                method=method,
-                threshold=thr,
-                alpha=alpha,
-                hemi=hemi,
-                low_freq=low_freq,
-                high_freq=high_freq,
-                harmonics=harmonics,
-                snr=snr,
-                oddball=oddball,
-                export_rois=export_rois,
-                baseline=baseline,
-                time_window=time_window,
-                queue=q,
-            )
+            with ProcessPoolExecutor(max_workers=1, mp_context=ctx) as ex:
+                future = ex.submit(
+                    worker.run_localization_worker,
+                    fif_path,
+                    out_dir,
+                    method=method,
+                    threshold=thr,
+                    alpha=alpha,
+                    hemi=hemi,
+                    low_freq=low_freq,
+                    high_freq=high_freq,
+                    harmonics=harmonics,
+                    snr=snr,
+                    oddball=oddball,
+                    export_rois=export_rois,
+                    baseline=baseline,
+                    time_window=time_window,
+                    queue=q,
+                )
 
             while True:
                 try:


### PR DESCRIPTION
## Summary
- use a multiprocessing Manager queue when spawning the LORETA worker

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68765d280f40832cb50d4b2f4c872195