### PR TITLE
Fix missing LoggingMixin alias

### DIFF
--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -1,48 +1,14 @@
 
-"""Logging helpers for both Tkinter and Qt widgets."""
+"""Thread-safe logging mixin for Qt widgets."""
 from __future__ import annotations
 
 import logging
-import tkinter as tk
 from PySide6.QtCore import QObject, Signal, Slot
 from PySide6.QtWidgets import QPlainTextEdit
 import pandas as pd
 
 
 logger = logging.getLogger(__name__)
-
-
-class QtLoggingMixin(QObject):
-    """Provide a thread-safe logging mechanism for Qt widgets."""
-
-
-    def log(self, message: str, level: int = logging.INFO) -> None:
-        """Write ``message`` to the GUI log widget and :mod:`logging`."""
-        if tk is None:  # During interpreter shutdown ``tk`` may be ``None``
-            return
-        ts = pd.Timestamp.now().strftime('%H:%M:%S.%f')[:-3]
-        formatted = f"{ts} [GUI]: {message}\n"
-
-        try:
-            if hasattr(self, "log_text") and self.log_text and self.log_text.winfo_exists():
-                if level != logging.DEBUG or logger.isEnabledFor(logging.DEBUG):
-                    self.log_text.configure(state="normal")
-                    self.log_text.insert(tk.END, formatted)
-                    self.log_text.see(tk.END)
-                    self.log_text.configure(state="disabled")
-        except Exception as e:  # pragma: no cover - best effort logging
-            logger.exception("Error writing log message to GUI: %s", e)
-
-
-    def __init__(self) -> None:  # pragma: no cover - GUI helper
-        super().__init__()
-        self.log_output: QPlainTextEdit | None = None
-        self.log_signal.connect(self._append_log)
-
-
-    def debug(self, message: str) -> None:
-        if logger.isEnabledFor(logging.DEBUG):
-            self.log(f"[DEBUG] {message}", level=logging.DEBUG)
 
 
 class QtLoggingMixin(QObject):
@@ -55,6 +21,16 @@ class QtLoggingMixin(QObject):
         self.log_output: QPlainTextEdit | None = None
         self.log_signal.connect(self._append_log)
 
+    def log(self, message: str, level: int = logging.INFO) -> None:
+        """Emit ``message`` to the GUI log widget and :mod:`logging`."""
+        ts = pd.Timestamp.now().strftime("%H:%M:%S.%f")[:-3]
+        formatted = f"{ts} [GUI]: {message}"
+        logger.log(level, formatted)
+        self.log_signal.emit(formatted)
+
+    def debug(self, message: str) -> None:
+        if logger.isEnabledFor(logging.DEBUG):
+            self.log(f"[DEBUG] {message}", level=logging.DEBUG)
 
     @Slot(str)
     def _append_log(self, msg: str) -> None:  # pragma: no cover - GUI helper
@@ -64,3 +40,7 @@ class QtLoggingMixin(QObject):
         self.log_output.appendPlainText(msg)
         bar = self.log_output.verticalScrollBar()
         bar.setValue(bar.maximum())
+
+
+# Backwards compatibility with previous Tk-based code
+LoggingMixin = QtLoggingMixin

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -46,6 +46,7 @@ from Main_App.file_selection import FileSelectionMixin
 from Main_App.event_detection import EventDetectionMixin
 from Main_App.validation_mixins import ValidationMixin
 from Main_App.processing_utils import ProcessingMixin
+# ``LoggingMixin`` is provided by :class:`QtLoggingMixin` for the Qt port
 from Main_App.logging_mixin import LoggingMixin
 from Main_App import update_manager
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,10 +4,14 @@
 
 """Entry point for launching the FPVS Toolbox GUI application."""
 
-from ctypes import windll
-
 try:
-    windll.shcore.SetProcessDpiAwareness(1)
+    from ctypes import windll  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - non-Windows
+    windll = None
+
+try:  # pragma: no cover - best effort on Windows
+    if windll is not None:
+        windll.shcore.SetProcessDpiAwareness(1)
 except Exception:
     pass
 


### PR DESCRIPTION
## Summary
- cleanup Qt logging mixin
- alias `LoggingMixin` for backwards compat
- note Qt alias import in `fpvs_app`
- make `main.py` handle non-Windows platforms

## Testing
- `ruff check ./src`
- `python src/main.py` *(fails: ModuleNotFoundError: No module named 'customtkinter')*

------
https://chatgpt.com/codex/tasks/task_e_687a561f95fc832ca22800553b7986d5