### PR TITLE
Improve overlay plot legend and title handling

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -418,6 +418,15 @@ class PlotGeneratorWindow(QWidget):
 
     def _overlay_toggled(self, checked: bool) -> None:
         self.condition_b_combo.setVisible(checked)
+        if checked:
+            self.title_edit.setEnabled(True)
+            self.title_edit.clear()
+            self.title_edit.setPlaceholderText(
+                "Enter base chart name (e.g. Color Response vs Category Response)"
+            )
+        else:
+            # Revert to auto-generation behavior when comparison mode is off
+            self._update_chart_title_state(self.condition_combo.currentText())
 
     def _select_folder(self) -> None:
         folder = QFileDialog.getExistingDirectory(self, "Select Excel Folder")
@@ -433,6 +442,12 @@ class PlotGeneratorWindow(QWidget):
 
     def _update_chart_title_state(self, condition: str) -> None:
         """Enable/disable the title field based on the selected condition."""
+        if self.overlay_check.isChecked():
+            self.title_edit.setEnabled(True)
+            self.title_edit.setPlaceholderText(
+                "Enter base chart name (e.g. Color Response vs Category Response)"
+            )
+            return
         if condition == ALL_CONDITIONS_OPTION:
             self.title_edit.setEnabled(False)
             self.title_edit.setPlaceholderText("")

--- a/src/Tools/Plot_Generator/worker.py
+++ b/src/Tools/Plot_Generator/worker.py
@@ -384,10 +384,15 @@ class _Worker(QObject):
 
             ax.set_xlabel(self.xlabel)
             ax.set_ylabel(self.ylabel)
-            ax.set_title(f"{self.condition} vs {self.condition_b} — {roi}")
-            ax.legend(loc="upper right", frameon=True)
+            base = self.title or f"{self.condition} vs {self.condition_b}"
+            ax.set_title(f"{base} — {roi}")
+            ax.legend(
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                borderaxespad=0,
+            )
             ax.grid(False)
-            fig.tight_layout()
+            fig.tight_layout(rect=[0, 0, 0.85, 1])
             fname = f"{self.condition}_vs_{self.condition_b}_{roi}_{self.metric}.png"
             fig.savefig(self.out_dir / fname)
             plt.close(fig)


### PR DESCRIPTION
## Summary
- allow customizing overlay comparison plot title
- position overlay comparison legend outside the plot
- adjust chart title field when overlay comparison toggled

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ec204d84832cbbebb6787c8333a1