### PR TITLE
Improve error group name logging

### DIFF
--- a/src/Tools/Average_Preprocessing/advanced_analysis_qt_group_ops.py
+++ b/src/Tools/Average_Preprocessing/advanced_analysis_qt_group_ops.py
@@ -89,8 +89,9 @@ class AdvancedAnalysisGroupOpsMixin:
             self._update_start_processing_button_state()
         except Exception as exc:  # pragma: no cover - runtime guard
             logger.exception("Unhandled error creating new group")
+            group_name = locals().get("name", "<unknown>")
             self.log_signal.emit(
-                f"!!! Error creating group '{name}': {exc}\n{traceback.format_exc()}"
+                f"!!! Error creating group '{group_name}': {exc}\n{traceback.format_exc()}"
             )
 
     def delete_selected_group(self) -> None:


### PR DESCRIPTION
## Summary
- make error log show group name when unknown

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaaf160d4832ca020cc29a1acf2e6