### PR TITLE
Use mixins for advanced averaging

### DIFF
--- a/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
+++ b/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
@@ -5,14 +5,28 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QAction  # noqa: F401
 import os  # noqa: F401
 
-# Import legacy functions but do NOT alter those files:
-from Tools.Average_Preprocessing.Legacy.advanced_analysis_file_ops import add_files, remove_selected  # noqa: F401
-from Tools.Average_Preprocessing.Legacy.advanced_analysis_group_ops import create_group, rename_group, delete_group  # noqa: F401, E501
-from Tools.Average_Preprocessing.Legacy.advanced_analysis_processing import start_processing, stop_processing  # noqa: F401, E501
-from Tools.Average_Preprocessing.Legacy.advanced_analysis_post import clear_log  # noqa: F401
+# Import legacy mixins but do NOT alter those files:
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_file_ops import (
+    AdvancedAnalysisFileOpsMixin,
+)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_group_ops import (
+    AdvancedAnalysisGroupOpsMixin,
+)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_processing import (
+    AdvancedAnalysisProcessingMixin,
+)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_post import (
+    AdvancedAnalysisPostMixin,
+)
 
 
-class AdvancedAveragingWindow(QMainWindow):
+class AdvancedAveragingWindow(
+    QMainWindow,
+    AdvancedAnalysisFileOpsMixin,
+    AdvancedAnalysisGroupOpsMixin,
+    AdvancedAnalysisProcessingMixin,
+    AdvancedAnalysisPostMixin,
+):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Advanced Averaging Analysis")


### PR DESCRIPTION
## Summary
- Import advanced analysis mixins instead of nonexistent functions
- Inherit AdvancedAveragingWindow from mixins to enable legacy behavior

## Testing
- `ruff check src/Tools/Average_Preprocessing/New_PySide6/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890f9d1859c832c99164e5c1b2ffa28