### PR TITLE
Fix post_process call in MainWindow

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -588,7 +588,8 @@ class MainWindow(QMainWindow):
                 self.log("Post-processing results")
                 # Supply the list of condition labels from the current project
                 condition_labels = list(self.currentProject.event_map.keys())
-                post_process(result, condition_labels)
+                # Supply self as the application context for logging
+                post_process(self, result, condition_labels)
 
             self._animate_progress_to(100)
             self.log("Processing complete")


### PR DESCRIPTION
## Summary
- pass `self` to `post_process` when running the legacy pipeline

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813af00c90832c84aab3c9236ac009