### PR TITLE
Decouple advanced analysis logging

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_base.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_base.py
@@ -51,8 +51,8 @@ class AdvancedAnalysisWindowBase(QtLoggingMixin, QDialog):
         self._stop_requested = threading.Event()
         self._active_threads: List[tuple] = []
 
-        if hasattr(self.master_app, "log"):
-            self.log_signal.connect(lambda m: self.master_app.log(f"[AdvAnalysis] {m}"))
+        # Do not forward log messages to the main application; keep them local
+        # to this window's log output.
 
         self._build_ui()
         self._populate_default_eeg_files()

--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_processing.py
@@ -139,7 +139,11 @@ class AdvancedAnalysisProcessingMixin:
             from Main_App.eeg_preprocessing import perform_preprocessing as _pp
 
             def preprocess_raw_method(raw, **params):
-                return _pp(raw_input=raw, params=params, log_func=self.master_app.log)[0]
+                return _pp(
+                    raw_input=raw,
+                    params=params,
+                    log_func=self.log_signal.emit,
+                )[0]
 
 
         thread = QThread()


### PR DESCRIPTION
## Summary
- ensure Advanced Analysis Qt window does not forward logs to FPVSApp
- use the window log signal in preprocessing fallback

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aa18b2be4832ca66a1cb4c6444f50