### PR TITLE
Add icon for SNR Plots

### DIFF
--- a/src/Main_App/PySide6_App/GUI/settings_panel.py
+++ b/src/Main_App/PySide6_App/GUI/settings_panel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal, QSettings
+from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -73,7 +73,7 @@ def init_sidebar(self) -> None:
         lay,
         "btn_graphs",
         "SNR Plots",
-        QIcon.fromTheme("view-bar-chart"),
+        "view-bar-chart",
         self.open_plot_generator,
     )
     self.btn_image = make_button(


### PR DESCRIPTION
## Summary
- tint SNR Plots button icon so it matches other sidebar buttons
- remove unused `QSettings` import

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688142e5b9e8832c89d8f31ed79e2404