### PR TITLE
Improve event map usability

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -343,6 +343,8 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         hl = QHBoxLayout(row)
         le_label = QLineEdit(label, row)
         le_id = QLineEdit(id, row)
+        le_label.returnPressed.connect(self.btn_add_row.click)
+        le_id.returnPressed.connect(self.btn_add_row.click)
         btn_rm = QPushButton("✕", row)
         def _remove() -> None:
             row.setParent(None)

--- a/src/Main_App/PySide6_App/GUI/ui_main.py
+++ b/src/Main_App/PySide6_App/GUI/ui_main.py
@@ -107,6 +107,7 @@ def init_ui(self) -> None:
     scroll.setWidgetResizable(True)
     self.event_container = QWidget()
     self.event_layout = QVBoxLayout(self.event_container)
+    self.event_layout.setSpacing(2)
     scroll.setWidget(self.event_container)
     vlay.addWidget(scroll)
     btns = QHBoxLayout()


### PR DESCRIPTION
## Summary
- tweak spacing of event map list
- allow pressing **Enter** in event map fields to add a condition

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688240102144832cb46c661cf8c02e99