### PR TITLE
Fix Qt double-init issue in advanced analysis

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_base.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_base.py
@@ -36,7 +36,7 @@ class AdvancedAnalysisWindowBase(QDialog, QtLoggingMixin):
     """Base dialog containing common UI for advanced averaging."""
 
     def __init__(self, master) -> None:
-        QDialog.__init__(self, None)
+        super().__init__(parent=None)
         QtLoggingMixin.__init__(self)
 
         self.master_app = master


### PR DESCRIPTION
## Summary
- avoid calling `QDialog.__init__` directly when creating `AdvancedAnalysisWindowBase`
- stop calling `QObject.__init__` from `QtLoggingMixin`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6b1796b0832ca0ff1c35f0722ae5