### PR TITLE
Add landing page with stacked widget

### DIFF
--- a/src/Main_App/PySide6_App/GUI/file_menu.py
+++ b/src/Main_App/PySide6_App/GUI/file_menu.py
@@ -19,10 +19,12 @@ def init_file_menu(self) -> None:
 
     action_new = QAction("New Project…", self)
     action_new.triggered.connect(self.new_project)
+    self.actionCreateNewProject = action_new
     file_menu.addAction(action_new)
 
     action_open = QAction("Open Existing Project…", self)
     action_open.triggered.connect(self.open_existing_project)
+    self.actionOpenExistingProject = action_open
     file_menu.addAction(action_open)
 
     action_edit = QAction("Edit Project Settings…", self)

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -139,6 +139,15 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         select_projects_root(self)
 
         init_file_menu(self)
+        if hasattr(self, "btn_create_project"):
+            self.btn_create_project.clicked.connect(
+                self.actionCreateNewProject.trigger
+            )
+        if hasattr(self, "btn_open_project"):
+            self.btn_open_project.clicked.connect(
+                self.actionOpenExistingProject.trigger
+            )
+        self.stacked.setCurrentIndex(0)
         self.log("Welcome to the FPVS Toolbox!")
         self.log(
             f"Appearance Mode: {self.settings.get('appearance', 'mode', 'System')}"
@@ -294,12 +303,18 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
     # ------------------------------------------------------------------
     def new_project(self) -> None:
         new_project(self)
+        if getattr(self, "currentProject", None):
+            self.stacked.setCurrentIndex(1)
 
     def open_existing_project(self) -> None:
         open_existing_project(self)
+        if getattr(self, "currentProject", None):
+            self.stacked.setCurrentIndex(1)
 
     def openProjectPath(self, folder: str) -> None:
         openProjectPath(self, folder)
+        if getattr(self, "currentProject", None):
+            self.stacked.setCurrentIndex(1)
 
     def edit_project_settings(self) -> None:
         """Delegate project editing to :mod:`project_manager`."""

--- a/src/Main_App/PySide6_App/GUI/ui_main.py
+++ b/src/Main_App/PySide6_App/GUI/ui_main.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QToolBar,
     QLabel,
     QWidget,
+    QStackedWidget,
     QVBoxLayout,
     QHBoxLayout,
     QGroupBox,
@@ -42,8 +43,23 @@ def init_ui(self) -> None:
     self.lbl_debug.setVisible(self.settings.debug_enabled())
     toolbar.addWidget(self.lbl_debug)
 
-    # Central container
-    container = QWidget(self)
+    # Stacked central widget
+    self.stacked = QStackedWidget(self)
+    self.setCentralWidget(self.stacked)
+
+    # ----- Page 0: Landing -----
+    landing = QWidget(self.stacked)
+    lay0 = QVBoxLayout(landing)
+    lay0.addStretch(1)
+    self.btn_create_project = QPushButton("Create New Project", landing)
+    self.btn_open_project = QPushButton("Open Existing Project", landing)
+    lay0.addWidget(self.btn_create_project)
+    lay0.addWidget(self.btn_open_project)
+    lay0.addStretch(1)
+    self.stacked.addWidget(landing)
+
+    # ----- Page 1: Main UI -----
+    container = QWidget(self.stacked)
     main_layout = QVBoxLayout(container)
     main_layout.setContentsMargins(10, 10, 10, 10)
     main_layout.setSpacing(12)
@@ -178,7 +194,7 @@ def init_ui(self) -> None:
 
     # Finalize
     self.homeWidget = container
-    self.setCentralWidget(container)
+    self.stacked.addWidget(container)
     self.setStatusBar(QStatusBar(self))
 
     # Connect toolbar buttons to methods

--- a/src/Tools/Plot_Generator/gui.py
+++ b/src/Tools/Plot_Generator/gui.py
@@ -5,7 +5,6 @@ import os
 import json
 import subprocess
 import sys
-import json
 from pathlib import Path
 
 from PySide6.QtCore import QThread, QPropertyAnimation, Qt


### PR DESCRIPTION
## Summary
- introduce a QStackedWidget with landing page
- expose new/open project actions for use outside the menu
- switch to project page when a project is loaded
- lint plot generator file

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bace44244832cb8dc82b0638daa4c