### PR TITLE
Improve error handling during processing

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -227,7 +227,12 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         # Mark that a real run is active
         self._run_active = True
         # Delegate to the legacy mixin’s processing entry point
-        super().start_processing()
+        try:
+            super().start_processing()
+        except Exception as e:  # pragma: no cover - GUI error path
+            logger.exception(e)
+            QMessageBox.critical(self, "Processing Error", str(e))
+            self._run_active = False
 
     def _periodic_queue_check(self) -> None:
         """Process queue messages only when a run is active."""


### PR DESCRIPTION
## Summary
- wrap `start_processing` in a try/except block so GUI errors do not spam dialogs

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a34460504832ca3c7969c28c2b7c0