### PR TITLE
Fix Stats imports for package execution

### DIFF
--- a/src/Tools/Stats/__init__.py
+++ b/src/Tools/Stats/__init__.py
@@ -4,13 +4,13 @@ try:
     # The legacy CustomTkinter window requires additional dependencies
     # that may not always be available. Import it lazily so that failure
     # to load the old UI does not break PySide6 components.
-    from .stats import StatsAnalysisWindow
+    from Tools.Stats.stats import StatsAnalysisWindow
 except Exception:  # pragma: no cover - optional legacy UI
     StatsAnalysisWindow = None
-from .stats_export import export_significance_results_to_excel
-from .stats_ui import StatsToolWidget
-from .stats_ui_ctk import launch_ctk_stats_tool
-from . import stats_file_scanner, stats_ui, stats_runners, stats_helpers
+from Tools.Stats.stats_export import export_significance_results_to_excel
+from Tools.Stats.stats_ui import StatsToolWidget
+from Tools.Stats.stats_ui_ctk import launch_ctk_stats_tool
+from Tools.Stats import stats_file_scanner, stats_ui, stats_runners, stats_helpers
 
 __all__ = [
     "export_significance_results_to_excel",

--- a/src/Tools/Stats/stats.py
+++ b/src/Tools/Stats/stats.py
@@ -27,9 +27,9 @@ from config import init_fonts, FONT_MAIN
 
 import pandas as pd
 
-from .stats_file_scanner import browse_folder, scan_folder, update_condition_menus, update_condition_B_options
-from .stats_ui_ctk import create_widgets
-from .stats_runners import (
+from Tools.Stats.stats_file_scanner import browse_folder, scan_folder, update_condition_menus, update_condition_B_options
+from Tools.Stats.stats_ui_ctk import create_widgets
+from Tools.Stats.stats_runners import (
     run_rm_anova,
     run_mixed_model,
     run_posthoc_tests,
@@ -37,7 +37,7 @@ from .stats_runners import (
     run_harmonic_check,
     _structure_harmonic_results,
 )
-from .stats_helpers import (
+from Tools.Stats.stats_helpers import (
     _load_base_freq,
     _load_bca_upper_limit,
     _load_alpha,
@@ -208,8 +208,8 @@ if __name__ == "__main__":
         if 'stats_export' not in sys.modules: sys.modules['stats_export'] = MockStatsExport()
         if 'repeated_m_anova' not in sys.modules: sys.modules['repeated_m_anova'] = MockRepeatedMAnova()
         # Re-import after mocking (or ensure they are imported after this block)
-        from . import stats_export
-        from repeated_m_anova import run_repeated_measures_anova
+        from Tools.Stats import stats_export
+        from Tools.Stats.repeated_m_anova import run_repeated_measures_anova
 
         ctk.CTkButton(root, text="Open Stats Tool",
                       command=lambda: StatsAnalysisWindow(master=TestMaster(), default_folder="")).pack(pady=20)

--- a/src/Tools/Stats/stats_analysis.py
+++ b/src/Tools/Stats/stats_analysis.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import scipy.stats as stats
 
-from .repeated_m_anova import run_repeated_measures_anova
+from Tools.Stats.repeated_m_anova import run_repeated_measures_anova
 from Main_App import SettingsManager
 
 # Regions of Interest (10-20 montage)

--- a/src/Tools/Stats/stats_helpers.py
+++ b/src/Tools/Stats/stats_helpers.py
@@ -2,7 +2,7 @@
 
 import logging
 from Main_App import SettingsManager
-from . import stats_analysis
+from Tools.Stats import stats_analysis
 
 logger = logging.getLogger(__name__)
 

--- a/src/Tools/Stats/stats_runners.py
+++ b/src/Tools/Stats/stats_runners.py
@@ -8,15 +8,15 @@ from scipy import stats
 import traceback
 import os
 
-from .repeated_m_anova import run_repeated_measures_anova
-from .mixed_effects_model import run_mixed_effects_model
-from .interpretation_helpers import generate_lme_summary
-from .posthoc_tests import (
+from Tools.Stats.repeated_m_anova import run_repeated_measures_anova
+from Tools.Stats.mixed_effects_model import run_mixed_effects_model
+from Tools.Stats.interpretation_helpers import generate_lme_summary
+from Tools.Stats.posthoc_tests import (
     run_posthoc_pairwise_tests,
     run_interaction_posthocs as perform_interaction_posthocs,
 )
-from .stats_helpers import load_rois_from_settings, apply_rois_to_modules
-from .stats_analysis import ALL_ROIS_OPTION
+from Tools.Stats.stats_helpers import load_rois_from_settings, apply_rois_to_modules
+from Tools.Stats.stats_analysis import ALL_ROIS_OPTION
 
 # These variables are set from settings at runtime
 ROIS = {}


### PR DESCRIPTION
## Summary
- remove relative imports from the Stats toolbox
- use absolute `Tools.Stats` package paths throughout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c5369360832c81ac96c42208a86e