### PR TITLE
Update QtLoggingMixin.debug to log to Python logging module

### DIFF
--- a/src/Main_App/logging_mixin.py
+++ b/src/Main_App/logging_mixin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from PySide6.QtCore import QObject, Signal, Slot
 from PySide6.QtGui import QTextCursor
+import logging
 
 from .settings_manager import SettingsManager
 
@@ -37,6 +38,7 @@ class QtLoggingMixin:
     def debug(self, message: str) -> None:
         if getattr(self, "debug_mode", False):
             self.log_signal.emit(f"[DEBUG] {message}")
+            logging.getLogger(type(self).__module__).debug(message)
 
 
 LoggingMixin = QtLoggingMixin


### PR DESCRIPTION
## Summary
- import `logging` in `QtLoggingMixin`
- send debug messages to the module logger while keeping log widget behaviour

## Testing
- `ruff check src/Main_App/logging_mixin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaaf0f4c8832caf6636e24183d0b2