### PR TITLE
Ensure start processing only enabled when all inputs valid

### DIFF
--- a/src/Main_App/file_selection.py
+++ b/src/Main_App/file_selection.py
@@ -12,6 +12,12 @@ class FileSelectionMixin:
         if folder:
             self.save_folder_path.set(folder)
             self.log(f"Output folder: {folder}")
+            adv = getattr(self, "_qt_adv_win", None)
+            if adv is not None:
+                try:
+                    adv._update_start_processing_button_state()
+                except Exception:
+                    pass
         else:
             self.log("Save folder selection cancelled.")
 

--- a/src/Tools/Average_Preprocessing/advanced_analysis_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_processing.py
@@ -2,14 +2,18 @@
 from .advanced_analysis_base import *  # noqa: F401,F403,F405
 class AdvancedAnalysisProcessingMixin:
         def _update_start_processing_button_state(self):
+            has_params = bool(getattr(self.master_app, "validated_params", None))
+            out_dir_obj = getattr(self.master_app, "save_folder_path", None)
+            has_out_dir = out_dir_obj is not None and getattr(out_dir_obj, "get", None) and out_dir_obj.get()
+
             all_groups_valid_and_saved = False
             if self.defined_groups:
                 all_groups_valid_and_saved = all(
                     g.get('config_saved') and g.get('file_paths') and g.get('condition_mappings')
                     for g in self.defined_groups
                 )
-    
-            button_state = "normal" if all_groups_valid_and_saved else "disabled"
+
+            button_state = "normal" if all_groups_valid_and_saved and has_params and has_out_dir else "disabled"
             if hasattr(self, 'start_adv_processing_button'):
                 self.start_adv_processing_button.configure(state=button_state)
     

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
@@ -62,13 +62,17 @@ class _Worker(QObject):
 
 class AdvancedAnalysisProcessingMixin:
     def _update_start_processing_button_state(self) -> None:
+        has_params = bool(getattr(self.master_app, "validated_params", None))
+        out_dir_obj = getattr(self.master_app, "save_folder_path", None)
+        has_out_dir = out_dir_obj is not None and getattr(out_dir_obj, "get", None) and out_dir_obj.get()
+
         all_valid = False
         if self.defined_groups:
             all_valid = all(
                 g.get('config_saved') and g.get('file_paths') and g.get('condition_mappings')
                 for g in self.defined_groups
             )
-        self.start_btn.setEnabled(all_valid)
+        self.start_btn.setEnabled(all_valid and has_params and has_out_dir)
 
     def _validate_processing_setup(self) -> Optional[tuple]:
         if not self.defined_groups:

--- a/tests/test_adv_processing_button_state.py
+++ b/tests/test_adv_processing_button_state.py
@@ -1,0 +1,111 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+def _import_module(monkeypatch):
+    dummy_core = types.SimpleNamespace(QObject=object, QThread=object, Signal=lambda *a, **k: object())
+    dummy_widgets = types.SimpleNamespace(QMessageBox=types.SimpleNamespace(critical=lambda *a, **k: None))
+    dummy_pyside = types.SimpleNamespace(QtCore=dummy_core, QtWidgets=dummy_widgets)
+    monkeypatch.setitem(sys.modules, "PySide6", dummy_pyside)
+    monkeypatch.setitem(sys.modules, "PySide6.QtCore", dummy_core)
+    monkeypatch.setitem(sys.modules, "PySide6.QtWidgets", dummy_widgets)
+
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Average_Preprocessing",
+        "advanced_analysis_qt_processing.py",
+    )
+
+    # Create minimal package structure so relative imports work
+    if "Tools" not in sys.modules:
+        sys.modules["Tools"] = types.ModuleType("Tools")
+    if "Tools.Average_Preprocessing" not in sys.modules:
+        pkg = types.ModuleType("Tools.Average_Preprocessing")
+        pkg.__path__ = []
+        sys.modules["Tools.Average_Preprocessing"] = pkg
+
+    if "Tools.Average_Preprocessing.advanced_analysis_core" not in sys.modules:
+        core_mod = types.ModuleType("Tools.Average_Preprocessing.advanced_analysis_core")
+        core_mod.run_advanced_averaging_processing = lambda *a, **k: None
+        sys.modules["Tools.Average_Preprocessing.advanced_analysis_core"] = core_mod
+
+    if "Main_App.post_process" not in sys.modules:
+        pp_mod = types.ModuleType("Main_App.post_process")
+        pp_mod.post_process = lambda *a, **k: None
+        sys.modules["Main_App.post_process"] = pp_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "Tools.Average_Preprocessing.adv_qt_proc",
+        path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+
+
+class DummyButton:
+    def __init__(self):
+        self.enabled = None
+
+    def setEnabled(self, val):
+        self.enabled = bool(val)
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, v):
+        self._value = v
+
+
+class DummyMaster:
+    def __init__(self):
+        self.validated_params = None
+        self.save_folder_path = DummyVar()
+
+
+def test_start_processing_button_state(monkeypatch):
+    module = _import_module(monkeypatch)
+    AdvancedAnalysisProcessingMixin = module.AdvancedAnalysisProcessingMixin
+
+    class DummyWin(AdvancedAnalysisProcessingMixin):
+        def __init__(self):
+            self.master_app = DummyMaster()
+            self.defined_groups = []
+            self.start_btn = DummyButton()
+
+    win = DummyWin()
+
+    # No params or output dir
+    win._update_start_processing_button_state()
+    assert win.start_btn.enabled is False
+
+    # Groups and output dir, but no params
+    win.defined_groups = [
+        {"config_saved": True, "file_paths": ["a"], "condition_mappings": [1]}
+    ]
+    win.master_app.save_folder_path.set("/tmp")
+    win._update_start_processing_button_state()
+    assert win.start_btn.enabled is False
+
+    # Params but missing output dir
+    win.master_app.validated_params = {"a": 1}
+    win.master_app.save_folder_path.set("")
+    win._update_start_processing_button_state()
+    assert win.start_btn.enabled is False
+
+    # All requirements met
+    win.master_app.save_folder_path.set("/tmp")
+    win._update_start_processing_button_state()
+    assert win.start_btn.enabled is True


### PR DESCRIPTION
## Summary
- refine `_update_start_processing_button_state` logic for both Tk and Qt advanced analysis modules
- refresh button state when output folder changes
- add regression test for start button enable rules

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795cbbf640832cba8737e336532fd6