### PR TITLE
Fix preprocess calls in PySide6 GUI

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -549,8 +549,13 @@ class MainWindow(QMainWindow):
                 raw = load_eeg_file(self, str(fp))
 
                 self.log("Preprocessing raw data")
-                processed = preprocess_raw(raw)
-                processed = perform_preprocessing(processed)
+                processed = preprocess_raw(self, raw)
+                processed, _ = perform_preprocessing(
+                    raw_input=processed,
+                    params={},
+                    log_func=self.log,
+                    filename_for_log=fp.name,
+                )
 
                 out_dir = str(
                     self.currentProject.project_root


### PR DESCRIPTION
## Summary
- pass `self` to `preprocess_raw`
- call `perform_preprocessing` with required parameters

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881321cb194832c93e3107786404757