### PR TITLE
Fix post_process argument mismatch

### DIFF
--- a/src/Main_App/PySide6_App/Backend/processing_controller.py
+++ b/src/Main_App/PySide6_App/Backend/processing_controller.py
@@ -73,7 +73,7 @@ def start_processing(self) -> None:
 
             self.log("Post-processing results")
             condition_labels = list(self.currentProject.event_map.keys())
-            post_process(self, result, condition_labels)
+            post_process(self, condition_labels)
 
         _animate_progress_to(self, 100)
         self.log("Processing complete")

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -269,9 +269,9 @@ class MainWindow(QMainWindow):
                 condition_labels = list(self.currentProject.event_map.keys())
                 if self.settings.debug_enabled():
                     self.log(
-                        f"[DEBUG] Calling post_process(self, result, {condition_labels})"
+                        f"[DEBUG] Calling post_process(self, {condition_labels})"
                     )
-                post_process(self, result, condition_labels)
+                post_process(self, condition_labels)
                 if self.settings.debug_enabled():
                     self.log("[DEBUG] post_process completed")
 


### PR DESCRIPTION
## Summary
- call `post_process` with the expected arguments in PySide6 processing code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688146626ab8832cb31b54e817369ba1