### PR TITLE
Fix CTk stats module export

### DIFF
--- a/src/Tools/Stats/stats_ui_ctk.py
+++ b/src/Tools/Stats/stats_ui_ctk.py
@@ -10,3 +10,16 @@ def launch_ctk_stats_tool() -> None:
     """Launch the old CustomTkinter-based stats tool in a separate process."""
     script = Path(__file__).resolve().with_name("stats.py")
     subprocess.Popen([sys.executable, str(script)], close_fds=True)
+
+
+def create_widgets() -> None:
+    """Entry point for launching the legacy CTk Stats Tool."""
+    # Import locally to avoid circular imports when ``stats`` imports this module.
+    from Tools.Stats.stats import StatsAnalysisWindow
+
+    window = StatsAnalysisWindow(None)
+    window.mainloop()
+
+
+# Make sure it's importable when using ``from Tools.Stats.stats_ui_ctk import create_widgets``
+__all__ = ["create_widgets"]


### PR DESCRIPTION
## Summary
- expose a `create_widgets` function in the CTk stats tool wrapper
- keep stats.py importing `create_widgets`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7d73e24832c8cf934c4dcca9e64