### PR TITLE
Refactor legacy advanced analysis imports for PySide6 averaging window

### DIFF
--- a/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
+++ b/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
@@ -6,16 +6,10 @@ from PySide6.QtGui import QAction  # noqa: F401
 import os  # noqa: F401
 
 # Import legacy functions but do NOT alter those files:
-from Tools.Average_Preprocessing.Legacy.advanced_analysis import (
-    add_files,  # noqa: F401
-    remove_selected,  # noqa: F401
-    create_group,  # noqa: F401
-    rename_group,  # noqa: F401
-    delete_group,  # noqa: F401
-    start_processing,  # noqa: F401
-    stop_processing,  # noqa: F401
-    clear_log,  # noqa: F401
-)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_file_ops import add_files, remove_selected  # noqa: F401
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_group_ops import create_group, rename_group, delete_group  # noqa: F401, E501
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_processing import start_processing, stop_processing  # noqa: F401, E501
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_post import clear_log  # noqa: F401
 
 
 class AdvancedAveragingWindow(QMainWindow):


### PR DESCRIPTION
## Summary
- Import advanced analysis operations from their dedicated legacy modules in the PySide6 averaging window

## Testing
- `ruff check src/Tools/Average_Preprocessing/New_PySide6/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f6f1ed78832c95814f7eba1598b8