### PR TITLE
Fix MainWindow import path

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -36,15 +36,15 @@ import pandas as pd
 from pathlib import Path
 import subprocess
 import sys
-from Main_App import build_menu_bar
-from Main_App import SettingsDialog
-from Main_App import SettingsManager
-from Main_App import Project
-from Main_App import load_eeg_file
-from Main_App import preprocess_raw
-from Main_App import perform_preprocessing
-from Main_App import process_data
-from Main_App import post_process
+from .menu_bar import build_menu_bar
+from .settings_panel import SettingsDialog
+from Main_App.Legacy_App.settings_manager import SettingsManager
+from Main_App.PySide6_App.Backend import Project
+from Main_App.Legacy_App.load_utils import load_eeg_file
+from Main_App.Legacy_App.app_logic import preprocess_raw
+from Main_App.Legacy_App.eeg_preprocessing import perform_preprocessing
+from Main_App.PySide6_App.Backend.processing import process_data
+from Main_App.Legacy_App.post_process import post_process
 class Processor(QObject):
     """Minimal processing stub emitting progress updates."""
 

--- a/src/Main_App/PySide6_App/GUI/menu_bar.py
+++ b/src/Main_App/PySide6_App/GUI/menu_bar.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from PySide6.QtWidgets import QMenuBar, QMainWindow
 from PySide6.QtGui    import QAction
-from Main_App import open_eloreta_tool
+from Main_App.Legacy_App.eloreta_launcher import open_eloreta_tool
 
 def build_menu_bar(parent: QMainWindow) -> QMenuBar:
     """

--- a/src/Main_App/PySide6_App/GUI/settings_panel.py
+++ b/src/Main_App/PySide6_App/GUI/settings_panel.py
@@ -20,8 +20,8 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 
-from Main_App import SettingsManager
-from Main_App import ROISettingsEditor
+from Main_App.Legacy_App.settings_manager import SettingsManager
+from .roi_settings_editor import ROISettingsEditor
 
 
 class SettingsPanel(QWidget):

--- a/src/Main_App/__init__.py
+++ b/src/Main_App/__init__.py
@@ -6,3 +6,49 @@ FPVS Toolbox application.  Importing ``Main_App`` allows external code to
 access utility classes such as :class:`SettingsManager` and tools for checking
 application updates.
 """
+
+from .Legacy_App.settings_manager import SettingsManager
+from .Legacy_App.settings_window import SettingsWindow
+from .Legacy_App.relevant_publications_window import (
+    RelevantPublicationsWindow,
+)
+from .Legacy_App.menu_bar import AppMenuBar
+from .Legacy_App.ui_setup_panels import SetupPanelManager
+from .Legacy_App.ui_event_map_manager import EventMapManager
+from .Legacy_App.event_map_utils import EventMapMixin
+from .Legacy_App.file_selection import FileSelectionMixin
+from .Legacy_App.event_detection import EventDetectionMixin
+from .Legacy_App.validation_mixins import ValidationMixin
+from .Legacy_App.processing_utils import ProcessingMixin
+from .Legacy_App.load_utils import load_eeg_file
+from .Legacy_App.eeg_preprocessing import perform_preprocessing
+from .Legacy_App.app_logic import preprocess_raw
+from .Legacy_App.post_process import post_process
+from .Legacy_App.debug_utils import (
+    configure_logging,
+    get_settings,
+    install_messagebox_logger,
+)
+from .PySide6_App.Backend import Project
+
+__all__ = [
+    "SettingsManager",
+    "SettingsWindow",
+    "RelevantPublicationsWindow",
+    "AppMenuBar",
+    "SetupPanelManager",
+    "EventMapManager",
+    "EventMapMixin",
+    "FileSelectionMixin",
+    "EventDetectionMixin",
+    "ValidationMixin",
+    "ProcessingMixin",
+    "load_eeg_file",
+    "perform_preprocessing",
+    "preprocess_raw",
+    "post_process",
+    "configure_logging",
+    "get_settings",
+    "install_messagebox_logger",
+    "Project",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ if USE_PYSIDE6:
     try:
         from PySide6.QtWidgets import QApplication
         from pathlib import Path
-        from Main_App import MainWindow
+        from Main_App.PySide6_App.GUI.main_window import MainWindow
     except ImportError as exc:  # pragma: no cover - import guard
         raise ImportError(
             "PySide6 not installed; install with 'pip install PySide6'"


### PR DESCRIPTION
## Summary
- correct the MainWindow import in `src/main.py`
- fix PySide6 GUI imports to use correct modules
- expose legacy utilities via `Main_App` package for backward compatibility

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688127025dcc832cb4b24c0a56b559fb