### PR TITLE
Fix load_eeg_file call in PySide6 GUI

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -546,7 +546,7 @@ class MainWindow(QMainWindow):
 
             for fp in bdf_files:
                 self.log(f"Loading EEG file: {fp.name}")
-                raw = load_eeg_file(str(fp))
+                raw = load_eeg_file(self, str(fp))
 
                 self.log("Preprocessing raw data")
                 processed = preprocess_raw(raw)


### PR DESCRIPTION
## Summary
- pass `self` to `load_eeg_file` when running the processing pipeline

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812fb98d00832ca5cd928d0678fe81