### PR TITLE
Switch Qt logging to signal-slot

### DIFF
--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -1,48 +1,28 @@
-"""Mixin that timestamps and routes messages to the GUI and ``logging``.
+"""Qt-based logging mixin using signals and slots."""
+from __future__ import annotations
 
-The mixin writes messages to a Tk ``Text`` widget if present while also
-forwarding them through :mod:`logging` for console output. Debug messages
-are only shown when the global logging level allows them, which is
-controlled via ``debug_utils.configure_logging``.
-"""
 import logging
-import tkinter as tk
-import pandas as pd
+from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtWidgets import QPlainTextEdit
 
 logger = logging.getLogger(__name__)
 
 
-class LoggingMixin:
-    """Adds a timestamped logging function used across the toolbox."""
+class QtLoggingMixin(QObject):
+    """Provide a thread-safe logging mechanism for Qt widgets."""
 
-    def log(self, message: str, level: int = logging.INFO) -> None:
-        """Write ``message`` to the GUI log widget and :mod:`logging`."""
-        if tk is None:  # During interpreter shutdown ``tk`` may be ``None``
+    log_signal = Signal(str)
+
+    def __init__(self) -> None:  # pragma: no cover - GUI helper
+        super().__init__()
+        self.log_output: QPlainTextEdit | None = None
+        self.log_signal.connect(self._append_log)
+
+    @Slot(str)
+    def _append_log(self, msg: str) -> None:  # pragma: no cover - GUI helper
+        """Append ``msg`` to ``self.log_output`` and scroll to bottom."""
+        if self.log_output is None:
             return
-        ts = pd.Timestamp.now().strftime('%H:%M:%S.%f')[:-3]
-        formatted = f"{ts} [GUI]: {message}\n"
-
-        try:
-            if hasattr(self, 'log_text') and self.log_text and self.log_text.winfo_exists():
-                if level != logging.DEBUG or logger.isEnabledFor(logging.DEBUG):
-                    self.log_text.configure(state="normal")
-                    self.log_text.insert(tk.END, formatted)
-                    self.log_text.see(tk.END)
-                    self.log_text.configure(state="disabled")
-        except Exception as e:  # pragma: no cover - best effort logging
-            logger.exception("Error writing log message to GUI: %s", e)
-
-        if level == logging.DEBUG:
-            logger.debug(message)
-        elif level == logging.WARNING:
-            logger.warning(message)
-        elif level == logging.ERROR:
-            logger.error(message)
-        elif level == logging.CRITICAL:
-            logger.critical(message)
-        else:
-            logger.info(message)
-
-    def debug(self, message: str) -> None:
-        if logger.isEnabledFor(logging.DEBUG):
-            self.log(f"[DEBUG] {message}", level=logging.DEBUG)
+        self.log_output.appendPlainText(msg)
+        bar = self.log_output.verticalScrollBar()
+        bar.setValue(bar.maximum())

