### PR TITLE
Add gridlines to plot generator

### DIFF
--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -36,6 +36,7 @@ from Main_App.settings_manager import SettingsManager
 from Tools.Plot_Generator.plot_settings import PlotSettingsManager
 from config import update_target_frequencies
 from Tools.Plot_Generator.snr_utils import calc_snr_matlab
+import math
 
 class _Worker(QObject):
     """Worker to process Excel files and generate plots."""
@@ -210,14 +211,14 @@ class _Worker(QObject):
             fig, ax = plt.subplots(figsize=(8, 3), dpi=300)
 
             freq_amp = dict(zip(freqs, amps))
-            line_color = "red" if self.use_matlab_style else "black"
+            line_color = "black"
 
             if self.metric == "SNR":
                 stem_vals = amps
                 ax.stem(
                     freqs,
                     stem_vals,
-                    linefmt=line_color,
+                    linefmt="red",
                     markerfmt=" ",
                     basefmt=" ",
                     bottom=1.0,
@@ -233,8 +234,8 @@ class _Worker(QObject):
                 )
 
 
-            mark_x = []
-            mark_y = []
+            mark_x: list[float] = []
+            mark_y: list[float] = []
             for odd in self.oddballs:
                 amp = freq_amp.get(odd)
                 if amp is None:
@@ -243,15 +244,32 @@ class _Worker(QObject):
                 mark_y.append(amp)
 
             if mark_x and not self.use_matlab_style:
-                ax.scatter(mark_x, mark_y, color="red", zorder=3)
+                ax.scatter(mark_x, mark_y, color="blue", zorder=3)
                 self._emit(
                     f"Marked {len(mark_x)} oddball points on ROI {roi}", 0, 0
                 )
 
-            ax.set_xticks(self.oddballs)
-            ax.set_xticklabels([f"{odd:.1f} Hz" for odd in self.oddballs])
+            tick_start = math.ceil(self.x_min)
+            tick_end = math.floor(self.x_max) + 1
+            ax.set_xticks(range(tick_start, tick_end))
             ax.set_xlim(self.x_min, self.x_max)
             ax.set_ylim(self.y_min, self.y_max)
+            for fx in range(max(1, tick_start), tick_end):
+                ax.axvline(
+                    fx,
+                    color="lightgray",
+                    linestyle="--",
+                    linewidth=0.5,
+                    zorder=0,
+                )
+            for y in range(math.ceil(self.y_min), math.floor(self.y_max) + 1):
+                ax.axhline(
+                    y,
+                    color="lightgray",
+                    linestyle="--",
+                    linewidth=0.5,
+                    zorder=0,
+                )
             if not self.use_matlab_style:
                 ax.axhline(1.0, color="gray", linestyle="--", linewidth=1, alpha=0.5)
             ax.set_xlabel(self.xlabel)

--- a/tests/test_plot_generator_gridlines.py
+++ b/tests/test_plot_generator_gridlines.py
@@ -1,0 +1,70 @@
+import importlib.util
+import os
+import pytest
+
+if importlib.util.find_spec("matplotlib") is None:
+    pytest.skip("matplotlib not available", allow_module_level=True)
+
+
+def _import_module():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "plot_generator.py",
+    )
+    spec = importlib.util.spec_from_file_location("plot_generator", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_gridlines_added(tmp_path, monkeypatch):
+    module = _import_module()
+
+    captured = {}
+
+    def dummy_close(fig):
+        captured["fig"] = fig
+
+    monkeypatch.setattr(module.plt, "close", dummy_close)
+    monkeypatch.setattr(module.matplotlib.figure.Figure, "savefig", lambda self, *a, **k: None)
+
+    worker = module._Worker(
+        folder=str(tmp_path),
+        condition="Cond",
+        metric="SNR",
+        roi_map={"roi": ["Cz"]},
+        selected_roi="roi",
+        oddballs=[1.0, 2.0],
+        title="t",
+        xlabel="x",
+        ylabel="y",
+        x_min=0.0,
+        x_max=3.0,
+        y_min=0.0,
+        y_max=3.0,
+        use_matlab_style=False,
+        out_dir=str(tmp_path),
+    )
+
+    worker._emit = lambda *a, **k: None
+    worker._plot([1.0, 2.0], {"roi": [1.5, 2.5]})
+
+    fig = captured.get("fig")
+    assert fig is not None
+    ax = fig.axes[0]
+    v_lines = {
+        line.get_xdata()[0]
+        for line in ax.lines
+        if line.get_color() == "lightgray" and line.get_xdata()[0] == line.get_xdata()[1]
+    }
+    h_lines = {
+        line.get_ydata()[0]
+        for line in ax.lines
+        if line.get_color() == "lightgray" and line.get_ydata()[0] == line.get_ydata()[1]
+    }
+    assert v_lines == {1.0, 2.0, 3.0}
+    assert h_lines == {0.0, 1.0, 2.0, 3.0}


### PR DESCRIPTION
## Summary
- draw gridlines at integer frequency and SNR values
- highlight oddball peaks with a marker
- color SNR stems red by default
- update gridlines test

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876c8f8971c832ca55c0a6aea577054