### PR TITLE
Ensure bool for start processing button

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
@@ -63,7 +63,11 @@ class _Worker(QObject):
 class AdvancedAnalysisProcessingMixin:
     def _update_start_processing_button_state(self) -> None:
         out_dir_obj = getattr(self.master_app, "save_folder_path", None)
-        has_out_dir = out_dir_obj is not None and getattr(out_dir_obj, "get", None) and out_dir_obj.get()
+        has_out_dir = bool(
+            out_dir_obj
+            and getattr(out_dir_obj, "get", None)
+            and out_dir_obj.get()
+        )
 
         all_valid = False
         if self.defined_groups:

--- a/tests/test_adv_processing_button_state.py
+++ b/tests/test_adv_processing_button_state.py
@@ -55,7 +55,9 @@ class DummyButton:
         self.enabled = None
 
     def setEnabled(self, val):
-        self.enabled = bool(val)
+        if not isinstance(val, bool):
+            raise TypeError("setEnabled expected a bool")
+        self.enabled = val
 
 
 class DummyVar:


### PR DESCRIPTION
## Summary
- fix `_update_start_processing_button_state` to explicitly cast the output directory status to `bool`
- tighten test helper so `setEnabled` requires a boolean

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_687a9953c75c832cbe8e1a1606563aed