### PR TITLE
Remove data select button hookup

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -144,10 +144,8 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
 
         # Legacy mixin compatibility ----------------------------
 
-        # 👉 ADD THESE THREE LINES:
         self.progress_bar.set = self.progress_bar.setValue
         self.btn_start.clicked.connect(self.start_processing)
-        self.btn_select_data.clicked.connect(self.select_data_source)
 
         self.gui_queue = queue.Queue()
         self.processing_thread = None
@@ -161,9 +159,6 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         self.save_folder_path = SimpleNamespace(get=lambda: "", set=lambda v: None)
         self.file_mode = SimpleNamespace(get=lambda: "Batch")
         self.file_type = SimpleNamespace(set=lambda v: None)
-        # Connect temporary data selection button to legacy mixin
-        if hasattr(self, "btn_select_data"):
-            self.btn_select_data.clicked.connect(self.select_data_source)
         self._processing_timer = QTimer(self)
         self._processing_timer.timeout.connect(self._periodic_queue_check)
         self._processing_timer.start(50)


### PR DESCRIPTION
## Summary
- delete obsolete comment about adding three lines
- drop all calls to `btn_select_data.clicked.connect`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b68fdba2c832cb3b3456c7970d3b9