### PR TITLE
Fix PySide6 import guard in main entrypoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -23,12 +23,13 @@ QCoreApplication.setApplicationName("FPVS Toolbox")
 if USE_PYSIDE6:
     try:
         from PySide6.QtWidgets import QApplication
-        from pathlib import Path
-        from Main_App.PySide6_App.GUI.main_window import MainWindow
     except ImportError as exc:  # pragma: no cover - import guard
         raise ImportError(
             "PySide6 not installed; install with 'pip install PySide6'"
         ) from exc
+
+    from pathlib import Path
+    from Main_App.PySide6_App.GUI.main_window import MainWindow
 else:
     from fpvs_app import FPVSApp
     from Main_App import configure_logging, get_settings, install_messagebox_logger


### PR DESCRIPTION
## Summary
- ensure only PySide6 import failure triggers the installation hint

## Testing
- `ruff check src/main.py`
- `ruff check src`
- `pytest -q` *(fails: FileNotFoundError in tests/test_stats_file_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_688908e41c48832cbd34c86ac2223a90