### PR TITLE
fix: import averaging mixins

### DIFF
--- a/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
+++ b/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
@@ -12,6 +12,19 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QAction  # noqa: F401
 import os  # noqa: F401
 
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_file_ops import (
+    AdvancedAnalysisFileOpsMixin,
+)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_group_ops import (
+    AdvancedAnalysisGroupOpsMixin,
+)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_processing import (
+    AdvancedAnalysisProcessingMixin,
+)
+from Tools.Average_Preprocessing.Legacy.advanced_analysis_post import (
+    AdvancedAnalysisPostMixin,
+)
+
 
 class AdvancedAveragingWindow(
     QMainWindow,


### PR DESCRIPTION
## Summary
- fix missing imports for Advanced Averaging mixins in PySide6 window

## Testing
- `ruff check src/Tools/Average_Preprocessing/New_PySide6/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fb9085ec832c965d85ec3d479ab4