### PR TITLE
Fix load_utils docstring and unsupported format handling

### DIFF
--- a/src/Main_App/load_utils.py
+++ b/src/Main_App/load_utils.py
@@ -1,7 +1,6 @@
 """Helper functions for reading EEG recordings into MNE.
-Supported ``.bdf`` and ``.set`` files are loaded with the
-appropriate options, and warnings are shown for unsupported
-formats."""
+Only ``.bdf`` files are supported and loaded with the appropriate
+options. A warning is shown for any unsupported format."""
 
 import os
 from tkinter import messagebox
@@ -10,7 +9,7 @@ import mne
 
 
 def load_eeg_file(app, filepath):
-    """Load an EEG file (.bdf or .set) and apply the standard montage.
+    """Load a ``.bdf`` EEG file and apply the standard montage.
 
     Parameters
     ----------
@@ -33,12 +32,11 @@ def load_eeg_file(app, filepath):
             with mne.utils.use_log_level('WARNING'):
                 raw = mne.io.read_raw_bdf(filepath, **kwargs)
             app.log("BDF loaded successfully.")
-        elif ext == ".set":
-            with mne.utils.use_log_level('WARNING'):
-                raw = mne.io.read_raw_eeglab(filepath, **kwargs)
-            app.log("SET loaded successfully.")
         else:
-            messagebox.showwarning("Unsupported File", f"Format '{ext}' not supported.")
+            messagebox.showwarning(
+                "Unsupported File",
+                f"Format '{ext}' not supported. Only '.bdf' files are supported.",
+            )
             return None
 
         if raw is None:


### PR DESCRIPTION
## Summary
- update module and function docstrings for `.bdf` only
- remove `.set` branch in `load_eeg_file`
- warn users when an unsupported extension is loaded

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a31c4f6c832cb4feef575a1720df