### PR TITLE
Add MATLAB-style SNR calculation for plot generator

### DIFF
--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -32,6 +32,7 @@ from Tools.Stats.stats_analysis import ALL_ROIS_OPTION
 from Main_App.settings_manager import SettingsManager
 from Tools.Plot_Generator.plot_settings import PlotSettingsManager
 from config import update_target_frequencies
+from Tools.Plot_Generator.snr_utils import calc_snr_matlab
 
 class _Worker(QObject):
     """Worker to process Excel files and generate plots."""
@@ -116,8 +117,19 @@ class _Worker(QObject):
             try:
                 if self.metric == "SNR":
                     xls = pd.ExcelFile(excel_path)
-                    sheet_to_load = "FullSNR" if "FullSNR" in xls.sheet_names else "SNR"
-                    df = pd.read_excel(xls, sheet_name=sheet_to_load)
+                    if "FullSNR" in xls.sheet_names:
+                        df = pd.read_excel(xls, sheet_name="FullSNR")
+                    else:
+                        df_amp = pd.read_excel(xls, sheet_name="FFT Amplitude (uV)")
+                        freq_cols_tmp = [
+                            c for c in df_amp.columns if isinstance(c, str) and c.endswith("_Hz")
+                        ]
+                        snr_vals = df_amp[freq_cols_tmp].apply(
+                            calc_snr_matlab, axis=1, result_type="expand"
+                        )
+                        snr_vals.columns = freq_cols_tmp
+                        snr_vals.insert(0, "Electrode", df_amp["Electrode"])
+                        df = snr_vals
                 else:
                     df = pd.read_excel(excel_path, sheet_name="BCA (uV)")
             except Exception as e:  # pragma: no cover - simple logging

--- a/src/Tools/Plot_Generator/snr_utils.py
+++ b/src/Tools/Plot_Generator/snr_utils.py
@@ -1,0 +1,56 @@
+"""Helper utilities for SNR calculations used by the plot generator."""
+
+from __future__ import annotations
+
+from typing import Sequence, List
+
+__all__ = ["calc_snr_matlab"]
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values)
+
+
+def calc_snr_matlab(amplitudes: Sequence[float]) -> List[float]:
+    """Return MATLAB-style SNR values for each amplitude bin.
+
+    Parameters
+    ----------
+    amplitudes:
+        Sequence of FFT amplitude values ordered by increasing frequency.
+
+    This mirrors the method used in some MATLAB FPVS scripts where a
+    +/-12-bin window is taken around the target bin, the immediate
+    neighbours (target\ ``\pm``\ 1) are removed, the maximum and minimum
+    remaining values are dropped and the mean of the rest is used as the
+    noise estimate.
+    """
+
+    amps = [float(a) for a in amplitudes]
+    n_bins = len(amps)
+    snr: List[float] = [0.0] * n_bins
+
+    for idx in range(n_bins):
+        low = max(0, idx - 12)
+        high = min(n_bins - 1, idx + 12)
+        neighbours = [amps[i] for i in range(low, high + 1)]
+
+        for remove in sorted({idx - 1, idx, idx + 1}, reverse=True):
+            if low <= remove <= high:
+                neighbours.pop(remove - low)
+
+        if not neighbours:
+            snr[idx] = 0.0
+            continue
+
+        if len(neighbours) > 2:
+            neighbours.remove(max(neighbours))
+            neighbours.remove(min(neighbours))
+
+        if neighbours:
+            mean_noise = _mean(neighbours)
+            snr[idx] = amps[idx] / mean_noise if mean_noise > 1e-12 else 0.0
+        else:
+            snr[idx] = 0.0
+
+    return snr

