### PR TITLE
Hook Advanced Averaging window to main GUI

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import QMessageBox
 from Tools.Stats import StatsWindow as PysideStatsWindow
 from Tools.Stats.Legacy.stats import StatsAnalysisWindow as launch_ctk_stats
 from Main_App.Legacy_App.post_process import post_process as _legacy_post_process
+from Tools.Average_Preprocessing.New_PySide6.main_window import AdvancedAveragingWindow
 from types import MethodType
 import logging
 import pandas as pd
@@ -362,12 +363,16 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
             env["FPVS_PROJECT_ROOT"] = str(proj.project_root)
         subprocess.Popen(cmd, close_fds=True, env=env)
 
+    def open_epoch_averaging(self) -> None:
+        """Instantiate and show the Advanced Averaging Analysis window."""
+        if not hasattr(self, "_epoch_win") or self._epoch_win is None:
+            self._epoch_win = AdvancedAveragingWindow()
+        self._epoch_win.show()
+        self._epoch_win.raise_()
+        self._epoch_win.activateWindow()
+
     def open_advanced_analysis_window(self) -> None:
-        QMessageBox.information(
-            self,
-            "Advanced Analysis",
-            "The advanced preprocessing tool is not yet available in the Qt interface.",
-        )
+        self.open_epoch_averaging()
 
     def show_relevant_publications(self) -> None:
         QMessageBox.information(

--- a/src/Main_App/PySide6_App/GUI/menu_bar.py
+++ b/src/Main_App/PySide6_App/GUI/menu_bar.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from PySide6.QtWidgets import QMenuBar, QMainWindow
-from PySide6.QtGui    import QAction
+from PySide6.QtGui import QAction
 from Main_App.Legacy_App.eloreta_launcher import open_eloreta_tool
+from Tools.Average_Preprocessing.New_PySide6.main_window import AdvancedAveragingWindow  # noqa: F401
 
 def build_menu_bar(parent: QMainWindow) -> QMenuBar:
     """
@@ -30,7 +31,7 @@ def build_menu_bar(parent: QMainWindow) -> QMenuBar:
         ("Source Localization (eLORETA/sLORETA)",      lambda: open_eloreta_tool(parent)),
         ("Image Resizer",                              parent.open_image_resizer),
         ("Generate SNR Plots",                         parent.open_plot_generator),
-        ("Average Epochs in Pre-Processing Phase",     parent.open_advanced_analysis_window),
+        ("Average Epochs in Pre-Processing Phase",     parent.open_epoch_averaging),
     ]
     for text, slot in items:
         action = QAction(text, parent)

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -79,7 +79,7 @@ def init_sidebar(self) -> None:
         lay, "btn_image", "Image Resizer", "camera-photo", self.open_image_resizer
     )
     self.btn_epoch = make_button(
-        lay, "btn_epoch", "Epoch Averaging", "view-refresh", self.open_advanced_analysis_window
+        lay, "btn_epoch", "Epoch Averaging", "view-refresh", self.open_epoch_averaging
     )
     divider = QFrame()
     divider.setFrameShape(QFrame.HLine)

--- a/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
+++ b/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
@@ -1,0 +1,98 @@
+from PySide6.QtWidgets import (
+    QMainWindow, QWidget, QGroupBox, QListWidget, QPushButton,
+    QHBoxLayout, QVBoxLayout, QPlainTextEdit, QSizePolicy,
+)
+from PySide6.QtGui import QAction  # noqa: F401
+import os  # noqa: F401
+
+# Import legacy functions but do NOT alter those files:
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_file_ops import add_files, remove_selected  # noqa: F401
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_group_ops import create_group, rename_group, delete_group  # noqa: F401
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_processing import start_processing, stop_processing  # noqa: F401
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_post import clear_log  # noqa: F401
+
+
+class AdvancedAveragingWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Advanced Averaging Analysis")
+        self._build_ui()
+
+    def _build_ui(self):
+        central = QWidget()
+        main_h = QHBoxLayout(central)
+
+        # — Left Panel —
+        left_v = QVBoxLayout()
+        # Source EEG Files group
+        src_gb = QGroupBox("Source EEG Files")
+        src_l = QVBoxLayout(src_gb)
+        self.src_list = QListWidget()
+        btn_h1 = QHBoxLayout()
+        self.btn_add = QPushButton("Add Files…")
+        self.btn_remove = QPushButton("Remove Selected")
+        btn_h1.addWidget(self.btn_add)
+        btn_h1.addWidget(self.btn_remove)
+        src_l.addWidget(self.src_list)
+        src_l.addLayout(btn_h1)
+        # Defined Averaging Groups group
+        grp_gb = QGroupBox("Defined Averaging Groups")
+        grp_l = QVBoxLayout(grp_gb)
+        self.grp_list = QListWidget()
+        btn_h2 = QHBoxLayout()
+        self.btn_new = QPushButton("Create New Group")
+        self.btn_rename = QPushButton("Rename Group")
+        self.btn_del = QPushButton("Delete Group")
+        btn_h2.addWidget(self.btn_new)
+        btn_h2.addWidget(self.btn_rename)
+        btn_h2.addWidget(self.btn_del)
+        grp_l.addWidget(self.grp_list)
+        grp_l.addLayout(btn_h2)
+
+        left_v.addWidget(src_gb)
+        left_v.addWidget(grp_gb)
+
+        # — Right Panel —
+        right_v = QVBoxLayout()
+        cfg_gb = QGroupBox("Group Configuration")
+        map_gb = QGroupBox("Condition Mapping for Selected Group")
+        cfg_gb.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        map_gb.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        right_v.addWidget(cfg_gb)
+        right_v.addWidget(map_gb)
+
+        main_h.addLayout(left_v)
+        main_h.addLayout(right_v)
+
+        # — Bottom Log & Buttons —
+        log_edit = QPlainTextEdit()
+        log_edit.setReadOnly(True)
+        btn_h3 = QHBoxLayout()
+        self.btn_start = QPushButton("Start Advanced Processing")
+        self.btn_stop = QPushButton("Stop")
+        self.btn_clear = QPushButton("Clear Log")
+        self.btn_close = QPushButton("Close")
+        btn_h3.addWidget(self.btn_start)
+        btn_h3.addWidget(self.btn_stop)
+        btn_h3.addStretch(1)
+        btn_h3.addWidget(self.btn_clear)
+        btn_h3.addWidget(self.btn_close)
+
+        # assemble everything
+        master_v = QVBoxLayout()
+        master_v.addLayout(main_h)
+        master_v.addWidget(log_edit)
+        master_v.addLayout(btn_h3)
+
+        central.setLayout(master_v)
+        self.setCentralWidget(central)
+
+        # — Hook up signals to imported legacy functions (slots left for you) —
+        # self.btn_add.clicked.connect(add_files)
+        # self.btn_remove.clicked.connect(remove_selected)
+        # self.btn_new.clicked.connect(create_group)
+        # self.btn_rename.clicked.connect(rename_group)
+        # self.btn_del.clicked.connect(delete_group)
+        # self.btn_start.clicked.connect(start_processing)
+        # self.btn_stop.clicked.connect(stop_processing)
+        # self.btn_clear.clicked.connect(clear_log)


### PR DESCRIPTION
## Summary
- Wire Tools menu item and sidebar button to open new Advanced Averaging window
- Add `open_epoch_averaging` method that instantiates the PySide6 averaging skeleton
- Import Advanced Averaging callbacks from their specific legacy modules

## Testing
- `ruff check src/Main_App/PySide6_App/GUI/menu_bar.py src/Main_App/PySide6_App/GUI/sidebar.py src/Main_App/PySide6_App/GUI/main_window.py src/Tools/Average_Preprocessing/New_PySide6/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ef851ffc832cb7bec3e58b1ef7ad