### PR TITLE
feat: add header label to advanced averaging window

### DIFF
--- a/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
+++ b/src/Tools/Average_Preprocessing/New_PySide6/main_window.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 from PySide6.QtGui import QCloseEvent
+from PySide6.QtCore import Qt
 import os
 
 # --- Ported Mixin Imports ---
@@ -56,6 +57,15 @@ class AdvancedAveragingWindow(
     def _build_ui(self):
         central = QWidget()
         main_v = QVBoxLayout(central)
+
+        # — Window Header —
+        header = QLabel("Advanced Averaging Analysis")
+        font = header.font()
+        font.setPointSize(font.pointSize() + 2)
+        font.setBold(True)
+        header.setFont(font)
+        header.setAlignment(Qt.AlignCenter)
+        main_v.addWidget(header)
 
         # Row 1: Explanatory Box
         info_box = QGroupBox()


### PR DESCRIPTION
## Summary
- Import Qt alignment utilities for the PySide6 GUI
- Display a bold, centered "Advanced Averaging Analysis" header at the top of the AdvancedAveragingWindow

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68937fe305b0832cbbaab2876c2149e4