### PR TITLE
Fix QObject init for logging mixin

### DIFF
--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -16,9 +16,8 @@ class QtLoggingMixin(QObject):
 
     log_signal = Signal(str)
 
-    def __init__(self) -> None:  # pragma: no cover - GUI helper
-        # Avoid calling :class:`QObject`'s initializer directly to prevent
-        # double initialization when used alongside Qt widgets.
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - GUI helper
+        super().__init__(*args, **kwargs)
         self.log_output: QPlainTextEdit | None = None
 
         if not getattr(self, "_connected", False):

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -82,7 +82,7 @@ ctk.set_appearance_mode("System")
 ctk.set_default_color_theme("blue")
 
 
-class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
+class FPVSApp(LoggingMixin, ctk.CTk, EventMapMixin, FileSelectionMixin,
               EventDetectionMixin, ValidationMixin, ProcessingMixin):
 
     """ Main application class replicating MATLAB FPVS analysis workflow using numerical triggers. """


### PR DESCRIPTION
## Summary
- properly initialize `LoggingMixin` as a QObject
- ensure the mixin is first in `FPVSApp` MRO

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6d441d78832cbd3899ec6a82290f