### PR TITLE
Fix folder scan to skip .fif

### DIFF
--- a/src/Tools/Stats/stats_file_scanner.py
+++ b/src/Tools/Stats/stats_file_scanner.py
@@ -39,6 +39,10 @@ def scan_folder(self):
 
     try:
         for item_name in os.listdir(parent_folder):  # These are expected to be condition subfolders
+            if '.fif' in item_name.lower():
+                self.log_to_main_app(
+                    f"  Skipping subfolder '{item_name}' because name contains '.fif'.")
+                continue
             item_path = os.path.join(parent_folder, item_name)
             if os.path.isdir(item_path):
                 condition_name_raw = item_name


### PR DESCRIPTION
## Summary
- ignore folders containing `.fif` when scanning for condition subfolders

## Testing
- `python -m compileall -q src/Tools src/Main_App src/Misc src/fpvs_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6876c4162e74832cb4f1b75fc4b65376