### PR TITLE
Ensure full-width styling for Current Project bar

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -141,8 +141,17 @@ class MainWindow(QMainWindow, FileSelectionMixin, ValidationMixin, ProcessingMix
         font.setPointSize(font.pointSize() + 2)
         font.setWeight(QFont.DemiBold)
         self.lbl_currentProject.setFont(font)
+
+        # Style the container so the full bar shares the same gray background
+        container = self.lbl_currentProject.parentWidget()
+        if container is not None:
+            container.setStyleSheet(
+                "background-color: #E8E8E8; border-bottom: 1px solid #CCCCCC;"
+            )
+
+        # Make label background transparent to inherit container color
         self.lbl_currentProject.setStyleSheet(
-            "background-color: #E8E8E8; border-bottom: 1px solid #CCCCCC; padding: 6px 12px;"
+            "background: transparent; padding: 6px 12px;"
         )
 
         # Force progress bar to render empty at full height


### PR DESCRIPTION
## Summary
- Style the parent container of the "Current Project" label so the bar uses a uniform gray background and bottom border
- Make the label itself transparent so the container styling spans the full width

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b98c3a78832cb29dc35f3f604905