### PR TITLE
Fix progress updates during plot generation

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -386,6 +386,7 @@ class PlotGeneratorWindow(QWidget):
             return
         folder, out_dir, x_min, x_max, y_min, y_max = self._gen_params
         condition = self._conditions_queue.pop(0)
+        self._current_condition += 1
 
         cond_out = Path(out_dir)
         if self._all_conditions:


### PR DESCRIPTION
## Summary
- increment condition counter before spawning plot generation threads so progress updates correctly

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877be7a54e4832cbfe19c8c00e3fea3