### PR TITLE
Style sidebar and progress bar in PySide6 main window

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QPushButton,
 )
 from PySide6.QtCore import QObject, Signal, QTimer, QPropertyAnimation, QRect
+from PySide6.QtGui import QFont
 import tkinter.messagebox as tk_messagebox
 from PySide6.QtWidgets import QMessageBox
 from Tools.Stats import StatsWindow as PysideStatsWindow
@@ -131,6 +132,25 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         self.setMinimumSize(1024, 768)
         self.currentProject: Project | None = None
         init_ui(self)
+
+        # Make sidebar charcoal without editing sidebar.py
+        self.sidebar.setStyleSheet("background-color: #2E2E2E;")
+
+        # Restyle "Current Project" label
+        font = self.lbl_currentProject.font()
+        font.setPointSize(font.pointSize() + 2)
+        font.setWeight(QFont.DemiBold)
+        self.lbl_currentProject.setFont(font)
+        self.lbl_currentProject.setStyleSheet(
+            "background-color: #E8E8E8; border-bottom: 1px solid #CCCCCC; padding: 6px 12px;"
+        )
+
+        # Force progress bar to render empty at full height
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setTextVisible(True)
+        self.progress_bar.setMinimumHeight(self.btn_start.minimumHeight())
+
         # Prevent spurious finalize/error dialogs until a run starts
         self._run_active = False
         # Support legacy .set() calls from processing_utils


### PR DESCRIPTION
## Summary
- Import QFont to support dynamic font styling for GUI elements
- Apply charcoal styling to sidebar and restyle the Current Project label with larger semi-bold text and gray background
- Ensure progress bar starts at full height with visible 0% value matching the Start button

## Testing
- `ruff check src/Main_App/PySide6_App/GUI/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b801f35c832c95fd2c91c8273653