--- a/src/Tools/Average_Preprocessing/advanced_analysis_base.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_base.py
@@ -8,11 +8,6 @@ Users can group source files together, choose an averaging method and then
 initiate processing via :mod:`advanced_analysis_core`.
 """
 
-import tkinter as tk
-from tkinter import filedialog
-import customtkinter as ctk
-from customtkinter import CTkInputDialog
-import CTkMessagebox
 import os
 import json
 import glob

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_file_ops.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_file_ops.py
@@ -25,17 +25,19 @@ class AdvancedAnalysisFileOpsMixin:
         if added:
             self.source_eeg_files.sort()
             self._update_source_files_listbox()
-            self.log(f"Added {added} source file(s). Total: {len(self.source_eeg_files)}.")
+            self.log_signal.emit(
+                f"Added {added} source file(s). Total: {len(self.source_eeg_files)}."
+            )
 
     def remove_source_files(self) -> None:
         indices = [self.source_files_list.row(it) for it in self.source_files_list.selectedItems()]
         if not indices:
-            self.log("No source files selected to remove.")
+            self.log_signal.emit("No source files selected to remove.")
             return
         removed_paths = [self.source_eeg_files[i] for i in indices]
         self.source_eeg_files = [f for i, f in enumerate(self.source_eeg_files) if i not in indices]
         self._update_source_files_listbox()
-        self.log(f"Removed {len(removed_paths)} file(s) from source list.")
+        self.log_signal.emit(f"Removed {len(removed_paths)} file(s) from source list.")
         self._check_groups_for_removed_files(removed_paths)
 
     def _update_source_files_listbox(self) -> None:

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_group_ops.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_group_ops.py
@@ -17,14 +17,14 @@ class AdvancedAnalysisGroupOpsMixin:
     def create_new_group(self) -> None:
         name, ok = QInputDialog.getText(self, "New Averaging Group", "Group name:")
         if not ok or not name.strip():
-            self.log("Group creation cancelled.")
+            self.log_signal.emit("Group creation cancelled.")
             return
         if any(g['name'] == name for g in self.defined_groups):
             QMessageBox.critical(self, "Error", f"A group named '{name}' already exists.")
             return
         id_str, ok = QInputDialog.getText(self, "Event IDs", "IDs to average (comma separated):")
         if not ok or not id_str:
-            self.log("Group creation cancelled (no IDs).")
+            self.log_signal.emit("Group creation cancelled (no IDs).")
             return
         try:
             ids_to_average = [int(x.strip()) for x in id_str.split(',') if x.strip()]
@@ -55,7 +55,9 @@ class AdvancedAnalysisGroupOpsMixin:
         }
         self.defined_groups.append(new_group)
         self._update_groups_listbox()
-        self.log(f"Created group '{name}' averaging IDs {ids_to_average} in all {len(self.source_eeg_files)} files.")
+        self.log_signal.emit(
+            f"Created group '{name}' averaging IDs {ids_to_average} in all {len(self.source_eeg_files)} files."
+        )
         idx = len(self.defined_groups) - 1
         self.groups_list.setCurrentRow(idx)
         self.on_group_select()
@@ -64,14 +66,14 @@ class AdvancedAnalysisGroupOpsMixin:
     def delete_selected_group(self) -> None:
         row = self.groups_list.currentRow()
         if row < 0:
-            self.log("No group selected to delete.")
+            self.log_signal.emit("No group selected to delete.")
             return
         name = self.defined_groups[row]['name']
         if QMessageBox.question(self, "Confirm Delete", f"Delete group '{name}'?") != QMessageBox.Yes:
             return
         del self.defined_groups[row]
         self._update_groups_listbox()
-        self.log(f"Deleted group: {name}")
+        self.log_signal.emit(f"Deleted group: {name}")
         self.selected_group_index = None
         self._clear_group_config_display()
         self._update_start_processing_button_state()
@@ -79,7 +81,7 @@ class AdvancedAnalysisGroupOpsMixin:
     def rename_selected_group(self) -> None:
         row = self.groups_list.currentRow()
         if row < 0:
-            self.log("No group selected to rename.")
+            self.log_signal.emit("No group selected to rename.")
             return
         current = self.defined_groups[row]['name']
         new_name, ok = QInputDialog.getText(self, "Rename Group", f"Enter a new name for '{current}':")
@@ -91,7 +93,7 @@ class AdvancedAnalysisGroupOpsMixin:
         self.defined_groups[row]['name'] = new_name
         self.defined_groups[row]['config_saved'] = False
         self._update_groups_listbox()
-        self.log(f"Renamed group to '{new_name}'.")
+        self.log_signal.emit(f"Renamed group to '{new_name}'.")
 
     def _update_groups_listbox(self) -> None:
         current = self.groups_list.currentRow()
@@ -142,11 +144,11 @@ class AdvancedAnalysisGroupOpsMixin:
     def save_current_group_config(self) -> bool:
         idx = self.selected_group_index
         if idx is None:
-            self.log("No group selected to save configuration for.")
+            self.log_signal.emit("No group selected to save configuration for.")
             return False
         g = self.defined_groups[idx]
         g['config_saved'] = True
-        self.log(f"Configuration saved for group '{g['name']}'.")
+        self.log_signal.emit(f"Configuration saved for group '{g['name']}'.")
         self._update_groups_listbox()
         self.save_group_config_btn.setEnabled(False)
         self._update_start_processing_button_state()

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_post.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_post.py
@@ -44,7 +44,7 @@ class AdvancedAnalysisPostMixin:
         try:
             with open(file_path, "w", encoding="utf-8") as f:
                 json.dump(self.defined_groups, f, indent=2)
-            self.log(f"Saved group configuration to {file_path}.")
+            self.log_signal.emit(f"Saved group configuration to {file_path}.")
         except Exception as e:  # pragma: no cover - display error
             QMessageBox.critical(self, "Error", f"Failed to save configuration:\n{e}")
 
@@ -69,7 +69,9 @@ class AdvancedAnalysisPostMixin:
             self._update_groups_listbox()
             self._clear_group_config_display()
             self._update_start_processing_button_state()
-            self.log(f"Loaded {len(self.defined_groups)} group(s) from {file_path}.")
+            self.log_signal.emit(
+                f"Loaded {len(self.defined_groups)} group(s) from {file_path}."
+            )
         except Exception as e:  # pragma: no cover - display error
             QMessageBox.critical(self, "Error", f"Failed to load configuration:\n{e}")
 

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
@@ -113,7 +113,7 @@ class AdvancedAnalysisProcessingMixin:
         return params, output_directory
 
     def _launch_processing_thread(self, main_app_params: Dict[str, Any], output_directory: str) -> None:
-        self.log("Starting processing thread...")
+        self.log_signal.emit("Starting processing thread...")
         self.progress_bar.show()
         self.progress_bar.setValue(0)
         self.start_btn.setEnabled(False)
@@ -152,7 +152,7 @@ class AdvancedAnalysisProcessingMixin:
 
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
-        worker.log.connect(self.log)
+        worker.log.connect(self.log_signal.emit)
         worker.progress.connect(lambda v: self.progress_bar.setValue(int(v * 100)))
         worker.finished.connect(lambda: self._on_worker_finished(thread, worker))
         self._active_threads.append((thread, worker))
@@ -172,10 +172,10 @@ class AdvancedAnalysisProcessingMixin:
         self.progress_bar.hide()
         self._update_start_processing_button_state()
         self._stop_requested.clear()
-        self.log("Processing finished.")
+        self.log_signal.emit("Processing finished.")
 
     def start_advanced_processing(self) -> None:
-        self.log("Attempting to start advanced processing...")
+        self.log_signal.emit("Attempting to start advanced processing...")
         validation = self._validate_processing_setup()
         if not validation:
             return
@@ -185,10 +185,10 @@ class AdvancedAnalysisProcessingMixin:
     def stop_processing(self) -> None:
 
         if not self._active_threads:
-            self.log("Processing is not currently running.")
+            self.log_signal.emit("Processing is not currently running.")
             return
         self._stop_requested.set()
-        self.log("Stop requested. Waiting for processing to terminate...")
+        self.log_signal.emit("Stop requested. Waiting for processing to terminate...")
         self.stop_btn.setEnabled(False)
         for thread, _ in list(self._active_threads):
             thread.requestInterruption()


### PR DESCRIPTION
## Summary
- introduce QtLoggingMixin with signal/slot logging
- update advanced analysis Qt window to use QtLoggingMixin
- append log messages through signals
- remove all tkinter/customtkinter imports from Average_Preprocessing

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a51592c14832c9b485895eeb8cdd2