### PR TITLE
Fix missing preprocess_raw argument

### DIFF
--- a/src/Main_App/PySide6_App/Backend/processing_controller.py
+++ b/src/Main_App/PySide6_App/Backend/processing_controller.py
@@ -50,7 +50,7 @@ def start_processing(self) -> None:
             raw = load_eeg_file(self, str(fp))
 
             self.log("Preprocessing raw data")
-            preprocessed = preprocess_raw(raw)
+            preprocessed = preprocess_raw(self, raw)
             preprocessed = perform_preprocessing(preprocessed)
 
             out_dir = str(

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -215,8 +215,8 @@ class MainWindow(QMainWindow):
 
                 self.log("Preprocessing raw data")
                 if self.settings.debug_enabled():
-                    self.log("[DEBUG] Calling preprocess_raw(raw)")
-                proc1 = preprocess_raw(raw)
+                    self.log("[DEBUG] Calling preprocess_raw(self, raw)")
+                proc1 = preprocess_raw(self, raw)
                 if self.settings.debug_enabled():
                     self.log(f"[DEBUG] preprocess_raw returned: {proc1!r}")
 


### PR DESCRIPTION
## Summary
- pass `self` to `preprocess_raw` when running the preprocessing step

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688143f96a58832cab43232103949562