### PR TITLE
Fix legacy progress bar calls

### DIFF
--- a/src/Main_App/PySide6_App/Backend/processing_controller.py
+++ b/src/Main_App/PySide6_App/Backend/processing_controller.py
@@ -69,7 +69,7 @@ def start_processing(self) -> None:
                 self.currentProject.project_root / self.currentProject.subfolders["excel"]
             )
             self.log(f"Running main processing (run_loreta={run_loreta})")
-            result = process_data(preprocessed, out_dir, run_loreta)
+            process_data(preprocessed, out_dir, run_loreta)
 
             self.log("Post-processing results")
             condition_labels = list(self.currentProject.event_map.keys())

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -76,6 +76,8 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         self.setMinimumSize(1024, 768)
         self.currentProject: Project | None = None
         init_ui(self)
+        # Support legacy .set() calls from processing_utils
+        self.progress_bar.set = self.progress_bar.setValue
         init_sidebar(self)
 
         select_projects_root(self)


### PR DESCRIPTION
## Summary
- patch progress bar so legacy `.set()` still works
- remove unused variable in `processing_controller`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688173689b2c832c90e2ebf52863c22f