--- a/tests/test_plot_generator_fft_snr.py
+++ b/tests/test_plot_generator_fft_snr.py
@@ -1,0 +1,110 @@
+import importlib.util
+import os
+import pytest
+
+if importlib.util.find_spec("matplotlib") is None:
+    pytest.skip("matplotlib not available", allow_module_level=True)
+
+import pandas as pd
+
+
+def _import_snr_utils():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "snr_utils.py",
+    )
+    spec = importlib.util.spec_from_file_location("snr_utils", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+snr_utils = _import_snr_utils()
+calc_snr_matlab = snr_utils.calc_snr_matlab
+
+
+def _import_module():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "plot_generator.py",
+    )
+    spec = importlib.util.spec_from_file_location("plot_generator", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_snr_calculated_from_fft(tmp_path, monkeypatch):
+    module = _import_module()
+
+    cond_dir = tmp_path / "Cond"
+    cond_dir.mkdir()
+
+    cols = [f"{i}_Hz" for i in range(1, 7)]
+    df1 = pd.DataFrame({
+        "Electrode": ["Cz", "Pz"],
+        cols[0]: [1, 1],
+        cols[1]: [1, 1],
+        cols[2]: [10, 14],
+        cols[3]: [1, 1],
+        cols[4]: [1, 1],
+        cols[5]: [1, 1],
+    })
+    df2 = pd.DataFrame({
+        "Electrode": ["Cz", "Pz"],
+        cols[0]: [1, 1],
+        cols[1]: [1, 1],
+        cols[2]: [6, 8],
+        cols[3]: [1, 1],
+        cols[4]: [1, 1],
+        cols[5]: [1, 1],
+    })
+    with pd.ExcelWriter(cond_dir / "sub1.xlsx") as writer:
+        df1.to_excel(writer, sheet_name="FFT Amplitude (uV)", index=False)
+    with pd.ExcelWriter(cond_dir / "sub2.xlsx") as writer:
+        df2.to_excel(writer, sheet_name="FFT Amplitude (uV)", index=False)
+
+    captured = {}
+
+    def dummy_plot(self, freqs, roi_data):
+        captured["freqs"] = freqs
+        captured["roi_data"] = roi_data
+
+    monkeypatch.setattr(module._Worker, "_plot", dummy_plot)
+    monkeypatch.setattr(module._Worker, "_emit", lambda *a, **k: None)
+
+    worker = module._Worker(
+        folder=str(tmp_path),
+        condition="Cond",
+        metric="SNR",
+        roi_map={"All": ["Cz", "Pz"]},
+        selected_roi="All",
+        oddballs=[],
+        title="t",
+        xlabel="x",
+        ylabel="y",
+        x_min=0.0,
+        x_max=6.0,
+        y_min=0.0,
+        y_max=20.0,
+        out_dir=str(tmp_path),
+    )
+
+    worker._run()
+
+    exp1 = [calc_snr_matlab(row) for row in df1[cols].values.tolist()]
+    mean1 = [sum(vals) / len(vals) for vals in zip(*exp1)]
+    exp2 = [calc_snr_matlab(row) for row in df2[cols].values.tolist()]
+    mean2 = [sum(vals) / len(vals) for vals in zip(*exp2)]
+    expected = [sum(vals) / 2 for vals in zip(mean1, mean2)]
+
+    assert captured["freqs"] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    assert captured["roi_data"] == {"All": expected}

--- a/tests/test_snr_utils.py
+++ b/tests/test_snr_utils.py
@@ -1,0 +1,25 @@
+import importlib.util
+import os
+
+def _import_snr_utils():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "snr_utils.py",
+    )
+    spec = importlib.util.spec_from_file_location("snr_utils", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+snr_utils = _import_snr_utils()
+calc_snr_matlab = snr_utils.calc_snr_matlab
+
+
+def test_calc_snr_matlab_basic():
+    amps = [1, 1, 10, 1, 1, 1]
+    expected = [1.0, 1.0, 10.0, 1.0, 1.0, 1.0]
+    assert calc_snr_matlab(amps) == expected


### PR DESCRIPTION
## Summary
- add `calc_snr_matlab` utility for computing SNR when only FFT amplitudes are available
- compute SNR from the "FFT Amplitude (uV)" sheet when a FullSNR sheet is absent
- test SNR utility and new FFT-based SNR path

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ab284bb0832c962e22fb2c3c6ced