### PR TITLE
Remove eeglab from pyinstaller options

### DIFF
--- a/src/Compiler_Script.py
+++ b/src/Compiler_Script.py
@@ -8,7 +8,6 @@ pyinstaller `
   --collect-all mne `
   --collect-data mne `
   --hidden-import=mne.io.bdf `
-  --hidden-import=mne.io.eeglab `
   --hidden-import=scipy `
   --hidden-import=scipy._cyutility `
   --hidden-import=pandas `

--- a/src/Misc/Compiler Script.py
+++ b/src/Misc/Compiler Script.py
@@ -30,8 +30,6 @@ if __name__ == "__main__":
         "--hidden-import",
         "mne.io.bdf",
         "--hidden-import",
-        "mne.io.eeglab",
-        "--hidden-import",
         "scipy",
         "--hidden-import",
         "pandas",


### PR DESCRIPTION
## Summary
- clean up pyinstaller options by removing `mne.io.eeglab`
- adjust Misc compiler script accordingly

## Testing
- `ruff check .`
- `pytest -q`
- ❌ `pip install pyinstaller` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876a31e2390832c9d1c15ad4fbc3b3a