### PR TITLE
Add thread cleanup for Qt averaging tool

### DIFF
--- a/src/Tools/Average_Preprocessing/__init__.py
+++ b/src/Tools/Average_Preprocessing/__init__.py
@@ -1,9 +1,11 @@
 # src/Tools/Average_Preprocessing/__init__.py
 
 from .advanced_analysis      import AdvancedAnalysisWindow
+from .advanced_analysis_qt   import AdvancedAnalysisWindow as AdvancedAnalysisWindowQt
 from .advanced_analysis_core import run_advanced_averaging_processing
 
 __all__ = [
     "AdvancedAnalysisWindow",
+    "AdvancedAnalysisWindowQt",
     "run_advanced_averaging_processing",
 ]

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt.py
@@ -1,0 +1,19 @@
+"""Aggregate Qt Advanced Analysis components into a single class."""
+
+from .advanced_analysis_qt_base import AdvancedAnalysisWindowBase
+from .advanced_analysis_qt_file_ops import AdvancedAnalysisFileOpsMixin
+from .advanced_analysis_qt_group_ops import AdvancedAnalysisGroupOpsMixin
+from .advanced_analysis_qt_processing import AdvancedAnalysisProcessingMixin
+from .advanced_analysis_qt_post import AdvancedAnalysisPostMixin
+
+
+class AdvancedAnalysisWindow(
+    AdvancedAnalysisFileOpsMixin,
+    AdvancedAnalysisGroupOpsMixin,
+    AdvancedAnalysisProcessingMixin,
+    AdvancedAnalysisPostMixin,
+    AdvancedAnalysisWindowBase,
+):
+    """Combined Qt-based window class composed from mixins."""
+
+    pass

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_base.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_base.py
@@ -1,0 +1,206 @@
+# advanced_analysis_qt_base.py
+"""PySide6 GUI for advanced averaging of preprocessed EEG epochs."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import List, Dict, Any, Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog, QFrame, QGridLayout, QHBoxLayout, QLabel,
+    QListWidget, QPushButton, QRadioButton, QTextEdit,
+    QVBoxLayout, QProgressBar
+)
+
+from Main_App.settings_manager import SettingsManager
+
+try:
+    from config import (
+        PAD_X, PAD_Y, BUTTON_WIDTH,
+    )
+except Exception:  # pragma: no cover - defaults
+    PAD_X = PAD_Y = 5
+    BUTTON_WIDTH = 180
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedAnalysisWindowBase(QDialog):
+    """Base dialog containing common UI for advanced averaging."""
+
+    def __init__(self, master) -> None:
+        super().__init__(None)
+        self.master_app = master
+        self.debug_mode = SettingsManager().debug_enabled()
+        self.setWindowTitle("Advanced Averaging Analysis")
+        self.resize(1050, 850)
+
+        self.source_eeg_files: List[str] = []
+        self.defined_groups: List[Dict[str, Any]] = []
+        self.selected_group_index: Optional[int] = None
+
+        self.processing_thread: Optional[threading.Thread] = None
+        self._stop_requested = threading.Event()
+        self._active_threads: List[tuple] = []
+
+        self._build_ui()
+        self._center()
+
+    # ------------------------------------------------------------------
+    # UI helpers
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        layout = QGridLayout(self)
+        layout.setColumnStretch(0, 1)
+        layout.setColumnStretch(1, 3)
+
+        left = QFrame()
+        left_layout = QVBoxLayout(left)
+        layout.addWidget(left, 0, 0)
+
+        left_layout.addWidget(QLabel("Source EEG Files"))
+        self.source_files_list = QListWidget()
+        left_layout.addWidget(self.source_files_list)
+
+        h = QHBoxLayout()
+        btn = QPushButton("Add Files…")
+        btn.clicked.connect(self.add_source_files)
+        h.addWidget(btn)
+        btn = QPushButton("Remove Selected")
+        btn.clicked.connect(self.remove_source_files)
+        h.addWidget(btn)
+        left_layout.addLayout(h)
+
+        left_layout.addWidget(QLabel("Defined Averaging Groups"))
+        self.groups_list = QListWidget()
+        self.groups_list.itemSelectionChanged.connect(self.on_group_select)
+        left_layout.addWidget(self.groups_list)
+
+        h2 = QHBoxLayout()
+        btn = QPushButton("Create New Group")
+        btn.clicked.connect(self.create_new_group)
+        h2.addWidget(btn)
+        btn = QPushButton("Rename Group")
+        btn.clicked.connect(self.rename_selected_group)
+        h2.addWidget(btn)
+        btn = QPushButton("Delete Group")
+        btn.clicked.connect(self.delete_selected_group)
+        h2.addWidget(btn)
+        left_layout.addLayout(h2)
+
+        right = QFrame()
+        right_layout = QVBoxLayout(right)
+        layout.addWidget(right, 0, 1)
+
+        right_layout.addWidget(QLabel("Group Configuration"))
+        self.group_config_frame = QFrame()
+        self.group_config_layout = QVBoxLayout(self.group_config_frame)
+        right_layout.addWidget(self.group_config_frame)
+
+        right_layout.addWidget(QLabel("Condition Mapping for Selected Group"))
+        self.condition_mapping_frame = QFrame()
+        self.condition_mapping_layout = QVBoxLayout(self.condition_mapping_frame)
+        right_layout.addWidget(self.condition_mapping_frame)
+
+        avg_box = QHBoxLayout()
+        avg_box.addWidget(QLabel("Averaging Method:"))
+        self.pool_rb = QRadioButton("Pool Trials")
+        self.pool_rb.setToolTip(
+            "All epochs from all files are pooled and averaged simultaneously."\
+            " Gives equal weight to every epoch and is typically preferred."
+        )
+        self.pool_rb.toggled.connect(self._update_current_group_avg_method)
+        avg_box.addWidget(self.pool_rb)
+        self.avg_rb = QRadioButton("Average of Averages")
+        self.avg_rb.setToolTip(
+            "Each file is averaged separately before averaging those results. "\
+            "Gives equal weight to files rather than epochs."
+        )
+        self.avg_rb.toggled.connect(self._update_current_group_avg_method)
+        avg_box.addWidget(self.avg_rb)
+        self.averaging_method_var = self.pool_rb
+        right_layout.addLayout(avg_box)
+
+        self.save_group_config_btn = QPushButton("Save Group Configuration")
+        self.save_group_config_btn.clicked.connect(self.save_current_group_config)
+        self.save_group_config_btn.setEnabled(False)
+        right_layout.addWidget(self.save_group_config_btn, alignment=Qt.AlignRight)
+
+        bottom = QFrame()
+        bottom_layout = QVBoxLayout(bottom)
+        layout.addWidget(bottom, 1, 0, 1, 2)
+
+        self.log_text = QTextEdit()
+        self.log_text.setReadOnly(True)
+        bottom_layout.addWidget(self.log_text)
+
+        hb = QHBoxLayout()
+        self.progress_bar = QProgressBar()
+        self.progress_bar.hide()
+        hb.addWidget(self.progress_bar)
+        self.clear_log_btn = QPushButton("Clear Log")
+        self.clear_log_btn.clicked.connect(self.clear_log)
+        hb.addWidget(self.clear_log_btn)
+        bottom_layout.addLayout(hb)
+
+        cb = QHBoxLayout()
+        self.start_btn = QPushButton("Start Advanced Processing")
+        self.start_btn.clicked.connect(self.start_advanced_processing)
+        cb.addWidget(self.start_btn)
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.clicked.connect(self.stop_processing)
+        self.stop_btn.setEnabled(False)
+        cb.addWidget(self.stop_btn)
+        self.close_btn = QPushButton("Close")
+        self.close_btn.clicked.connect(self._on_close)
+        cb.addWidget(self.close_btn)
+        bottom_layout.addLayout(cb)
+
+        self._clear_group_config_display()
+
+    def _center(self) -> None:
+        geo = self.frameGeometry()
+        center = self.parent().geometry().center() if self.parent() else self.screen().availableGeometry().center()
+        geo.moveCenter(center)
+        self.move(geo.topLeft())
+
+    def log(self, message: str) -> None:
+        self.log_text.append(message)
+        if hasattr(self.master_app, "log"):
+            self.master_app.log(f"[AdvAnalysis] {message}")
+
+    def clear_log(self) -> None:
+        self.log_text.clear()
+
+    def debug(self, message: str) -> None:
+        if self.debug_mode:
+            self.log(f"[DEBUG] {message}")
+
+    def _clear_group_config_display(self) -> None:
+        for layout in (self.group_config_layout, self.condition_mapping_layout):
+            while layout.count():
+                item = layout.takeAt(0)
+                widget = item.widget()
+                if widget:
+                    widget.deleteLater()
+        self.save_group_config_btn.setEnabled(False)
+        self.pool_rb.setChecked(True)
+
+    # Placeholder methods for mixins --------------------
+    def add_source_files(self) -> None: ...
+    def remove_source_files(self) -> None: ...
+    def create_new_group(self) -> None: ...
+    def rename_selected_group(self) -> None: ...
+    def delete_selected_group(self) -> None: ...
+    def on_group_select(self) -> None: ...
+    def save_current_group_config(self) -> bool: ...
+    def start_advanced_processing(self) -> None: ...
+    def stop_processing(self) -> None: ...
+    def _update_current_group_avg_method(self) -> None: ...
+    def _on_close(self) -> None: ...
+
+    def closeEvent(self, event) -> None:
+        # Allow mixins to override with custom close logic
+        super().closeEvent(event)

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_demo.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_demo.py
@@ -1,0 +1,49 @@
+"""Standalone demo for the PySide6 Advanced Analysis window."""
+
+from __future__ import annotations
+
+import os
+import sys
+import logging
+from pathlib import Path
+from PySide6.QtWidgets import QApplication
+
+from .advanced_analysis_qt import AdvancedAnalysisWindow
+from .advanced_analysis_core import run_advanced_averaging_processing
+
+logger = logging.getLogger(__name__)
+
+
+class DummyMasterApp:
+    def __init__(self) -> None:
+        self.validated_params = {
+            "low_pass": 0.1,
+            "high_pass": 50,
+            "epoch_start": -1,
+            "epoch_end": 2,
+            "stim_channel": "Status",
+        }
+        self.save_folder_path = type("Obj", (), {"get": lambda self: str(Path(os.getcwd()) / "test_adv_output_qt")})()
+        os.makedirs(self.save_folder_path.get(), exist_ok=True)
+
+    def log(self, message: str) -> None:
+        logger.info("[DummyMasterLog] %s", message)
+
+    def load_eeg_file(self, filepath):
+        logger.info("DummyLoad: %s", filepath)
+        return "dummy_raw_obj_for_test"
+
+    def preprocess_raw(self, raw, **params):
+        logger.info("DummyPreproc of '%s' with %s", raw, params)
+        return "dummy_proc_raw_obj_for_test"
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    app = QApplication(sys.argv)
+    master = DummyMasterApp()
+    if run_advanced_averaging_processing is None:
+        logger.critical("CRITICAL ERROR: core processing not imported.")
+    win = AdvancedAnalysisWindow(master)
+    win.show()
+    app.exec()

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_file_ops.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_file_ops.py
@@ -1,0 +1,56 @@
+# advanced_analysis_qt_file_ops.py
+"""File operations mixin for the PySide6 advanced analysis window."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+
+from PySide6.QtWidgets import QFileDialog
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedAnalysisFileOpsMixin:
+    def add_source_files(self) -> None:
+        files, _ = QFileDialog.getOpenFileNames(self, "Select EEG Files", filter="EEG files (*.bdf)")
+        if not files:
+            return
+        added = 0
+        for fp in files:
+            if fp not in self.source_eeg_files:
+                self.source_eeg_files.append(fp)
+                added += 1
+        if added:
+            self.source_eeg_files.sort()
+            self._update_source_files_listbox()
+            self.log(f"Added {added} source file(s). Total: {len(self.source_eeg_files)}.")
+
+    def remove_source_files(self) -> None:
+        indices = [self.source_files_list.row(it) for it in self.source_files_list.selectedItems()]
+        if not indices:
+            self.log("No source files selected to remove.")
+            return
+        removed_paths = [self.source_eeg_files[i] for i in indices]
+        self.source_eeg_files = [f for i, f in enumerate(self.source_eeg_files) if i not in indices]
+        self._update_source_files_listbox()
+        self.log(f"Removed {len(removed_paths)} file(s) from source list.")
+        self._check_groups_for_removed_files(removed_paths)
+
+    def _update_source_files_listbox(self) -> None:
+        self.source_files_list.clear()
+        for fp in self.source_eeg_files:
+            self.source_files_list.addItem(Path(fp).name)
+
+    def _check_groups_for_removed_files(self, removed_paths: List[str]) -> None:
+        affected = False
+        for group in self.defined_groups:
+            before = len(group['file_paths'])
+            group['file_paths'] = [p for p in group['file_paths'] if p not in removed_paths]
+            if len(group['file_paths']) != before:
+                group['config_saved'] = False
+                affected = True
+        if affected:
+            self._update_groups_listbox()
+            self._update_start_processing_button_state()

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_group_ops.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_group_ops.py
@@ -1,0 +1,154 @@
+# advanced_analysis_qt_group_ops.py
+"""Group management mixin for Qt advanced analysis window."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QInputDialog, QMessageBox, QLabel
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedAnalysisGroupOpsMixin:
+    def create_new_group(self) -> None:
+        name, ok = QInputDialog.getText(self, "New Averaging Group", "Group name:")
+        if not ok or not name.strip():
+            self.log("Group creation cancelled.")
+            return
+        if any(g['name'] == name for g in self.defined_groups):
+            QMessageBox.critical(self, "Error", f"A group named '{name}' already exists.")
+            return
+        id_str, ok = QInputDialog.getText(self, "Event IDs", "IDs to average (comma separated):")
+        if not ok or not id_str:
+            self.log("Group creation cancelled (no IDs).")
+            return
+        try:
+            ids_to_average = [int(x.strip()) for x in id_str.split(',') if x.strip()]
+        except ValueError:
+            QMessageBox.critical(self, "Error", "Enter only integers separated by commas.")
+            return
+        if not ids_to_average:
+            QMessageBox.critical(self, "Error", "Enter at least one event ID.")
+            return
+        if not self.source_eeg_files:
+            QMessageBox.critical(self, "Error", "No EEG files selected. Add files first.")
+            return
+        mapping_rule = {'output_label': name, 'sources': []}
+        for fp in self.source_eeg_files:
+            for event_id_val in ids_to_average:
+                mapping_rule['sources'].append({
+                    'file_path': fp,
+                    'original_label': str(event_id_val),
+                    'original_id': event_id_val,
+                })
+        new_group = {
+            'name': name,
+            'file_paths': list(self.source_eeg_files),
+            'condition_mappings': [mapping_rule],
+            'averaging_method': 'Pool Trials',
+            'config_saved': True,
+            'ui_mapping_rules': []
+        }
+        self.defined_groups.append(new_group)
+        self._update_groups_listbox()
+        self.log(f"Created group '{name}' averaging IDs {ids_to_average} in all {len(self.source_eeg_files)} files.")
+        idx = len(self.defined_groups) - 1
+        self.groups_list.setCurrentRow(idx)
+        self.on_group_select()
+        self._update_start_processing_button_state()
+
+    def delete_selected_group(self) -> None:
+        row = self.groups_list.currentRow()
+        if row < 0:
+            self.log("No group selected to delete.")
+            return
+        name = self.defined_groups[row]['name']
+        if QMessageBox.question(self, "Confirm Delete", f"Delete group '{name}'?") != QMessageBox.Yes:
+            return
+        del self.defined_groups[row]
+        self._update_groups_listbox()
+        self.log(f"Deleted group: {name}")
+        self.selected_group_index = None
+        self._clear_group_config_display()
+        self._update_start_processing_button_state()
+
+    def rename_selected_group(self) -> None:
+        row = self.groups_list.currentRow()
+        if row < 0:
+            self.log("No group selected to rename.")
+            return
+        current = self.defined_groups[row]['name']
+        new_name, ok = QInputDialog.getText(self, "Rename Group", f"Enter a new name for '{current}':")
+        if not ok or not new_name.strip():
+            return
+        if any(i != row and g['name'] == new_name for i, g in enumerate(self.defined_groups)):
+            QMessageBox.critical(self, "Error", f"A group named '{new_name}' already exists.")
+            return
+        self.defined_groups[row]['name'] = new_name
+        self.defined_groups[row]['config_saved'] = False
+        self._update_groups_listbox()
+        self.log(f"Renamed group to '{new_name}'.")
+
+    def _update_groups_listbox(self) -> None:
+        current = self.groups_list.currentRow()
+        self.groups_list.clear()
+        for g in self.defined_groups:
+            status = "" if g.get('config_saved') else " (Unsaved)"
+            self.groups_list.addItem(f"{g['name']} ({len(g['file_paths'])} files){status}")
+        if current >= 0 and current < self.groups_list.count():
+            self.groups_list.setCurrentRow(current)
+
+    def on_group_select(self) -> None:
+        row = self.groups_list.currentRow()
+        if row < 0:
+            return
+        self.selected_group_index = row
+        self._display_group_configuration()
+        self.save_group_config_btn.setEnabled(not self.defined_groups[row].get('config_saved', False))
+
+    def _display_group_configuration(self) -> None:
+        self._clear_group_config_display()
+        idx = self.selected_group_index
+        if idx is None or idx >= len(self.defined_groups):
+            return
+        g = self.defined_groups[idx]
+        self.group_config_layout.addWidget(QLabel(f"Group Name: {g['name']}"))
+        files_display = "\n".join(Path(fp).name for fp in g['file_paths']) or "No files in this group."
+        self.group_config_layout.addWidget(QLabel("Files in this group:\n" + files_display))
+        if g.get('condition_mappings'):
+            mapping = g['condition_mappings'][0]
+            ids = sorted({src['original_id'] for src in mapping['sources']})
+            self.condition_mapping_layout.addWidget(QLabel(f"Averaging Rule: '{mapping['output_label']}'"))
+            self.condition_mapping_layout.addWidget(QLabel(f"Averages IDs: {', '.join(map(str, ids))}"))
+        self.pool_rb.setChecked(g.get('averaging_method', 'Pool Trials') == 'Pool Trials')
+
+    def _update_current_group_avg_method(self) -> None:
+        idx = self.selected_group_index
+        if idx is None:
+            return
+        method = 'Pool Trials' if self.pool_rb.isChecked() else 'Average of Averages'
+        g = self.defined_groups[idx]
+        if g.get('averaging_method') != method:
+            g['averaging_method'] = method
+            g['config_saved'] = False
+            self._update_groups_listbox()
+            self.save_group_config_btn.setEnabled(True)
+            self._update_start_processing_button_state()
+
+    def save_current_group_config(self) -> bool:
+        idx = self.selected_group_index
+        if idx is None:
+            self.log("No group selected to save configuration for.")
+            return False
+        g = self.defined_groups[idx]
+        g['config_saved'] = True
+        self.log(f"Configuration saved for group '{g['name']}'.")
+        self._update_groups_listbox()
+        self.save_group_config_btn.setEnabled(False)
+        self._update_start_processing_button_state()
+        QMessageBox.information(self, "Configuration Saved", f"Configuration for group '{g['name']}' has been saved.")
+        return True

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_post.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_post.py
@@ -1,0 +1,104 @@
+# advanced_analysis_qt_post.py
+"""Post/utility mixin for Qt advanced analysis window."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedAnalysisPostMixin:
+    def _extract_pid_for_group(self, group_data: Dict[str, Any]) -> str:
+        file_paths = group_data.get('file_paths', [])
+        if not file_paths:
+            return "UnknownPID"
+        base_name = Path(file_paths[0]).stem
+        pid_regex_primary = r"\b(P\d+|S\d+|Sub\d+)\b"
+        match = re.search(pid_regex_primary, base_name, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+        if '_' in base_name:
+            for part in base_name.split('_'):
+                if re.fullmatch(r"(P\d+|S\d+|Sub\d+)", part, re.IGNORECASE):
+                    return part.upper()
+        cleaned_pid = re.sub(r"(_unamb|_ambig|_mid|_run\d*|_sess\d*|_task\w*|_eeg|_raw|_preproc|_ica).*", "", base_name, flags=re.IGNORECASE)
+        cleaned_pid = re.sub(r"[^A-Za-z0-9_]", "", cleaned_pid)
+        if '_' in cleaned_pid:
+            for part in cleaned_pid.split('_'):
+                if re.fullmatch(r"(P\d+|S\d+|Sub\d+)", part, re.IGNORECASE):
+                    return part.upper()
+        cleaned_pid_alphanum_only = re.sub(r"[^A-Za-z0-9]", "", cleaned_pid)
+        return cleaned_pid_alphanum_only if cleaned_pid_alphanum_only else base_name
+
+    def save_groups_to_file(self) -> None:
+        file_path, _ = QFileDialog.getSaveFileName(self, "Save Group Configuration", filter="JSON files (*.json)")
+        if not file_path:
+            return
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(self.defined_groups, f, indent=2)
+            self.log(f"Saved group configuration to {file_path}.")
+        except Exception as e:  # pragma: no cover - display error
+            QMessageBox.critical(self, "Error", f"Failed to save configuration:\n{e}")
+
+    def load_groups_from_file(self) -> None:
+        file_path, _ = QFileDialog.getOpenFileName(self, "Load Group Configuration", filter="JSON files (*.json)")
+        if not file_path:
+            return
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, list) or not all(isinstance(g, dict) for g in data):
+                raise ValueError("Invalid configuration structure")
+            required = {"name", "file_paths", "condition_mappings", "averaging_method", "config_saved"}
+            for group in data:
+                if not required.issubset(group.keys()):
+                    raise ValueError("Configuration missing required keys")
+            self.defined_groups = data
+            all_paths = {fp for g in self.defined_groups for fp in g.get("file_paths", [])}
+            self.source_eeg_files = sorted(all_paths)
+            self.selected_group_index = None
+            self._update_source_files_listbox()
+            self._update_groups_listbox()
+            self._clear_group_config_display()
+            self._update_start_processing_button_state()
+            self.log(f"Loaded {len(self.defined_groups)} group(s) from {file_path}.")
+        except Exception as e:  # pragma: no cover - display error
+            QMessageBox.critical(self, "Error", f"Failed to load configuration:\n{e}")
+
+    def _on_close(self) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Qt window close handling
+    # ------------------------------------------------------------------
+    def closeEvent(self, event) -> None:
+        if getattr(self, "_active_threads", None):
+            if QMessageBox.question(
+                self,
+                "Confirm Close",
+                "Processing is ongoing. Stop and close?",
+            ) != QMessageBox.Yes:
+                event.ignore()
+                return
+            self.stop_processing()
+            for thread, worker in list(self._active_threads):
+                thread.requestInterruption()
+                thread.quit()
+                thread.wait(10000)
+                worker.deleteLater()
+                thread.deleteLater()
+                self._active_threads.remove((thread, worker))
+        if hasattr(self.master_app, "_on_qt_window_closed"):
+            try:
+                self.master_app._on_qt_window_closed()
+            except Exception:
+                pass
+        super().closeEvent(event)

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
@@ -1,0 +1,188 @@
+# advanced_analysis_qt_processing.py
+"""Processing mixin using QThread for the PySide6 advanced analysis window."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, Optional
+
+from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtWidgets import QMessageBox
+
+from .advanced_analysis_core import run_advanced_averaging_processing
+from Main_App.post_process import post_process as _external_post_process_actual
+
+logger = logging.getLogger(__name__)
+
+
+class _Worker(QObject):
+    progress = Signal(float)
+    log = Signal(str)
+    finished = Signal()
+
+    def __init__(
+        self,
+        defined_groups: list,
+        main_app_params: dict,
+        load_file_method,
+        preprocess_raw_method,
+        output_directory: str,
+        pid_extractor,
+        stop_event: threading.Event,
+    ) -> None:
+        super().__init__()
+        self.defined_groups = defined_groups
+        self.main_app_params = main_app_params
+        self.load_file_method = load_file_method
+        self.preprocess_raw_method = preprocess_raw_method
+        self.output_directory = output_directory
+        self.pid_extractor = pid_extractor
+        self.stop_event = stop_event
+
+    def run(self) -> None:
+        try:
+            run_advanced_averaging_processing(
+                self.defined_groups,
+                self.main_app_params,
+                self.load_file_method,
+                self.preprocess_raw_method,
+                _external_post_process_actual,
+                self.output_directory,
+                self.pid_extractor,
+                self.log.emit,
+                self.progress.emit,
+                self.stop_event,
+            )
+        except Exception as e:  # pragma: no cover - user display
+            self.log.emit(f"!!! CRITICAL THREAD ERROR !!!\n{e}")
+        finally:
+            self.finished.emit()
+
+
+class AdvancedAnalysisProcessingMixin:
+    def _update_start_processing_button_state(self) -> None:
+        all_valid = False
+        if self.defined_groups:
+            all_valid = all(
+                g.get('config_saved') and g.get('file_paths') and g.get('condition_mappings')
+                for g in self.defined_groups
+            )
+        self.start_btn.setEnabled(all_valid)
+
+    def _validate_processing_setup(self) -> Optional[tuple]:
+        if not self.defined_groups:
+            QMessageBox.critical(self, "Error", "No averaging groups defined.")
+            return None
+        for i, group in enumerate(self.defined_groups):
+            if not group.get('config_saved'):
+                QMessageBox.critical(self, "Error", f"Group '{group['name']}' has unsaved changes.")
+                self.groups_list.setCurrentRow(i)
+                return None
+            if not group.get('file_paths'):
+                QMessageBox.critical(self, "Error", f"Group '{group['name']}' contains no files.")
+                self.groups_list.setCurrentRow(i)
+                return None
+            if not group.get('condition_mappings'):
+                QMessageBox.critical(self, "Error", f"Group '{group['name']}' has no mapping rules defined.")
+                self.groups_list.setCurrentRow(i)
+                return None
+        params = getattr(self.master_app, 'validated_params', None)
+        if not params:
+            ok = False
+            if hasattr(self.master_app, '_validate_inputs'):
+                try:
+                    ok = self.master_app._validate_inputs()
+                except Exception as e:  # pragma: no cover - user display
+                    QMessageBox.critical(self, "Error", f"Error validating main application inputs:\n{e}")
+                    return None
+                params = getattr(self.master_app, 'validated_params', None)
+            if not ok or not params:
+                QMessageBox.critical(self, "Error", "Main application parameters not set.")
+                return None
+        out_obj = getattr(self.master_app, 'save_folder_path', None)
+        if not out_obj or not hasattr(out_obj, 'get'):
+            QMessageBox.critical(self, "Error", "Main application output folder path is not configured.")
+            return None
+        output_directory = out_obj.get()
+        return params, output_directory
+
+    def _launch_processing_thread(self, main_app_params: Dict[str, Any], output_directory: str) -> None:
+        self.log("Starting processing thread...")
+        self.progress_bar.show()
+        self.progress_bar.setValue(0)
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        self.close_btn.setEnabled(False)
+        self._stop_requested.clear()
+
+        if hasattr(self.master_app, 'load_eeg_file'):
+            load_file_method = self.master_app.load_eeg_file
+        else:
+            from Main_App.load_utils import load_eeg_file as _load
+
+            def load_file_method(fp):
+                return _load(self.master_app, fp)
+
+        if hasattr(self.master_app, 'preprocess_raw'):
+            preprocess_raw_method = self.master_app.preprocess_raw
+        else:
+            from Main_App.eeg_preprocessing import perform_preprocessing as _pp
+
+            def preprocess_raw_method(raw, **params):
+                return _pp(raw_input=raw, params=params, log_func=self.master_app.log)[0]
+
+        thread = QThread()
+        worker = _Worker(
+            self.defined_groups,
+            main_app_params,
+            load_file_method,
+            preprocess_raw_method,
+            output_directory,
+            self._extract_pid_for_group,
+            self._stop_requested,
+        )
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.log.connect(self.log)
+        worker.progress.connect(lambda v: self.progress_bar.setValue(int(v * 100)))
+        worker.finished.connect(lambda: self._on_worker_finished(thread, worker))
+        self._active_threads.append((thread, worker))
+        thread.start()
+
+    def _on_worker_finished(self, thread: QThread, worker: QObject) -> None:
+        if (thread, worker) in self._active_threads:
+            self._active_threads.remove((thread, worker))
+        thread.requestInterruption()
+        thread.quit()
+        thread.wait()
+        worker.deleteLater()
+        thread.deleteLater()
+        self.stop_btn.setEnabled(False)
+        self.close_btn.setEnabled(True)
+        self.progress_bar.hide()
+        self._update_start_processing_button_state()
+        self._stop_requested.clear()
+        self.log("Processing finished.")
+
+    def start_advanced_processing(self) -> None:
+        self.log("Attempting to start advanced processing...")
+        validation = self._validate_processing_setup()
+        if not validation:
+            return
+        params, out_dir = validation
+        self._launch_processing_thread(params, out_dir)
+
+    def stop_processing(self) -> None:
+        if not self._active_threads:
+            self.log("Processing is not currently running.")
+            return
+        self._stop_requested.set()
+        self.log("Stop requested. Waiting for processing to terminate...")
+        self.stop_btn.setEnabled(False)
+        for thread, _ in list(self._active_threads):
+            thread.requestInterruption()
+        # threads will shut down via _on_worker_finished
+
+
+


### PR DESCRIPTION
## Summary
- keep references to active QThreads in the PySide6 advanced averaging window
- ensure worker threads are cleaned up and waited on when the window closes
- issue stop signals from the stop button
- cancel Tk timers when the Qt window closes and handle quitting gracefully

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68790d6e74bc832c8d7f81debda5864e