### PR TITLE
Initialize logging before Qt app

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,11 @@ if USE_PYSIDE6:
     # An error here will now raise the correct, unmasked traceback.
     from pathlib import Path
     from Main_App.PySide6_App.GUI.main_window import MainWindow
+    from Main_App import (
+        configure_logging,
+        get_settings,
+        install_messagebox_logger,
+    )
 else:
     from fpvs_app import FPVSApp
     from Main_App import configure_logging, get_settings, install_messagebox_logger
@@ -51,6 +56,11 @@ def main() -> None:
         return
 
     if USE_PYSIDE6:
+        settings = get_settings()
+        debug = settings.debug_enabled()
+        configure_logging(debug)
+        install_messagebox_logger(debug)
+
         app = QApplication([])
         qss = Path(__file__).resolve().parent / "qdark_sidebar.qss"
         if qss.exists():


### PR DESCRIPTION
## Summary
- import logging utilities when using PySide6
- configure logging and install messagebox logger before creating `QApplication`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a243b10ac832cb4dbc59c1f3ad6b2