### PR TITLE
Ensure debug label visible only when enabled

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -64,6 +64,7 @@ class MainWindow(QMainWindow):
         self.btn_start = QPushButton("Start Processing", self)
         self.lbl_debug = QLabel("DEBUG MODE ENABLED", self)
         self.lbl_debug.setStyleSheet("color: red;")
+        self.lbl_debug.setVisible(self.settings.debug_enabled())
         for w in (
             self.btn_open_eeg,
             self.btn_open_output,
@@ -226,6 +227,7 @@ class MainWindow(QMainWindow):
         dlg = SettingsDialog(self.settings, self)
         self._settings_dialog = dlg
         dlg.exec()
+        self.lbl_debug.setVisible(self.settings.debug_enabled())
         self._settings_dialog = None
 
     def check_for_updates(self) -> None:

--- a/src/Main_App/GUI/settings_panel.py
+++ b/src/Main_App/GUI/settings_panel.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QDialogButtonBox,
     QFileDialog,
+    QMessageBox,
 )
 
 from Main_App.settings_manager import SettingsManager
@@ -260,8 +261,17 @@ class SettingsDialog(QDialog):
         self.manager.set("loreta", "time_window_end_ms", self.t_end_edit.text())
         self.manager.set("visualization", "time_index_ms", self.display_time_edit.text())
         self.manager.set("loreta", "auto_oddball_localization", str(self.auto_loc_check.isChecked()))
+
+        prev_debug = self.manager.debug_enabled()
         self.manager.set("debug", "enabled", str(self.debug_check.isChecked()))
         self.manager.save()
+
+        if not prev_debug and self.manager.debug_enabled():
+            QMessageBox.information(
+                self,
+                "Debug Mode Enabled",
+                "Debug mode enabled. Please close and reopen FPVS Toolbox for changes to take effect.",
+            )
 
         try:
             from Tools.Stats.stats_helpers import load_rois_from_settings, apply_rois_to_modules


### PR DESCRIPTION
## Summary
- hide `DEBUG MODE ENABLED` label when debug mode is disabled
- update label visibility after closing the Settings dialog
- warn users they must restart after enabling debug mode

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa8fc14b8832c9067d86c6ff3a5df