### PR TITLE
Fix post_process call

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -586,7 +586,9 @@ class MainWindow(QMainWindow):
                 result = process_data(processed, out_dir, run_loreta)
 
                 self.log("Post-processing results")
-                post_process(result)
+                # Supply the list of condition labels from the current project
+                condition_labels = list(self.currentProject.event_map.keys())
+                post_process(result, condition_labels)
 
             self._animate_progress_to(100)
             self.log("Processing complete")


### PR DESCRIPTION
## Summary
- fix PySide6 GUI to supply condition labels when calling legacy `post_process`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688139e169b4832c9f9602e8914e1cbf