### PR TITLE
Fix stem color option in plot generator

### DIFF
--- a/src/Tools/Plot_Generator/worker.py
+++ b/src/Tools/Plot_Generator/worker.py
@@ -199,7 +199,7 @@ class _Worker(QObject):
                 ax.stem(
                     freqs,
                     stem_vals,
-                    linefmt="red",
+                    linefmt=line_color,
                     markerfmt=" ",
                     basefmt=" ",
                     bottom=1.0,


### PR DESCRIPTION
## Summary
- use configured stem plot color when plotting SNR stems

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b19834e0832c950938dd43581537