### PR TITLE
Add plot tool menu and settings

### DIFF
--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -27,7 +27,13 @@ from PySide6.QtWidgets import (
     QPlainTextEdit,
     QProgressBar,
     QWidget,
+    QMenuBar,
+    QMenu,
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
 )
+from PySide6.QtGui import QAction
 from Tools.Stats.stats_helpers import load_rois_from_settings
 from Tools.Stats.stats_analysis import ALL_ROIS_OPTION
 from Main_App.settings_manager import SettingsManager
@@ -55,6 +61,7 @@ class _Worker(QObject):
         y_min: float,
         y_max: float,
         out_dir: str,
+        stem_color: str = "red",
 
     ) -> None:
         super().__init__()
@@ -72,6 +79,9 @@ class _Worker(QObject):
         self.y_max = y_max
 
         self.out_dir = Path(out_dir)
+        self.stem_color = stem_color.lower()
+        # maintain oddballs attribute for compatibility with older versions
+        self.oddballs: List[float] = []
 
 
     def run(self) -> None:
@@ -202,7 +212,7 @@ class _Worker(QObject):
         for roi, amps in roi_data.items():
             fig, ax = plt.subplots(figsize=(8, 3), dpi=300)
 
-            line_color = "black"
+            line_color = self.stem_color
 
             if self.metric == "SNR":
                 stem_vals = amps
@@ -241,6 +251,31 @@ class _Worker(QObject):
             self._emit(f"Saved {fname}")
 
 
+class _SettingsDialog(QDialog):
+    """Dialog for configuring plot options."""
+
+    def __init__(self, parent: QWidget, color: str) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+        layout = QVBoxLayout(self)
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Stem Plot Line Color:"))
+        self.combo = QComboBox()
+        self.combo.addItems(["Red", "Blue", "Green", "Purple"])
+        self.combo.setCurrentText(color.capitalize())
+        row.addWidget(self.combo)
+        layout.addLayout(row)
+        btns = QHBoxLayout()
+        ok = QPushButton("OK")
+        ok.clicked.connect(self.accept)
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btns.addWidget(ok)
+        btns.addWidget(cancel)
+        layout.addLayout(btns)
+
+    def selected_color(self) -> str:
+        return self.combo.currentText().lower()
 
 class PlotGeneratorWindow(QWidget):
     """Main window for generating plots."""
@@ -254,6 +289,7 @@ class PlotGeneratorWindow(QWidget):
         self.plot_mgr = PlotSettingsManager()
         default_in = self.plot_mgr.get("paths", "input_folder", "")
         default_out = self.plot_mgr.get("paths", "output_folder", "")
+        self.stem_color = self.plot_mgr.get_stem_color()
         main_default = mgr.get("paths", "output_folder", "")
         if not default_in:
             default_in = main_default
@@ -289,7 +325,17 @@ class PlotGeneratorWindow(QWidget):
         self._worker: _Worker | None = None
 
     def _build_ui(self) -> None:
-        layout = QGridLayout(self)
+        root_layout = QVBoxLayout(self)
+        menu = QMenuBar()
+        file_menu = QMenu("File", self)
+        menu.addMenu(file_menu)
+        action = QAction("Settings", self)
+        action.triggered.connect(self._open_settings)
+        file_menu.addAction(action)
+        root_layout.addWidget(menu)
+
+        layout = QGridLayout()
+        root_layout.addLayout(layout)
         row = 0
         layout.addWidget(QLabel("Excel Files Folder:"), row, 0)
         self.folder_edit = QLineEdit()
@@ -517,6 +563,7 @@ class PlotGeneratorWindow(QWidget):
             y_min,
             y_max,
             out_dir,
+            self.stem_color,
 
         )
         self._worker.moveToThread(self._thread)
@@ -527,6 +574,13 @@ class PlotGeneratorWindow(QWidget):
         self._thread.finished.connect(self._thread.deleteLater)
         self._thread.finished.connect(self._generation_finished)
         self._thread.start()
+
+    def _open_settings(self) -> None:
+        dlg = _SettingsDialog(self, self.stem_color)
+        if dlg.exec():
+            self.stem_color = dlg.selected_color()
+            self.plot_mgr.set_stem_color(self.stem_color)
+            self.plot_mgr.save()
 
     def _open_output_folder(self) -> None:
         folder = self.out_edit.text()

--- a/src/Tools/Plot_Generator/plot_settings.py
+++ b/src/Tools/Plot_Generator/plot_settings.py
@@ -20,6 +20,8 @@ class PlotSettingsManager:
         self.ini_path = ini_path or _default_ini_path()
         self.config = configparser.ConfigParser()
         self.load()
+        if not self.config.has_option("plot", "stem_color"):
+            self.set("plot", "stem_color", "red")
 
     def load(self) -> None:
         self.config.read(self.ini_path)
@@ -32,7 +34,15 @@ class PlotSettingsManager:
     def get(self, section: str, option: str, fallback: str = '') -> str:
         return self.config.get(section, option, fallback=fallback)
 
+    def get_stem_color(self) -> str:
+        """Return the stored stem plot line color."""
+        return self.get("plot", "stem_color", "red")
+
     def set(self, section: str, option: str, value: str) -> None:
         if not self.config.has_section(section):
             self.config.add_section(section)
         self.config.set(section, option, value)
+
+    def set_stem_color(self, color: str) -> None:
+        """Persist the stem plot line color."""
+        self.set("plot", "stem_color", color)


### PR DESCRIPTION
## Summary
- add menu bar and settings dialog to plot tool
- allow saving default stem plot line color
- keep a placeholder `oddballs` attribute for compatibility

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876cb1d243c832c968fff6d1f9d9341