### PR TITLE
Fix duplicate Qt dialog wrappers

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -70,17 +70,6 @@ def _qt_askyesno(title, message, **options):
     return result == QMessageBox.Yes
 
 
-def _qt_showinfo(title, message, **options):
-    QMessageBox.information(None, title, message)
-
-
-def _qt_askyesno(title, message, **options):
-    result = QMessageBox.question(
-        None, title, message, QMessageBox.Yes | QMessageBox.No
-    )
-    return result == QMessageBox.Yes
-
-
 tk_messagebox.showerror = _qt_showerror
 tk_messagebox.showwarning = _qt_showwarning
 tk_messagebox.showinfo = _qt_showinfo


### PR DESCRIPTION
## Summary
- drop duplicate definitions of `_qt_showinfo` and `_qt_askyesno`
- keep tkinter messagebox wrappers bound to the Qt versions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a243aa950832caf2bc161a79a3886