### PR TITLE
Fix plot progress bar resetting

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -354,6 +354,10 @@ class PlotGeneratorWindow(QWidget):
     def _on_progress(self, msg: str, processed: int, total: int) -> None:
         if msg:
             self._append_log(msg)
+        # Avoid resetting the progress bar when only log messages are emitted
+        if total == 0:
+            return
+
         if self._total_conditions:
             frac = (self._current_condition - 1) / self._total_conditions
             if total:


### PR DESCRIPTION
## Summary
- avoid resetting the progress bar when moving between conditions in Plot Generator

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877bd674f74832cbf06cfb0aa145775