### PR TITLE
Improve PlotGenerator menu style

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -108,6 +108,14 @@ class PlotGeneratorWindow(QWidget):
     def _build_ui(self) -> None:
         root_layout = QVBoxLayout(self)
         menu = QMenuBar()
+        menu.setNativeMenuBar(False)
+        menu.setStyleSheet(
+            "QMenuBar {background-color: #f0f0f0;}"
+            "QMenuBar::item {padding: 2px 8px; background: transparent;}"
+            "QMenuBar::item:selected {background: #e5e5e5;}"
+            "QMenu {background-color: #f0f0f0;}"
+            "QMenu::item:selected {background-color: #0078d7; color: white;}"
+        )
         file_menu = QMenu("File", self)
         menu.addMenu(file_menu)
         action = QAction("Settings", self)


### PR DESCRIPTION
## Summary
- tweak the plot generator menubar and menu styling to mimic Windows 11

## Testing
- `ruff check . --quiet` *(fails: F821 in worker.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aecf4e70832c8f325028a44cea7a