### PR TITLE
Ensure debug label visible only when enabled

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -64,6 +64,7 @@ class MainWindow(QMainWindow):
         self.btn_start = QPushButton("Start Processing", self)
         self.lbl_debug = QLabel("DEBUG MODE ENABLED", self)
         self.lbl_debug.setStyleSheet("color: red;")
+        self.lbl_debug.setVisible(self.settings.debug_enabled())
         for w in (
             self.btn_open_eeg,
             self.btn_open_output,
@@ -226,6 +227,7 @@ class MainWindow(QMainWindow):
         dlg = SettingsDialog(self.settings, self)
         self._settings_dialog = dlg
         dlg.exec()
+        self.lbl_debug.setVisible(self.settings.debug_enabled())
         self._settings_dialog = None
 
     def check_for_updates(self) -> None:


### PR DESCRIPTION
## Summary
- hide `DEBUG MODE ENABLED` label when debug mode is disabled
- update label visibility after closing the Settings dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa8fc14b8832c9067d86c6ff3a5df