### PR TITLE
Demodalize LORETA viewer to avoid modal freeze

### DIFF
--- a/src/Tools/SourceLocalization/qt_dialog.py
+++ b/src/Tools/SourceLocalization/qt_dialog.py
@@ -363,11 +363,16 @@ class SourceLocalizationDialog(QDialog):
         )
         log.debug("ENTER _open_viewer", extra=pre_state)
         base = self._last_stc_base or ""
+        opts = QFileDialog.Options()
+        # Use Qt's own dialog to avoid Windows native modality quirks
+        opts |= QFileDialog.DontUseNativeDialog
+        log.debug("stc_file_dialog", extra={"native": False})
         path, _ = QFileDialog.getOpenFileName(
             self,
             "Open STC (pick -lh.stc or -rh.stc)",
             base,
             "MNE STC (*.stc)",
+            options=opts,
         )
         if not path:
             log.debug("EXIT _open_viewer (cancel)")

--- a/src/Tools/SourceLocalization/visualization.py
+++ b/src/Tools/SourceLocalization/visualization.py
@@ -164,14 +164,15 @@ def view_source_estimate(
         )
         kwargs = {"title": window_title or _derive_title(stc_path)}
         app = QtWidgets.QApplication.instance()
-        if app is not None:
+        has_app = app is not None
+        if has_app:
             kwargs.update(
                 {"interactive": False, "auto_close": False, "window_size": (900, 700)}
             )
-            log.debug("pv_plotter_show", extra={"blocking": False, **kwargs})
+            log.debug("pv_plotter_show", extra={"has_app": True, "blocking": False, **kwargs})
             pl.show(**kwargs)
         else:
-            log.debug("pv_plotter_show", extra={"blocking": True, **kwargs})
+            log.debug("pv_plotter_show", extra={"has_app": False, "blocking": True, **kwargs})
             pl.show(**kwargs)
         log.debug("EXIT view_source_estimate", extra={"path": stc_path})
         return pl

--- a/tests/test_loreta_viewer_focus.py
+++ b/tests/test_loreta_viewer_focus.py
@@ -5,9 +5,10 @@ from pathlib import Path
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 from PySide6 import QtWidgets
+import logging
 
 
-def test_loreta_viewer_focus(qtbot, monkeypatch):
+def test_loreta_viewer_focus(qtbot, monkeypatch, caplog):
     # Stub external dependencies
     class DummySettings:
         def __init__(self):
@@ -79,6 +80,8 @@ def test_loreta_viewer_focus(qtbot, monkeypatch):
         QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: ("dummy-lh.stc", "")
     )
 
+    caplog.set_level(logging.DEBUG, logger="Tools.SourceLocalization")
+
     dlg._open_viewer()
 
     viewer = pyqt_viewer._OPEN_VIEWERS[-1]
@@ -89,6 +92,10 @@ def test_loreta_viewer_focus(qtbot, monkeypatch):
         assert QtWidgets.QApplication.activeWindow() is viewer
 
     qtbot.waitUntil(_active, timeout=500)
+
+    qtbot.wait(1000)
+    ticks = [r for r in caplog.records if r.message == "sentinel tick"]
+    assert len(ticks) >= 2
 
     for w in QtWidgets.QApplication.topLevelWidgets():
         assert not w.isModal()


### PR DESCRIPTION
## Summary
- open STC file with Qt dialog and log dialog modality before launching viewer
- launch viewer modelessly, audit top-level windows, and run a sentinel timer
- ensure PyVista renders non-blocking when a Qt app exists
- add pytest-qt regression test verifying viewer activation and sentinel ticks

## Testing
- `ruff check src/Tools/SourceLocalization/qt_dialog.py src/Tools/SourceLocalization/pyqt_viewer.py src/Tools/SourceLocalization/visualization.py tests/test_loreta_viewer_focus.py >/tmp/ruff.log && tail -n 20 /tmp/ruff.log`
- `pytest tests/test_loreta_viewer_focus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a37a3e006c832ca4fd1ef2320e10bc