### PR TITLE
fix: support launching LORETA from PySide6

### DIFF
--- a/src/Main_App/Legacy_App/eloreta_launcher.py
+++ b/src/Main_App/Legacy_App/eloreta_launcher.py
@@ -2,36 +2,46 @@
 
 from __future__ import annotations
 
-from tkinter import messagebox
-
 
 def open_eloreta_tool(app):
     """Launch the eLORETA/sLORETA GUI.
 
     Parameters
     ----------
-    app : tkinter.Misc
-        Parent window from which the tool is launched.
+    app : object
+        Parent window from which the tool is launched. May be a PySide6
+        ``QWidget`` or ``None``.
     """
-    if not messagebox.askyesno(
-        "LORETA Tool Warning",
-        (
-            "IMPORTANT: The LORETA Tool is currently under active development. "
-            "Certain features may not work as intended. Continue?"
-        ),
-        parent=app,
-    ):
-        return None
+
+    try:  # Use a Qt message box when available
+        from PySide6.QtWidgets import QMessageBox, QWidget
+    except Exception:  # pragma: no cover - PySide6 not installed
+        QMessageBox = None
+        QWidget = object
+
+    if isinstance(app, QWidget) and QMessageBox is not None:
+        reply = QMessageBox.question(
+            app,
+            "LORETA Tool Warning",
+            (
+                "IMPORTANT: The LORETA Tool is currently under active development. "
+                "Certain features may not work as intended. Continue?"
+            ),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return None
 
     # Import inside the function to avoid heavy dependencies at startup
     from Tools.SourceLocalization import SourceLocalizationWindow
 
-    tool = SourceLocalizationWindow(master=app)
-    try:
-        # Respect any stored geometry settings if available
+    tool = SourceLocalizationWindow()
+
+    try:  # Restore previous window geometry if available
         geometry = app.settings.get("gui", "eloreta_size", "900x700")
         tool.geometry(geometry)
-    except Exception:
-        # If the app has no settings or retrieval fails, ignore
+    except Exception:  # pragma: no cover - optional
         pass
+
     return tool

--- a/src/Tools/SourceLocalization/eloreta_gui.py
+++ b/src/Tools/SourceLocalization/eloreta_gui.py
@@ -23,7 +23,16 @@ from . import runner, worker
 
 class SourceLocalizationWindow(ctk.CTkToplevel):
     def __init__(self, master=None):
+        self._owns_root = False
+        if master is None or not hasattr(master, "tk"):
+            master = ctk.CTk()
+            master.withdraw()
+            self._owns_root = True
+        self._root = master
         super().__init__(master)
+        if self._owns_root:
+            self.protocol("WM_DELETE_WINDOW", self._root.destroy)
+            threading.Thread(target=self._root.mainloop, daemon=True).start()
         self.transient(master)
         init_fonts()
         self.option_add("*Font", str(FONT_MAIN), 80)


### PR DESCRIPTION
## Summary
- allow source localization tool to launch from a PySide6 window without providing a Tk root by relying on a Qt message box
- let `SourceLocalizationWindow` create its own hidden Tk root and run its loop in a background thread when needed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689200c76edc832ca716aec970884acc