### PR TITLE
Add new bar chart icon

### DIFF
--- a/src/Main_App/PySide6_App/GUI/icons/snr_plots.svg
+++ b/src/Main_App/PySide6_App/GUI/icons/snr_plots.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="10" width="3" height="11" fill="#FFFFFF"/>
+  <rect x="9" y="6" width="3" height="15" fill="#FFFFFF"/>
+  <rect x="15" y="3" width="3" height="18" fill="#FFFFFF"/>
+  <rect x="21" y="8" width="3" height="13" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
## Summary
- create the new `icons` directory under the PySide6 GUI
- add a simple 24x24 monochrome bar chart SVG as `snr_plots.svg`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b694619bc832ca209223498b57772