### PR TITLE
Fix GUI subtool launching

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -256,14 +256,14 @@ class MainWindow(QMainWindow):
     def open_image_resizer(self) -> None:
         cmd = [sys.executable]
         if not getattr(sys, "frozen", False):
-            cmd.append(str(Path(__file__).resolve().parent.parent / "main.py"))
+            cmd.append(str(Path(__file__).resolve().parents[2] / "main.py"))
         cmd.append("--run-image-resizer")
         subprocess.Popen(cmd, close_fds=True)
 
     def open_plot_generator(self) -> None:
         cmd = [sys.executable]
         if not getattr(sys, "frozen", False):
-            cmd.append(str(Path(__file__).resolve().parent.parent / "main.py"))
+            cmd.append(str(Path(__file__).resolve().parents[2] / "main.py"))
         cmd.append("--run-plot-generator")
         subprocess.Popen(cmd, close_fds=True)
 


### PR DESCRIPTION
## Summary
- fix subprocess path for image resizer and plot generator so that they target src/main.py

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb4b4b7e8832c9ae341505f8c4c3a