### PR TITLE
Add Clear Log tooltip to plot generator log

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -354,7 +354,7 @@ class PlotGeneratorWindow(QWidget):
         clear_btn = QPushButton()
         clear_btn.setIcon(self.style().standardIcon(QStyle.SP_TrashIcon))
         clear_btn.setFixedSize(22, 22)
-        clear_btn.setToolTip("Clear log")
+        clear_btn.setToolTip("Clear Log")
         clear_btn.clicked.connect(lambda: self.log.clear())
         header.addWidget(clear_btn)
         console_layout.addLayout(header)


### PR DESCRIPTION
## Summary
- update the trash icon tooltip text in the plot generator GUI to read "Clear Log"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877d36c2a60832cab505377a6c5615e