### PR TITLE
Fix import error by re-exporting logging utilities

### DIFF
--- a/src/Main_App/__init__.py
+++ b/src/Main_App/__init__.py
@@ -7,10 +7,10 @@ access utility classes such as :class:`SettingsManager` and tools for checking
 application updates.
 """
 
+from . import Legacy_App
+
 from .Legacy_App.settings_manager import SettingsManager
 from .Legacy_App.settings_window import SettingsWindow
-from .Legacy_App.debug_utils import configure_logging
-from .Legacy_App.settings_manager import get_settings
 from .Legacy_App.relevant_publications_window import (
     RelevantPublicationsWindow,
 )
@@ -28,6 +28,8 @@ from .Legacy_App.app_logic import preprocess_raw
 from .Legacy_App.post_process import post_process
 from .Legacy_App.debug_utils import install_messagebox_logger
 from .PySide6_App.Backend import Project
+from .Legacy_App.debug_utils      import configure_logging
+from .Legacy_App.settings_manager import get_settings
 
 __all__ = [
     "SettingsManager",
@@ -49,4 +51,5 @@ __all__ = [
     "get_settings",
     "install_messagebox_logger",
     "Project",
+    "Legacy_App",
 ]


### PR DESCRIPTION
## Summary
- import `Legacy_App` in `Main_App` package
- re-export `configure_logging` and `get_settings`

## Testing
- `ruff check --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812c53ea54832c903c4cbb01152fca