### PR TITLE
Persist Projects Root once via QSettings

### DIFF
--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -69,7 +69,10 @@ class MainWindow(QMainWindow):
         self._init_sidebar()
 
         settings = QSettings()
-        saved_root = settings.value("paths/projectsRoot", "", type=str)
+        settings.beginGroup("paths")
+        saved_root = settings.value("projectsRoot", "", type=str)
+        settings.endGroup()
+
         if saved_root and Path(saved_root).is_dir():
             self.projectsRoot = Path(saved_root)
         else:
@@ -83,9 +86,11 @@ class MainWindow(QMainWindow):
                     "You must select a Projects Root folder to continue.",
                 )
                 sys.exit(1)
-            settings.setValue("paths/projectsRoot", root)
-            settings.sync()
             self.projectsRoot = Path(root)
+            settings.beginGroup("paths")
+            settings.setValue("projectsRoot", str(self.projectsRoot))
+            settings.endGroup()
+            settings.sync()
 
         self._init_file_menu()
         self.log("Welcome to the FPVS Toolbox!")

--- a/src/main.py
+++ b/src/main.py
@@ -9,11 +9,16 @@ USE_PYSIDE6 = True
 
 from ctypes import windll
 import sys
+from PySide6.QtCore import QCoreApplication
 
 try:
     windll.shcore.SetProcessDpiAwareness(1)
 except Exception:
     pass
+
+QCoreApplication.setOrganizationName("MississippiStateUniversity")
+QCoreApplication.setOrganizationDomain("msstate.edu")
+QCoreApplication.setApplicationName("FPVS Toolbox")
 
 if USE_PYSIDE6:
     try:


### PR DESCRIPTION
## Summary
- configure `QSettings` with application metadata
- store/retrieve the projects root folder once using QSettings

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688103adb964832c8c3748b4c6989854