### PR TITLE
Handle windll import cross-platform in main entrypoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,12 +7,13 @@
 
 USE_PYSIDE6 = True #"currently in dual GUI mode - set to False to use the legacy Tkinter GUI"
 
-from ctypes import windll
+import ctypes
 import sys
 from PySide6.QtCore import QCoreApplication
 
+# Set DPI awareness on Windows; safe to ignore on other platforms
 try:
-    windll.shcore.SetProcessDpiAwareness(1)
+    ctypes.windll.shcore.SetProcessDpiAwareness(1)
 except Exception:
     pass
 


### PR DESCRIPTION
## Summary
- make ctypes.windll access optional so `main.py` works on non-Windows platforms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899fdf1a918832ca1a44667c336156e