### PR TITLE
feat: add single-thread safeguards

### DIFF
--- a/src/Main_App/PySide6_App/Backend/preprocess.py
+++ b/src/Main_App/PySide6_App/Backend/preprocess.py
@@ -103,7 +103,7 @@ def perform_preprocessing(
             try:
                 ds = float(downsample_rate)
                 if sf > ds:
-                    raw.resample(ds, npad="auto", window="hann", verbose=False)
+                    raw.resample(ds, npad="auto", window="hann", n_jobs=1, verbose=False)
                     log_func(f"Resampled {fname} to {raw.info['sfreq']:.1f}Hz.")
                 elif abs(sf - ds) < 1e-6:
                     log_func(f"Already at {downsample_rate}Hz; skipping resample for {fname}.")
@@ -134,6 +134,7 @@ def perform_preprocessing(
                     h_trans_bandwidth=high_trans_bw,
                     filter_length=filter_len_points,
                     skip_by_annotation="edge",
+                    n_jobs=1,
                     verbose=False,
                 )
                 log_func(f"Filter OK for {fname}.")

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -17,7 +17,7 @@ from types import MethodType, SimpleNamespace, ModuleType
 from collections import deque
 
 # Qt / PySide6
-from PySide6.QtCore import QObject, QTimer, Signal, QThread
+from PySide6.QtCore import QObject, QTimer, Signal, QThread, Slot
 from PySide6.QtGui import QFont, QIntValidator, QCloseEvent, QAction  # noqa: F401
 from PySide6.QtWidgets import (
     QApplication,
@@ -383,7 +383,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
 
         # Default: timer on; we'll stop it in process mode
         if not self._processing_timer.isActive():
-            self._processing_timer.start(50)
+            self._processing_timer.start(100)
 
         try:
             if not getattr(self, "_n_jobs_ignored_logged", False):
@@ -467,7 +467,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
             from Main_App.Performance.mp_env import set_blas_threads_single_process
             set_blas_threads_single_process()
             if not self._processing_timer.isActive():
-                self._processing_timer.start(50)
+                self._processing_timer.start(100)
             super().start_processing()
 
         except Exception as e:
@@ -519,6 +519,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
             pass
         super()._finalize_processing(success)
 
+    @Slot()
     def _periodic_queue_check(self) -> None:
         if not self._run_active:
             return
@@ -556,7 +557,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
                     self._finalize_processing(True)
                 return
 
-        delay = 16 if processed else 50
+        delay = 100
         QTimer.singleShot(delay, self._periodic_queue_check)
 
     def _start_post_worker(self, file_name: str, epochs_dict: dict, labels: list[str]) -> None:

--- a/src/Main_App/PySide6_App/adapters/post_export_adapter.py
+++ b/src/Main_App/PySide6_App/adapters/post_export_adapter.py
@@ -96,7 +96,7 @@ def _write_missing_fifs(ctx: LegacyCtx, save_root: Path, labels: List[str]) -> i
         out_path = out_dir / _legacy_like_fname(base_stem, label)
         if not out_path.exists():
             try:
-                epochs.save(str(out_path), overwrite=True)
+                epochs.save(str(out_path), overwrite=True, split_size=2 * 1024 ** 3)
                 written += 1
             except Exception:
                 # Keep quiet; Excel export may still succeed

--- a/src/Main_App/PySide6_App/workers/mp_runner_bridge.py
+++ b/src/Main_App/PySide6_App/workers/mp_runner_bridge.py
@@ -6,7 +6,7 @@ from multiprocessing import Queue, get_context
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from PySide6.QtCore import QObject, QTimer, Signal
+from PySide6.QtCore import QObject, QTimer, Signal, Slot
 
 from Main_App.Performance.mp_env import set_blas_threads_single_process
 from Main_App.Performance.process_runner import RunParams, run_project_parallel
@@ -54,6 +54,7 @@ class MpRunnerBridge(QObject):
         self._total = len(data_files)
         self._timer.start()
 
+    @Slot()
     def _poll(self) -> None:
         if not self._q:
             return

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,10 @@
 
 """Entry point for launching the FPVS Toolbox GUI application."""
 
+from Main_App.Performance.mp_env import set_blas_threads_single_process
+
+set_blas_threads_single_process()
+
 USE_PYSIDE6 = True  # currently in dual GUI mode - set to False to use the legacy Tkinter GUI
 
 from ctypes import windll

--- a/tests/test_phase1_perf_hygiene.py
+++ b/tests/test_phase1_perf_hygiene.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import types
+from pathlib import Path
+import pytest
+
+
+def test_phase1_perf_hygiene(qtbot):
+    main_path = Path(__file__).resolve().parents[1] / "src" / "main.py"
+    lines = main_path.read_text().splitlines()
+    set_line = next(i for i, l in enumerate(lines) if "set_blas_threads_single_process()" in l)
+    main_app_import = next(i for i, l in enumerate(lines) if "from Main_App" in l and "mp_env" not in l)
+    assert set_line < main_app_import
+
+    for var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+        os.environ.pop(var, None)
+    mp_env_path = Path(__file__).resolve().parents[1] / "src" / "Main_App" / "Performance" / "mp_env.py"
+    spec = types.ModuleType("mp_env")
+    exec(mp_env_path.read_text(), spec.__dict__)
+    spec.set_blas_threads_single_process()
+    assert os.environ.get("OMP_NUM_THREADS")
+
+    sys.modules.pop("Main_App", None)
+    stub = types.ModuleType("Main_App")
+    stub.__path__ = [str(Path(__file__).resolve().parents[1] / "src" / "Main_App")]
+    class _SettingsManager:
+        def __init__(self, *a, **k):
+            pass
+    stub.SettingsManager = _SettingsManager
+    sys.modules["Main_App"] = stub
+    legacy_stub = types.ModuleType("Main_App.Legacy_App")
+    legacy_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "src" / "Main_App" / "Legacy_App")]
+    sys.modules["Main_App.Legacy_App"] = legacy_stub
+    pp_stub = types.ModuleType("Main_App.Legacy_App.post_process")
+    def _pp(*a, **k):
+        return None
+    pp_stub.post_process = _pp
+    sys.modules["Main_App.Legacy_App.post_process"] = pp_stub
+
+    try:
+        from Main_App.PySide6_App.GUI.main_window import MainWindow
+    except Exception as e:  # pragma: no cover - env missing deps
+        pytest.skip(f"MainWindow import skipped: {e}")
+
+    window = MainWindow()
+    qtbot.addWidget(window)
+
+    timer = window._processing_timer
+    timer.start(100)
+    assert timer.interval() >= 100
+
+    assert callable(window._periodic_queue_check)
+    assert timer.receivers(timer.timeout) > 0


### PR DESCRIPTION
## Summary
- cap BLAS threads before numpy loads in main entry
- force single-threaded MNE ops and chunked epoch writes
- mark hot Qt callbacks with @Slot and calm polling to 100ms

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_phase1_perf_hygiene.py -q` *(skipped: MainWindow import skipped: cannot import name 'Variable' from 'tkinter')*


------
https://chatgpt.com/codex/tasks/task_e_689e06d1cfe8832c9320a610592b9fa1