### PR TITLE
Limit advanced analysis file import to BDF

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis_file_ops.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_file_ops.py
@@ -6,7 +6,7 @@ class AdvancedAnalysisFileOpsMixin:
     
             files = filedialog.askopenfilenames(
                 title="Select EEG Files",
-                filetypes=[("EEG files", "*.bdf *.set"), ("All files", "*.*")],
+                filetypes=[("EEG files", "*.bdf")],
                 parent=self,
             )
             if not files:


### PR DESCRIPTION
## Summary
- narrow advanced analysis file dialog to only show BDF files

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a31d1c8c832cbefffd5a1a44d4d4