### PR TITLE
Add temporary data selection button

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -99,6 +99,9 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         self.save_folder_path = SimpleNamespace(get=lambda: "", set=lambda v: None)
         self.file_mode = SimpleNamespace(get=lambda: "Batch")
         self.file_type = SimpleNamespace(set=lambda v: None)
+        # Connect temporary data selection button to legacy mixin
+        if hasattr(self, "btn_select_data"):
+            self.btn_select_data.clicked.connect(self.select_data_source)
         self._processing_timer = QTimer(self)
         self._processing_timer.timeout.connect(self._periodic_queue_check)
         self._processing_timer.start(50)

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QFrame,
     QDockWidget,
     QApplication,
+    QPushButton,
 )
 from PySide6.QtGui import QIcon, QPixmap, QPainter, QColor
 from PySide6.QtCore import Qt, QSize
@@ -87,6 +88,11 @@ def init_sidebar(self) -> None:
     divider.setFixedHeight(1)
     divider.setStyleSheet("background:#444;")
     lay.addWidget(divider)
+
+    # Temporary button to trigger legacy data selection
+    self.btn_select_data = QPushButton("Select Data Folder...")
+    self.btn_select_data.setObjectName("btn_select_data")
+    lay.addWidget(self.btn_select_data)
 
     lay.addStretch(1)
 


### PR DESCRIPTION
## Summary
- add `QPushButton` in sidebar for selecting a data folder
- hook the new button to the legacy `select_data_source` workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815a27629c832cb2f9de461e7c2f87