### PR TITLE
Fix ROI add button signal

### DIFF
--- a/src/Main_App/PySide6_App/GUI/settings_panel.py
+++ b/src/Main_App/PySide6_App/GUI/settings_panel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal, QSettings
+from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -219,7 +219,7 @@ class SettingsDialog(QDialog):
         form.addRow(QLabel("Regions of Interest"), self.roi_editor)
 
         add_btn = QPushButton("+ Add ROI")
-        add_btn.clicked.connect(self.roi_editor.add_entry)
+        add_btn.clicked.connect(lambda: self.roi_editor.add_entry())
         form.addRow(add_btn)
 
         tabs.addTab(tab, "Stats")


### PR DESCRIPTION
## Summary
- fix connection for Add ROI button so clicked state isn't passed to `add_entry`
- remove unused `QSettings` import to satisfy linter

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688143527910832cb0632aca2efed040