### PR TITLE
Modernize PySide6 GUI

### DIFF
--- a/src/Main_App/GUI/settings_panel.py
+++ b/src/Main_App/GUI/settings_panel.py
@@ -5,11 +5,11 @@ from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QFormLayout,
+    QGridLayout,
     QLineEdit,
     QPushButton,
     QLabel,
     QHBoxLayout,
-    QDialog,
     QTabWidget,
     QComboBox,
     QCheckBox,
@@ -66,8 +66,8 @@ class SettingsPanel(QWidget):
         self.settings_canceled.emit()
 
 
-class SettingsDialog(QDialog):
-    """Dialog for editing application settings via :class:`SettingsManager`."""
+class SettingsDialog(QWidget):
+    """Widget for editing application settings via :class:`SettingsManager`."""
 
     def __init__(self, manager: SettingsManager, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -88,11 +88,12 @@ class SettingsDialog(QDialog):
         self._init_stats_tab(tabs)
         self._init_oddball_tab(tabs)
         self._init_loreta_tab(tabs)
+        self._init_preproc_tab(tabs)
 
         btn_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         layout.addWidget(btn_box)
         btn_box.accepted.connect(self._save)
-        btn_box.rejected.connect(self.reject)
+        btn_box.rejected.connect(lambda: None)
 
     # ------------------------------------------------------------------
     def _init_general_tab(self, tabs: QTabWidget) -> None:
@@ -219,6 +220,48 @@ class SettingsDialog(QDialog):
         tabs.addTab(tab, "LORETA")
 
     # ------------------------------------------------------------------
+    def _init_preproc_tab(self, tabs: QTabWidget) -> None:
+        tab = QWidget()
+        grid = QGridLayout(tab)
+        params = [
+            "Low Pass (Hz):",
+            "High Pass (Hz):",
+            "Downsample (Hz):",
+            "Epoch Start (s):",
+            "Rejection Z-Thresh:",
+            "Epoch End (s):",
+            "Ref Chan 1:",
+            "Ref Chan 2:",
+            "Max Chan Idx Keep:",
+            "Max Bad Chans (Flag):",
+        ]
+        self.pre_edits = []
+        defaults = [
+            ("preprocessing", "low_pass", "0.1"),
+            ("preprocessing", "high_pass", "50"),
+            ("preprocessing", "downsample", "256"),
+            ("preprocessing", "epoch_start", "-1"),
+            ("preprocessing", "reject_thresh", "5"),
+            ("preprocessing", "epoch_end", "125"),
+            ("preprocessing", "ref_chan1", "EXG1"),
+            ("preprocessing", "ref_chan2", "EXG2"),
+            ("preprocessing", "max_idx_keep", "64"),
+            ("preprocessing", "max_bad_chans", "10"),
+        ]
+        for i, (label, (sec, opt, fb)) in enumerate(zip(params, defaults)):
+            row, col = divmod(i, 2)
+            grid.addWidget(QLabel(label), row, col * 2)
+            edit = QLineEdit(self.manager.get(sec, opt, fb))
+            self.pre_edits.append(edit)
+            grid.addWidget(edit, row, col * 2 + 1)
+        self.cb_save_fif = QCheckBox("Save Preprocessed .fif")
+        self.cb_save_fif.setChecked(
+            self.manager.get("paths", "save_fif", "False").lower() == "true"
+        )
+        grid.addWidget(self.cb_save_fif, 5, 0, 1, 4)
+        tabs.addTab(tab, "Preprocessing")
+
+    # ------------------------------------------------------------------
     def _with_browse(self, edit: QLineEdit) -> QWidget:
         container = QWidget()
         layout = QHBoxLayout(container)
@@ -251,6 +294,21 @@ class SettingsDialog(QDialog):
         self.manager.set("analysis", "bca_upper_limit", self.bca_limit_edit.text())
         self.manager.set("analysis", "alpha", self.alpha_edit.text())
         self.manager.set_roi_pairs(self.roi_editor.get_pairs())
+        pre_keys = [
+            ("preprocessing", "low_pass"),
+            ("preprocessing", "high_pass"),
+            ("preprocessing", "downsample"),
+            ("preprocessing", "epoch_start"),
+            ("preprocessing", "reject_thresh"),
+            ("preprocessing", "epoch_end"),
+            ("preprocessing", "ref_chan1"),
+            ("preprocessing", "ref_chan2"),
+            ("preprocessing", "max_idx_keep"),
+            ("preprocessing", "max_bad_chans"),
+        ]
+        for edit, (sec, opt) in zip(self.pre_edits, pre_keys):
+            self.manager.set(sec, opt, edit.text())
+        self.manager.set("paths", "save_fif", str(self.cb_save_fif.isChecked()))
         self.manager.set("loreta", "mri_path", self.mri_edit.text())
         self.manager.set("loreta", "loreta_low_freq", self.low_freq_edit.text())
         self.manager.set("loreta", "loreta_high_freq", self.high_freq_edit.text())
@@ -295,4 +353,4 @@ class SettingsDialog(QDialog):
         except Exception:
             pass
 
-        self.accept()
+        # Settings page does not close

--- a/src/qdark_sidebar.qss
+++ b/src/qdark_sidebar.qss
@@ -1,11 +1,18 @@
+/* Global Dark Theme */
+QWidget, QMainWindow, QMenuBar, QToolBar, QStatusBar, QDialog, QGroupBox {
+  background-color: #212121;
+  color: #EEEEEE;
+}
+/* Sidebar */
 QWidget#sidebar {
   background-color: #212121;
 }
 QWidget#sidebar QToolButton {
-  color: #EEEEEE;
+  color: #FFFFFF;
   background: transparent;
   border: none;
   padding: 12px 16px;
+  qproperty-iconSize: 24px 24px;
   text-align: left;
   font: 11pt "Segoe UI";
 }


### PR DESCRIPTION
## Summary
- implement global dark theme styles
- refactor `MainWindow` to use sidebar navigation with `QStackedWidget`
- move preprocessing controls to the settings page
- provide placeholder pages for future tools

## Testing
- `ruff check src/Main_App/GUI/main_window.py src/Main_App/GUI/settings_panel.py`
- `pytest -k test_config_freqs -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc60a55fc832cb859a6b1190ee8c9