### PR TITLE
Update plot tool folder filtering and UI

### DIFF
--- a/tests/test_plot_generator_baseline.py
+++ b/tests/test_plot_generator_baseline.py
@@ -38,7 +38,6 @@ def test_plot_contains_baseline_line(tmp_path, monkeypatch):
         metric="SNR",
         roi_map={"roi": ["Cz"]},
         selected_roi="roi",
-        oddballs=[1.0],
         title="t",
         xlabel="x",
         ylabel="y",
@@ -46,7 +45,6 @@ def test_plot_contains_baseline_line(tmp_path, monkeypatch):
         x_max=2.0,
         y_min=0.0,
         y_max=2.0,
-        use_matlab_style=False,
         out_dir=str(tmp_path),
     )
 
@@ -59,44 +57,3 @@ def test_plot_contains_baseline_line(tmp_path, monkeypatch):
     assert any(
         getattr(line, "get_ydata", lambda: [])() == [1.0, 1.0] for line in ax.lines
     )
-
-
-def test_matlab_style_skips_baseline_and_scatter(tmp_path, monkeypatch):
-    module = _import_module()
-
-    captured = {}
-
-    def dummy_close(fig):
-        captured["fig"] = fig
-
-    monkeypatch.setattr(module.plt, "close", dummy_close)
-    monkeypatch.setattr(module.matplotlib.figure.Figure, "savefig", lambda self, *a, **k: None)
-
-    worker = module._Worker(
-        folder=str(tmp_path),
-        condition="Cond",
-        metric="SNR",
-        roi_map={"roi": ["Cz"]},
-        selected_roi="roi",
-        oddballs=[1.0],
-        title="t",
-        xlabel="x",
-        ylabel="y",
-        x_min=0.0,
-        x_max=2.0,
-        y_min=0.0,
-        y_max=2.0,
-        use_matlab_style=True,
-        out_dir=str(tmp_path),
-    )
-
-    worker._emit = lambda *a, **k: None
-    worker._plot([1.0], {"roi": [0.5]})
-
-    fig = captured.get("fig")
-    assert fig is not None
-    ax = fig.axes[0]
-    assert all(
-        getattr(line, "get_ydata", lambda: [])() != [1.0, 1.0] for line in ax.lines
-    )
-    assert len(ax.collections) == 1

--- a/tests/test_plot_generator_fft_snr.py
+++ b/tests/test_plot_generator_fft_snr.py
@@ -87,7 +87,6 @@ def test_snr_calculated_from_fft(tmp_path, monkeypatch):
         metric="SNR",
         roi_map={"All": ["Cz", "Pz"]},
         selected_roi="All",
-        oddballs=[],
         title="t",
         xlabel="x",
         ylabel="y",

--- a/tests/test_plot_generator_full_snr_roi.py
+++ b/tests/test_plot_generator_full_snr_roi.py
@@ -67,7 +67,6 @@ def test_full_snr_roi_averaging(tmp_path, monkeypatch):
         metric="SNR",
         roi_map={"All": ["Cz", "Pz"]},
         selected_roi="All",
-        oddballs=[],
         title="t",
         xlabel="x",
         ylabel="y",
@@ -75,7 +74,6 @@ def test_full_snr_roi_averaging(tmp_path, monkeypatch):
         x_max=2.0,
         y_min=-1.0,
         y_max=1.0,
-        use_matlab_style=False,
         out_dir=str(tmp_path),
     )
 

--- a/tests/test_plot_generator_ignore_fif.py
+++ b/tests/test_plot_generator_ignore_fif.py
@@ -1,0 +1,39 @@
+import importlib.util
+import os
+import pytest
+
+if importlib.util.find_spec("matplotlib") is None:
+    pytest.skip("matplotlib not available", allow_module_level=True)
+
+
+def _import_module():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "plot_generator.py",
+    )
+    spec = importlib.util.spec_from_file_location("plot_generator", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_populate_conditions_skips_fif(tmp_path):
+    module = _import_module()
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+
+    (tmp_path / "CondA").mkdir()
+    (tmp_path / "skip.fif.data").mkdir()
+
+    win = module.PlotGeneratorWindow()
+    win._populate_conditions(str(tmp_path))
+    items = [win.condition_combo.itemText(i) for i in range(win.condition_combo.count())]
+    assert "CondA" in items
+    assert all(".fif" not in item for item in items)
+
+    app.quit()

--- a/tests/test_plot_generator_title_roi.py
+++ b/tests/test_plot_generator_title_roi.py
@@ -38,7 +38,6 @@ def test_roi_added_to_title(tmp_path, monkeypatch):
         metric="SNR",
         roi_map={"Occipital": ["Cz"]},
         selected_roi="Occipital",
-        oddballs=[1.0],
         title="Cond",
         xlabel="x",
         ylabel="y",
@@ -46,7 +45,6 @@ def test_roi_added_to_title(tmp_path, monkeypatch):
         x_max=2.0,
         y_min=-1.0,
         y_max=1.0,
-        use_matlab_style=False,
         out_dir=str(tmp_path),
     )
 


### PR DESCRIPTION
## Summary
- filter out `.fif` directories when populating conditions in the plot tool
- drop oddball frequency and MATLAB style options from the plot generator UI
- adjust plotting logic to always use default style
- update tests to match new behaviour
- add a test to ensure `.fif` folders are ignored

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c78b8394832c8f2bdde2661905a7