### PR TITLE
Fix File menu lookup

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -77,11 +77,6 @@ class MainWindow(QMainWindow):
         # Menu bar
         menu = build_menu_bar(self)
         self.setMenuBar(menu)
-        # Keep a reference to the File menu so it isn't destroyed
-        if menu.actions():
-            self.file_menu = menu.actions()[0].menu()
-        else:
-            self.file_menu = None
 
         # Top toolbar
         toolbar = QToolBar(self)
@@ -312,13 +307,9 @@ class MainWindow(QMainWindow):
         if not menu_bar:
             return
 
-        file_menu = getattr(self, "file_menu", None)
+        file_menu = menu_bar.findChild(QMenu, "fileMenu")
         if file_menu is None:
-            actions = menu_bar.actions()
-            if not actions:
-                return
-            file_menu = actions[0].menu()
-            self.file_menu = file_menu
+            return
 
         file_menu.clear()
 

--- a/src/Main_App/GUI/menu_bar.py
+++ b/src/Main_App/GUI/menu_bar.py
@@ -11,6 +11,7 @@ def build_menu_bar(parent: QMainWindow) -> QMenuBar:
 
     # File
     file_menu = menu_bar.addMenu("File")
+    file_menu.setObjectName("fileMenu")
     for text, slot in [
         ("Settings",         parent.open_settings_window),
         ("Check for Updates", parent.check_for_updates),


### PR DESCRIPTION
## Summary
- assign name to File menu when building menu bar
- stop storing `self.file_menu`
- find the File menu dynamically when configuring actions

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880ea283280832c87e981d353b5287f