### PR TITLE
Persist projects root across sessions

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -69,21 +69,23 @@ class MainWindow(QMainWindow):
         self._init_sidebar()
 
         settings = QSettings()
-        projects_root = settings.value("paths/projectsRoot", "", type=str)
-        if not projects_root:
-            projects_root = QFileDialog.getExistingDirectory(
+        saved_root = settings.value("paths/projectsRoot", "", type=str)
+        if saved_root and Path(saved_root).is_dir():
+            self.projectsRoot = Path(saved_root)
+        else:
+            root = QFileDialog.getExistingDirectory(
                 self, "Select Projects Root Folder", ""
             )
-            if not projects_root:
+            if not root:
                 QMessageBox.critical(
                     self,
                     "Projects Root Required",
                     "You must select a Projects Root folder to continue.",
                 )
                 sys.exit(1)
-            settings.setValue("paths/projectsRoot", projects_root)
+            settings.setValue("paths/projectsRoot", root)
             settings.sync()
-        self.projectsRoot = Path(projects_root)
+            self.projectsRoot = Path(root)
 
         self._init_file_menu()
         self.log("Welcome to the FPVS Toolbox!")
@@ -612,7 +614,7 @@ class MainWindow(QMainWindow):
         # Update header
         self.lbl_currentProject.setText(f"Current Project: {project.name}")
 
-        self.settings.set("paths", "data_folder", project.input_folder)
+        self.settings.set("paths", "data_folder", str(project.input_folder))
         self.settings.save()
 
         # Processing Options

--- a/src/Main_App/GUI/settings_panel.py
+++ b/src/Main_App/GUI/settings_panel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Signal, QSettings
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -91,6 +91,10 @@ class SettingsDialog(QDialog):
         self._init_stats_tab(tabs)
         self._init_oddball_tab(tabs)
         self._init_loreta_tab(tabs)
+
+        self.btn_changeRoot = QPushButton("Change Projects Root…", self)
+        self.btn_changeRoot.clicked.connect(self.changeProjectsRoot)
+        layout.addWidget(self.btn_changeRoot)
 
         btn_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         layout.addWidget(btn_box)
@@ -289,6 +293,24 @@ class SettingsDialog(QDialog):
         folder = QFileDialog.getExistingDirectory(self, "Select Folder", edit.text() or "")
         if folder:
             edit.setText(folder)
+
+    # ------------------------------------------------------------------
+    def changeProjectsRoot(self) -> None:
+        settings = QSettings()
+        root = QFileDialog.getExistingDirectory(
+            self,
+            "Select Projects Root Folder",
+            settings.value("paths/projectsRoot", ""),
+        )
+        if not root:
+            return
+        settings.setValue("paths/projectsRoot", root)
+        settings.sync()
+        QMessageBox.information(
+            self,
+            "Projects Root Updated",
+            f"New Projects Root: {root}",
+        )
 
     # ------------------------------------------------------------------
     def _save(self) -> None:


### PR DESCRIPTION
## Summary
- prompt for projects root only when necessary
- allow changing projects root from settings dialog
- avoid saving Path objects in settings

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688101637414832cad484844cf28e354