### PR TITLE
White-out SNR icon and remove sidebar title bar

### DIFF
--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -71,7 +71,7 @@ def init_sidebar(self) -> None:
         self.open_stats_analyzer,
     )
     icon_dir = Path(__file__).resolve().parent / "icons"
-    snr_icon = QIcon(str(icon_dir / "snr_plots.svg"))
+    snr_icon = white_icon(str(icon_dir / "snr_plots.svg"))
     self.btn_graphs = make_button(
         lay, "btn_graphs", "SNR Plots", snr_icon, self.open_plot_generator
     )
@@ -101,3 +101,5 @@ def init_sidebar(self) -> None:
     dock.setWidget(sidebar)
     dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
     self.addDockWidget(Qt.LeftDockWidgetArea, dock)
+    # Remove the empty gray title bar above the sidebar
+    dock.setTitleBarWidget(QWidget())


### PR DESCRIPTION
## Summary
- Tint sidebar SNR icon white for consistency
- Hide QDockWidget title bar to remove unused gray strip

## Testing
- `ruff check src/Main_App/PySide6_App/GUI/sidebar.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c1d75ae4832c97fd30a710ba553f