### PR TITLE
Fix overlay progress counters

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -123,6 +123,8 @@ class PlotGeneratorWindow(QWidget):
         }
         self._orig_defaults = self._defaults.copy()
         self._conditions_queue: list[str] = []
+        self._total_conditions = 0
+        self._current_condition = 0
 
         self._all_conditions = False
 


### PR DESCRIPTION
## Summary
- initialize total and current condition counters in the plot generator window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877eee04f34832c8e8bc8ab2d3967f9