### PR TITLE
Remove temporary sidebar data button

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -147,7 +147,6 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         # 👉 ADD THESE THREE LINES:
         self.progress_bar.set = self.progress_bar.setValue
         self.btn_start.clicked.connect(self.start_processing)
-        self.btn_select_data.clicked.connect(self.select_data_source)
 
         self.gui_queue = queue.Queue()
         self.processing_thread = None
@@ -161,9 +160,6 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         self.save_folder_path = SimpleNamespace(get=lambda: "", set=lambda v: None)
         self.file_mode = SimpleNamespace(get=lambda: "Batch")
         self.file_type = SimpleNamespace(set=lambda v: None)
-        # Connect temporary data selection button to legacy mixin
-        if hasattr(self, "btn_select_data"):
-            self.btn_select_data.clicked.connect(self.select_data_source)
         self._processing_timer = QTimer(self)
         self._processing_timer.timeout.connect(self._periodic_queue_check)
         self._processing_timer.start(50)

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -9,7 +9,6 @@ from PySide6.QtWidgets import (
     QFrame,
     QDockWidget,
     QApplication,
-    QPushButton,
 )
 from PySide6.QtGui import QIcon, QPixmap, QPainter, QColor
 from PySide6.QtCore import Qt, QSize
@@ -88,11 +87,6 @@ def init_sidebar(self) -> None:
     divider.setFixedHeight(1)
     divider.setStyleSheet("background:#444;")
     lay.addWidget(divider)
-
-    # Temporary button to trigger legacy data selection
-    self.btn_select_data = QPushButton("Select Data Folder...")
-    self.btn_select_data.setObjectName("btn_select_data")
-    lay.addWidget(self.btn_select_data)
 
     lay.addStretch(1)
 


### PR DESCRIPTION
## Summary
- clean up sidebar by removing the temporary *Select Data Folder* QPushButton
- drop related click-handler wiring in `MainWindow`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b68fcb3e0832c86e9de2cdcdafe5f