### PR TITLE
Fix missing processing module

### DIFF
--- a/src/Main_App/Backend/processing.py
+++ b/src/Main_App/Backend/processing.py
@@ -1,0 +1,26 @@
+"""Legacy data processing entry point.
+
+This module exposes the ``process_data`` function used by the
+PySide6 GUI. The original implementation resided under a
+``Main_App.Processing`` package which no longer exists. The
+function here provides a stub interface so that the GUI can import
+it without raising ``ImportError``.
+"""
+
+from __future__ import annotations
+
+def process_data(input_dir: str, output_dir: str, run_loreta: bool) -> None:
+    """Process EEG data using the legacy pipeline.
+
+    Parameters
+    ----------
+    input_dir : str
+        Path to the directory containing raw data files.
+    output_dir : str
+        Destination directory for processed results.
+    run_loreta : bool
+        Whether to run LORETA source localization.
+    """
+
+    # Placeholder for the removed legacy implementation
+    pass

--- a/src/Main_App/GUI/main_window.py
+++ b/src/Main_App/GUI/main_window.py
@@ -40,7 +40,7 @@ from Main_App.GUI.menu_bar import build_menu_bar
 from Main_App.GUI.settings_panel import SettingsDialog
 from Main_App.settings_manager import SettingsManager
 from Main_App.Backend.project import Project
-from Main_App.Processing.processing import process_data
+from Main_App.Backend.processing import process_data
 class Processor(QObject):
     """Minimal processing stub emitting progress updates."""
 


### PR DESCRIPTION
## Summary
- add stub processing module under Main_App.Backend
- fix import path in new GUI

## Testing
- `ruff check src/Main_App/Backend/processing.py src/Main_App/GUI/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688117aacbbc832c9cf06b7afc336019