### PR TITLE
Implement overlay comparison plotting

### DIFF
--- a/src/Tools/Plot_Generator/plot_settings.py
+++ b/src/Tools/Plot_Generator/plot_settings.py
@@ -22,6 +22,8 @@ class PlotSettingsManager:
         self.load()
         if not self.config.has_option("plot", "stem_color"):
             self.set("plot", "stem_color", "red")
+        if not self.config.has_option("plot", "stem_color_b"):
+            self.set("plot", "stem_color_b", "blue")
 
     def load(self) -> None:
         self.config.read(self.ini_path)
@@ -38,6 +40,10 @@ class PlotSettingsManager:
         """Return the stored stem plot line color."""
         return self.get("plot", "stem_color", "red")
 
+    def get_second_color(self) -> str:
+        """Return the stored second stem plot color."""
+        return self.get("plot", "stem_color_b", "blue")
+
     def set(self, section: str, option: str, value: str) -> None:
         if not self.config.has_section(section):
             self.config.add_section(section)
@@ -46,3 +52,7 @@ class PlotSettingsManager:
     def set_stem_color(self, color: str) -> None:
         """Persist the stem plot line color."""
         self.set("plot", "stem_color", color)
+
+    def set_second_color(self, color: str) -> None:
+        """Persist the second stem plot line color."""
+        self.set("plot", "stem_color_b", color)


### PR DESCRIPTION
## Summary
- expand plot settings to store two stem colors
- add Overlay Comparison controls in the plot generator GUI
- compute plots for two conditions at once in worker when overlay enabled
- overlay Condition A and B curves with oddball peak markers

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e826909c832cbbc00673c829c5a1