### PR TITLE
Fix import error with legacy stats window

### DIFF
--- a/src/Tools/Stats/__init__.py
+++ b/src/Tools/Stats/__init__.py
@@ -1,13 +1,18 @@
 # src/Tools/Stats/__init__.py
 
-from .stats import StatsAnalysisWindow
+try:
+    # The legacy CustomTkinter window requires additional dependencies
+    # that may not always be available. Import it lazily so that failure
+    # to load the old UI does not break PySide6 components.
+    from .stats import StatsAnalysisWindow
+except Exception:  # pragma: no cover - optional legacy UI
+    StatsAnalysisWindow = None
 from .stats_export import export_significance_results_to_excel
 from .stats_ui import StatsToolWidget
 from .stats_ui_ctk import launch_ctk_stats_tool
 from . import stats_file_scanner, stats_ui, stats_runners, stats_helpers
 
 __all__ = [
-    "StatsAnalysisWindow",
     "export_significance_results_to_excel",
     "stats_file_scanner",
     "stats_ui",
@@ -16,3 +21,6 @@ __all__ = [
     "StatsToolWidget",
     "launch_ctk_stats_tool",
 ]
+
+if StatsAnalysisWindow is not None:  # pragma: no cover - optional legacy UI
+    __all__.insert(0, "StatsAnalysisWindow")


### PR DESCRIPTION
## Summary
- make `StatsAnalysisWindow` optional so PySide6 GUI can load even if the
  CustomTkinter stats UI can't be imported

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c3453994832ca2dd68502b7e251a