### PR TITLE
Add debug logging for output path and condition labels

### DIFF
--- a/src/Main_App/Legacy_App/processing_utils.py
+++ b/src/Main_App/Legacy_App/processing_utils.py
@@ -110,6 +110,7 @@ class ProcessingMixin:
                     original_data = self.preprocessed_data
                     self.preprocessed_data = epochs_dict
                     try:
+                        self.log(f"Post-process condition labels: {labels}")
                         _external_post_process(self, labels)
                     except Exception as e:
                         self.log(f"!!! post_process error for {fname}: {e}")
@@ -463,6 +464,12 @@ class ProcessingMixin:
                         self.data_paths = [f_path]
                         self.preprocessed_data = file_epochs
                         try:
+                            gui_queue.put(
+                                {
+                                    'type': 'log',
+                                    'message': f"Post-process condition labels: {list(file_epochs.keys())}",
+                                }
+                            )
                             self.post_process(list(file_epochs.keys()))
                         except Exception as e_post:
                             gui_queue.put({'type': 'log',

--- a/src/Main_App/PySide6_App/Backend/processing_controller.py
+++ b/src/Main_App/PySide6_App/Backend/processing_controller.py
@@ -73,6 +73,7 @@ def start_processing(self) -> None:
 
             self.log("Post-processing results")
             condition_labels = list(self.currentProject.event_map.keys())
+            self.log(f"Post-process condition labels: {condition_labels}")
             post_process(self, condition_labels)
 
         _animate_progress_to(self, 100)

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -392,6 +392,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         # Provide legacy post_process with a .get() for the Excel output folder
         excel_dir = project.project_root / project.subfolders["excel"]
         self.save_folder_path = SimpleNamespace(get=lambda: str(excel_dir))
+        self.log(f"Save folder path set: {self.save_folder_path.get()}")
 
         def make_entry(value: str):
             edit = QLineEdit(str(value))


### PR DESCRIPTION
## Summary
- log project output folder when loading a project
- show condition labels before post-processing

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878c4bc208832c8e4bf5f46e58b1fd