### PR TITLE
Fix advanced averaging start validation

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
@@ -62,7 +62,6 @@ class _Worker(QObject):
 
 class AdvancedAnalysisProcessingMixin:
     def _update_start_processing_button_state(self) -> None:
-        has_params = bool(getattr(self.master_app, "validated_params", None))
         out_dir_obj = getattr(self.master_app, "save_folder_path", None)
         has_out_dir = out_dir_obj is not None and getattr(out_dir_obj, "get", None) and out_dir_obj.get()
 
@@ -72,7 +71,7 @@ class AdvancedAnalysisProcessingMixin:
                 g.get('config_saved') and g.get('file_paths') and g.get('condition_mappings')
                 for g in self.defined_groups
             )
-        self.start_btn.setEnabled(all_valid and has_params and has_out_dir)
+        self.start_btn.setEnabled(all_valid and has_out_dir)
 
     def _validate_processing_setup(self) -> Optional[tuple]:
         if not self.defined_groups:
@@ -91,20 +90,20 @@ class AdvancedAnalysisProcessingMixin:
                 QMessageBox.critical(self, "Error", f"Group '{group['name']}' has no mapping rules defined.")
                 self.groups_list.setCurrentRow(i)
                 return None
-        params = getattr(self.master_app, 'validated_params', None)
-        if not params:
-
-            ok = False
-            if hasattr(self.master_app, '_validate_inputs'):
-                try:
-                    ok = self.master_app._validate_inputs()
-                except Exception as e:  # pragma: no cover - user display
-                    QMessageBox.critical(self, "Error", f"Error validating main application inputs:\n{e}")
-                    return None
-                params = getattr(self.master_app, 'validated_params', None)
-            if not ok or not params:
-                QMessageBox.critical(self, "Error", "Main application parameters not set.")
+        ok = True
+        if hasattr(self.master_app, '_validate_inputs'):
+            try:
+                ok = self.master_app._validate_inputs()
+            except Exception as e:  # pragma: no cover - user display
+                QMessageBox.critical(self, "Error", f"Error validating main application inputs:\n{e}")
                 return None
+            params = getattr(self.master_app, 'validated_params', None)
+        else:
+            params = getattr(self.master_app, 'validated_params', None)
+
+        if not ok or not params:
+            QMessageBox.critical(self, "Error", "Main application parameters not set.")
+            return None
 
         out_obj = getattr(self.master_app, 'save_folder_path', None)
         if not out_obj or not hasattr(out_obj, 'get'):

--- a/tests/test_adv_processing_button_state.py
+++ b/tests/test_adv_processing_button_state.py
@@ -87,7 +87,7 @@ def test_start_processing_button_state(monkeypatch):
 
     win = DummyWin()
 
-    # No params or output dir
+    # No groups or output dir
     win._update_start_processing_button_state()
     assert win.start_btn.enabled is False
 
@@ -97,7 +97,7 @@ def test_start_processing_button_state(monkeypatch):
     ]
     win.master_app.save_folder_path.set("/tmp")
     win._update_start_processing_button_state()
-    assert win.start_btn.enabled is False
+    assert win.start_btn.enabled is True
 
     # Params but missing output dir
     win.master_app.validated_params = {"a": 1}


### PR DESCRIPTION
## Summary
- relax start button gating so validated_params aren't required beforehand
- always revalidate main application settings before starting advanced averaging
- update tests for new logic

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795b72c844832cb597704314bb13cd