### PR TITLE
Auto-load project paths in SNR plot tool

### DIFF
--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -40,6 +41,40 @@ from Tools.Plot_Generator.plot_settings import PlotSettingsManager
 from .worker import _Worker
 
 ALL_CONDITIONS_OPTION = "All Conditions"
+
+
+def _auto_detect_project_dir() -> Path:
+    """Return the nearest ancestor folder containing ``project.json``."""
+    path = Path.cwd()
+    while not (path / "project.json").is_file():
+        if path.parent == path:
+            return Path.cwd()
+        path = path.parent
+    return path
+
+
+def _project_paths(parent: QWidget | None, project_dir: str | None) -> tuple[str | None, str | None]:
+    """Return Excel and SNR plot folders for the given or detected project."""
+    if project_dir and os.path.isdir(project_dir):
+        root = Path(project_dir)
+    else:
+        proj = getattr(parent, "currentProject", None)
+        if proj and hasattr(proj, "project_root"):
+            root = Path(proj.project_root)
+        else:
+            root = _auto_detect_project_dir()
+
+    manifest = root / "project.json"
+    if manifest.is_file():
+        try:
+            with open(manifest, "r") as f:
+                cfg = json.load(f)
+            excel_sub = cfg.get("subfolders", {}).get("excel", "1 - Excel Data Files")
+            snr_sub = cfg.get("subfolders", {}).get("snr", "2 - SNR Plots")
+            return str(root / excel_sub), str(root / snr_sub)
+        except Exception:
+            pass
+    return None, None
 
 class _SettingsDialog(QDialog):
     """Dialog for configuring plot options."""
@@ -89,7 +124,7 @@ class _SettingsDialog(QDialog):
 class PlotGeneratorWindow(QWidget):
     """Main window for generating plots."""
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None, project_dir: str | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Generate SNR Plots")
         self.roi_map = load_rois_from_settings()
@@ -105,6 +140,12 @@ class PlotGeneratorWindow(QWidget):
             default_in = main_default
         if not default_out:
             default_out = main_default
+
+        proj_in, proj_out = _project_paths(parent, project_dir)
+        if proj_in:
+            default_in = proj_in
+        if proj_out:
+            default_out = proj_out
         self._defaults = {
             "title_snr": "SNR Plot",
             "xlabel": "Frequency (Hz)",


### PR DESCRIPTION
## Summary
- enhance Generate SNR Plots window to read project.json
- look for Excel and SNR folders based on the active project

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6daaa2c8832c8511786f85b1ad72