### PR TITLE
Add minimal PySide6 MainWindow

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from PySide6 import QtWidgets
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Minimal window displaying a blank label."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("FPVS Toolbox")
+
+        label = QtWidgets.QLabel("")
+        label.setAlignment(QtWidgets.Qt.AlignmentFlag.AlignCenter)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addWidget(label)
+        self.setCentralWidget(central)
+
+
+def main() -> None:
+    app = QtWidgets.QApplication([])
+    window = MainWindow()
+    window.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
 # main.py
 
 #!/usr/bin/env python3
+# ruff: noqa: E402
 
 """Entry point for launching the FPVS Toolbox GUI application."""
+
+USE_PYSIDE6 = True
 
 from ctypes import windll
 
@@ -11,33 +14,48 @@ try:
 except Exception:
     pass
 
-from fpvs_app import FPVSApp
-from Main_App.debug_utils import configure_logging, get_settings, install_messagebox_logger
-import multiprocessing
-import sys
+if USE_PYSIDE6:
+    try:
+        from PySide6.QtWidgets import QApplication
+        from Main_App.GUI.main_window import MainWindow
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise ImportError(
+            "PySide6 not installed; install with 'pip install PySide6'"
+        ) from exc
+else:
+    from fpvs_app import FPVSApp
+    from Main_App.debug_utils import configure_logging, get_settings, install_messagebox_logger
+    import multiprocessing
+    import sys
 
 def main() -> None:
     """Entry point for running the FPVS Toolbox or its sub-tools."""
-    multiprocessing.freeze_support()
+    if USE_PYSIDE6:
+        app = QApplication([])
+        window = MainWindow()
+        window.show()
+        app.exec()
+    else:
+        multiprocessing.freeze_support()
 
-    if "--run-image-resizer" in sys.argv:
-        from Tools.Image_Resizer import pyside_resizer
+        if "--run-image-resizer" in sys.argv:
+            from Tools.Image_Resizer import pyside_resizer
 
-        pyside_resizer.main()
-        return
+            pyside_resizer.main()
+            return
 
-    if "--run-plot-generator" in sys.argv:
-        from Tools.Plot_Generator import plot_generator
+        if "--run-plot-generator" in sys.argv:
+            from Tools.Plot_Generator import plot_generator
 
-        plot_generator.main()
-        return
+            plot_generator.main()
+            return
 
-    settings = get_settings()
-    debug = settings.debug_enabled()
-    configure_logging(debug)
-    install_messagebox_logger(debug)
-    app = FPVSApp()
-    app.mainloop()
+        settings = get_settings()
+        debug = settings.debug_enabled()
+        configure_logging(debug)
+        install_messagebox_logger(debug)
+        app = FPVSApp()
+        app.mainloop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement a basic MainWindow for PySide6
- add a USE_PYSIDE6 toggle in main.py with switchable launching logic

## Testing
- `ruff check src/main.py`
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eaf039c74832c9ecb4e77f255a910