### PR TITLE
Load project defaults in SNR plot tool

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -20,6 +20,7 @@ import pandas as pd
 from pathlib import Path
 import subprocess
 import sys
+import os
 import queue
 from .settings_panel import SettingsDialog
 from .sidebar import init_sidebar
@@ -341,7 +342,11 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
                 / "plot_generator.py"
             )
             cmd.append(str(script))
-        subprocess.Popen(cmd, close_fds=True)
+        env = os.environ.copy()
+        proj = getattr(self, "currentProject", None)
+        if proj and hasattr(proj, "project_root"):
+            env["FPVS_PROJECT_ROOT"] = str(proj.project_root)
+        subprocess.Popen(cmd, close_fds=True, env=env)
 
     def open_advanced_analysis_window(self) -> None:
         QMessageBox.information(

--- a/tests/test_plot_generator_project_defaults.py
+++ b/tests/test_plot_generator_project_defaults.py
@@ -1,0 +1,71 @@
+import importlib.util
+import os
+import json
+import pytest
+
+if importlib.util.find_spec("matplotlib") is None:
+    pytest.skip("matplotlib not available", allow_module_level=True)
+
+
+def _import_module():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "Tools",
+        "Plot_Generator",
+        "plot_generator.py",
+    )
+    spec = importlib.util.spec_from_file_location("plot_generator", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_defaults_loaded_from_project(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    excel = proj / "1 - Excel Data Files"
+    snr = proj / "2 - SNR Plots"
+    excel.mkdir()
+    snr.mkdir()
+    data = {
+        "name": "Test",
+        "subfolders": {"excel": "1 - Excel Data Files", "snr": "2 - SNR Plots"},
+    }
+    (proj / "project.json").write_text(json.dumps(data))
+
+    monkeypatch.chdir(proj)
+    module = _import_module()
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    win = module.PlotGeneratorWindow()
+    assert win.folder_edit.text() == str(excel)
+    assert win.out_edit.text() == str(snr)
+    app.quit()
+
+
+def test_defaults_loaded_from_env(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    excel = proj / "1 - Excel Data Files"
+    snr = proj / "2 - SNR Plots"
+    excel.mkdir()
+    snr.mkdir()
+    data = {
+        "name": "EnvTest",
+        "subfolders": {"excel": "1 - Excel Data Files", "snr": "2 - SNR Plots"},
+    }
+    (proj / "project.json").write_text(json.dumps(data))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FPVS_PROJECT_ROOT", str(proj))
+    module = _import_module()
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    win = module.PlotGeneratorWindow()
+    assert win.folder_edit.text() == str(excel)
+    assert win.out_edit.text() == str(snr)
+    app.quit()


### PR DESCRIPTION
## Summary
- automatically detect a `project.json` and use its folders as the default
  input and output paths for the SNR plot generator
- test that project folders are preloaded when opening the tool
- pass `FPVS_PROJECT_ROOT` env var from main window and respect it in the tool
- verify env var detection with a new test

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b6daaa2c8832c8511786f85b1ad72