### PR TITLE
Fix plot generator imports

### DIFF
--- a/src/Main_App/Legacy_App/settings_window.py
+++ b/src/Main_App/Legacy_App/settings_window.py
@@ -280,7 +280,10 @@ class SettingsWindow(ctk.CTkToplevel):
 
         # Update ROI definitions in any open Stats windows
         try:
-            from Tools.Stats.stats_helpers import load_rois_from_settings, apply_rois_to_modules
+            from Tools.Stats.Legacy.stats_helpers import (
+                load_rois_from_settings,
+                apply_rois_to_modules,
+            )
             from Tools.Stats.stats import StatsAnalysisWindow
             rois = load_rois_from_settings(self.manager)
             apply_rois_to_modules(rois)

--- a/src/Main_App/PySide6_App/GUI/settings_panel.py
+++ b/src/Main_App/PySide6_App/GUI/settings_panel.py
@@ -352,7 +352,10 @@ class SettingsDialog(QDialog):
             )
 
         try:
-            from Tools.Stats.stats_helpers import load_rois_from_settings, apply_rois_to_modules
+            from Tools.Stats.Legacy.stats_helpers import (
+                load_rois_from_settings,
+                apply_rois_to_modules,
+            )
             from Tools.Stats.stats import StatsAnalysisWindow
 
             rois = load_rois_from_settings(self.manager)

--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -33,8 +33,8 @@ from PySide6.QtGui import QAction, QColor
 from PySide6.QtWidgets import QColorDialog
 
 
-from Tools.Stats.stats_helpers import load_rois_from_settings
-from Tools.Stats.stats_analysis import ALL_ROIS_OPTION
+from Tools.Stats.Legacy.stats_helpers import load_rois_from_settings
+from Tools.Stats.Legacy.stats_analysis import ALL_ROIS_OPTION
 from Main_App import SettingsManager
 from Tools.Plot_Generator.plot_settings import PlotSettingsManager
 from .worker import _Worker

--- a/src/Tools/Plot_Generator/worker.py
+++ b/src/Tools/Plot_Generator/worker.py
@@ -15,7 +15,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from PySide6.QtCore import QObject, Signal
 
-from Tools.Stats.stats_analysis import ALL_ROIS_OPTION
+from Tools.Stats.Legacy.stats_analysis import ALL_ROIS_OPTION
 from Tools.Plot_Generator.snr_utils import calc_snr_matlab
 
 # Global plotting style applied after imports

--- a/tests/test_stats_file_scanner.py
+++ b/tests/test_stats_file_scanner.py
@@ -3,7 +3,15 @@ import os
 
 
 def _import_scanner_module():
-    path = os.path.join(os.path.dirname(__file__), '..', 'src', 'Tools', 'Stats', 'stats_file_scanner.py')
+    path = os.path.join(
+        os.path.dirname(__file__),
+        '..',
+        'src',
+        'Tools',
+        'Stats',
+        'Legacy',
+        'stats_file_scanner.py',
+    )
     spec = importlib.util.spec_from_file_location('stats_file_scanner', path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- update plot generator imports to reference Stats legacy modules
- adjust settings windows to use legacy stats helpers
- update stats file scanner test path

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68893dbd8938832cb2954a714794f657