### PR TITLE
fix: handle missing data subfolder

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -369,8 +369,15 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
             QMessageBox.warning(self, "No Project", "Please load a project first.")
             return
 
-        data_dir = self.currentProject.subfolders["data"]
-        excel_dir = self.currentProject.subfolders["excel"]
+        data_dir = self.currentProject.subfolders.get("data")
+        if data_dir is None:
+            data_dir = str(self.currentProject.input_folder)
+        else:
+            data_dir = str(self.currentProject.project_root / data_dir)
+        excel_dir = str(
+            self.currentProject.project_root
+            / self.currentProject.subfolders.get("excel", "")
+        )
 
         # create or reuse the window
         if not getattr(self, "_epoch_win", None):


### PR DESCRIPTION
## Summary
- prevent crash when launching advanced averaging without a `data` subfolder by defaulting to the project's input folder
- resolve output path relative to project root

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891159987a4832cae0b3afa53a46563