### PR TITLE
Rewrite menu bar using PySide6

### DIFF
--- a/src/Main_App/menu_bar.py
+++ b/src/Main_App/menu_bar.py
@@ -1,72 +1,58 @@
-# src/Main_App/menu_bar.py
-# -*- coding: utf-8 -*-
-"""
-Handles the creation and command linking for the main application menu bar
-of the FPVS Toolbox.
-"""
-import tkinter as tk
-# Note: Other imports like webbrowser, messagebox, etc., are not needed here
-# if the command methods themselves remain in the main FPVSApp class.
-from Main_App.eloreta_launcher import open_eloreta_tool
+"""Menu bar creation utilities for the FPVS Toolbox main window."""
 
-class AppMenuBar:
-    def __init__(self, app_reference):
-        """
-        Initializes the AppMenuBar.
+from __future__ import annotations
 
-        Args:
-            app_reference: A reference to the main FPVSApp instance.
-                           This allows menu commands to call methods on the main app.
-        """
-        self.app_ref = app_reference
+from PySide6.QtWidgets import QAction, QMainWindow, QMenu, QMenuBar
 
-    def populate_menu(self, menubar_widget):
-        """
-        Creates and populates the menu bar structure onto the provided menubar_widget.
+__all__ = ["build_menu_bar"]
 
-        Args:
-            menubar_widget: The tk.Menu widget created in the main app
-                            (e.g., self.menubar in FPVSApp).
-        """
-        # === File menu ===
-        file_menu = tk.Menu(menubar_widget, tearoff=0)
-        menubar_widget.add_cascade(label="File", menu=file_menu)
 
-        file_menu.add_command(label="Settings", command=self.app_ref.open_settings_window)
+def build_menu_bar(parent: QMainWindow) -> QMenuBar:
+    """Create and return the application's menu bar.
 
-        file_menu.add_separator()
-        file_menu.add_command(label="Check for Updates", command=self.app_ref.check_for_updates)
-        file_menu.add_separator()
-        file_menu.add_command(label="Exit", command=self.app_ref.quit) # Calls quit method on main app
+    Parameters
+    ----------
+    parent : QMainWindow
+        Main window that will own the returned :class:`QMenuBar`.
 
-        # === Tools menu ===
-        tools_menu = tk.Menu(menubar_widget, tearoff=0)
-        menubar_widget.add_cascade(label="Tools", menu=tools_menu)
-        tools_menu.add_command(label="Stats Toolbox", command=self.app_ref.open_stats_analyzer)
-        tools_menu.add_separator()
-        tools_menu.add_command(
-            label="Source Localization (eLORETA/sLORETA)",
-            command=lambda: open_eloreta_tool(self.app_ref),
-        )
-        tools_menu.add_separator()
-        tools_menu.add_command(label="Image Resizer", command=self.app_ref.open_image_resizer)
-        tools_menu.add_separator()
-        tools_menu.add_command(
-            label="Generate SNR Plots",
-            command=self.app_ref.open_plot_generator,
-        )
-        tools_menu.add_separator()
-        tools_menu.add_command(
-            label="Average Epochs in Pre-Processing Phase",
-            command=self.app_ref.open_advanced_analysis_window,
-        )
+    Returns
+    -------
+    QMenuBar
+        The fully constructed menu bar with File, Tools and Help menus.
+    """
+    menu_bar = QMenuBar(parent)
+    parent.setMenuBar(menu_bar)
 
-        # === Help menu ===
-        help_menu = tk.Menu(menubar_widget, tearoff=0)
-        menubar_widget.add_cascade(label="Help", menu=help_menu)
-        help_menu.add_command(
-            label="Relevant Publications",
-            command=self.app_ref.show_relevant_publications,
-        )
-        help_menu.add_separator()
-        help_menu.add_command(label="About...", command=self.app_ref.show_about_dialog)
+    # === File menu ===
+    file_menu = QMenu("File", menu_bar)
+    menu_bar.addMenu(file_menu)
+
+    file_menu.addAction(QAction("Settings", parent))
+    file_menu.addSeparator()
+    file_menu.addAction(QAction("Check for Updates", parent))
+    file_menu.addSeparator()
+    file_menu.addAction(QAction("Exit", parent))
+
+    # === Tools menu ===
+    tools_menu = QMenu("Tools", menu_bar)
+    menu_bar.addMenu(tools_menu)
+
+    tools_menu.addAction(QAction("Stats Toolbox", parent))
+    tools_menu.addSeparator()
+    tools_menu.addAction(QAction("Source Localization (eLORETA/sLORETA)", parent))
+    tools_menu.addSeparator()
+    tools_menu.addAction(QAction("Image Resizer", parent))
+    tools_menu.addSeparator()
+    tools_menu.addAction(QAction("Generate SNR Plots", parent))
+    tools_menu.addSeparator()
+    tools_menu.addAction(QAction("Average Epochs in Pre-Processing Phase", parent))
+
+    # === Help menu ===
+    help_menu = QMenu("Help", menu_bar)
+    menu_bar.addMenu(help_menu)
+
+    help_menu.addAction(QAction("Relevant Publications", parent))
+    help_menu.addSeparator()
+    help_menu.addAction(QAction("About...", parent))
+
+    return menu_bar


### PR DESCRIPTION
## Summary
- reimplement `menu_bar.py` using PySide6
- expose `build_menu_bar(parent: QMainWindow) -> QMenuBar`

## Testing
- `ruff check src/Main_App/menu_bar.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb541f8ac832c9d4ca6e6e763669d