### PR TITLE
Add SourceLocalization import test

### DIFF
--- a/tests/test_source_localization_import.py
+++ b/tests/test_source_localization_import.py
@@ -1,0 +1,16 @@
+import importlib.util
+import pytest
+
+for mod in (
+    "customtkinter",
+    "PySide6",
+    "pyvista",
+    "pyvistaqt",
+    "mne",
+):
+    if importlib.util.find_spec(mod) is None:
+        pytest.skip(f"{mod} not available", allow_module_level=True)
+
+def test_import_source_localization():
+    import Tools.SourceLocalization as SL
+    assert hasattr(SL, "STCViewer")


### PR DESCRIPTION
## Summary
- add a test that imports `Tools.SourceLocalization` and verifies access to `STCViewer`
- skip the test if heavy GUI dependencies are missing

## Testing
- `ruff check . --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68812da3a0c0832cb2af3e57ec75a73e