### PR TITLE
Fix legacy stats imports

### DIFF
--- a/src/Tools/Stats/PySide6/stats_ui_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_ui_pyside6.py
@@ -9,8 +9,9 @@ import os
 import json
 from types import SimpleNamespace
 
-# Legacy imports for scanning and analysis
-from Tools.Stats.stats_file_scanner_pyside6 import scan_folder_simple, ScanError
+# Imports for scanning (PySide6) and statistical analysis (legacy)
+# Use the PySide6-specific file scanner rather than the legacy one
+from .stats_file_scanner_pyside6 import scan_folder_simple, ScanError
 from Tools.Stats.stats_runners import (
     run_rm_anova, run_mixed_model,
     run_posthoc_tests, run_interaction_posthocs,

--- a/src/Tools/Stats/__init__.py
+++ b/src/Tools/Stats/__init__.py
@@ -1,8 +1,23 @@
-# src/Tools/Stats/__init__.py
+"""Expose stats modules after the Legacy/PySide6 refactor."""
 
-from .stats import StatsAnalysisWindow
-from .stats_export import export_significance_results_to_excel
-from . import stats_file_scanner, stats_ui, stats_runners, stats_helpers
+# Legacy Tkinter based implementation
+from .Legacy.stats import StatsAnalysisWindow
+from .Legacy.stats_export import export_significance_results_to_excel
+from .Legacy import (
+    stats_file_scanner,
+    stats_ui,
+    stats_runners,
+    stats_helpers,
+    stats_analysis,
+    full_snr,
+    interpretation_helpers,
+    mixed_effects_model,
+    repeated_m_anova,
+    posthoc_tests,
+)
+
+# PySide6 specific helpers
+from .PySide6 import stats_file_scanner_pyside6, stats_ui_pyside6
 
 __all__ = [
     "StatsAnalysisWindow",
@@ -11,4 +26,12 @@ __all__ = [
     "stats_ui",
     "stats_runners",
     "stats_helpers",
+    "stats_analysis",
+    "full_snr",
+    "interpretation_helpers",
+    "mixed_effects_model",
+    "repeated_m_anova",
+    "posthoc_tests",
+    "stats_file_scanner_pyside6",
+    "stats_ui_pyside6",
 ]

--- a/src/Tools/Stats/stats_file_scanner.py
+++ b/src/Tools/Stats/stats_file_scanner.py
@@ -1,0 +1,18 @@
+"""Compatibility wrapper for the legacy stats_file_scanner module."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from types import ModuleType
+
+_path = os.path.join(os.path.dirname(__file__), "Legacy", "stats_file_scanner.py")
+_spec = importlib.util.spec_from_file_location("_legacy_stats_file_scanner", _path)
+_legacy_module: ModuleType = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(_legacy_module)
+
+# Export all public names from the legacy module
+__all__ = [name for name in dir(_legacy_module) if not name.startswith("_")]
+for name in __all__:
+    globals()[name] = getattr(_legacy_module, name)


### PR DESCRIPTION
## Summary
- update `Tools/Stats` package exports to work with new Legacy/PySide6 layout
- add compatibility loader for `stats_file_scanner`
- ensure PySide6 stats UI imports the PySide6 file scanner

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68890bb569e8832c9e1a5f5cd3656b08