### PR TITLE
feat: async stats run and focus retention

### DIFF
--- a/src/Tools/Stats/PySide6/stats_worker.py
+++ b/src/Tools/Stats/PySide6/stats_worker.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+import time
+from PySide6.QtCore import QObject, Signal, Slot, QRunnable, QThreadPool
+from PySide6.QtWidgets import QWidget, QPushButton, QLabel, QProgressBar
+from PySide6.QtGui import QAction
+
+_qt_refs = (QWidget, QPushButton, QLabel, QProgressBar, QAction, QThreadPool)
+
+logger = logging.getLogger("Tools.Stats")
+
+
+class StatsWorker(QRunnable):
+    class Signals(QObject):
+        progress = Signal(int)
+        message = Signal(str)
+        error = Signal(str)
+        finished = Signal(dict)
+
+    def __init__(self, fn, *args, **kwargs):
+        super().__init__()
+        self.signals = self.Signals()
+        self._fn = fn
+        self._args = args
+        self._kwargs = kwargs
+
+    @Slot()
+    def run(self) -> None:
+        t0 = time.perf_counter()
+        try:
+            result = self._fn(
+                self.signals.progress.emit, self.signals.message.emit, *self._args, **self._kwargs
+            )
+            payload = result if isinstance(result, dict) else {"result": result}
+            self.signals.finished.emit(payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("stats_run_failed")
+            self.signals.error.emit(str(exc))
+        finally:
+            dt = (time.perf_counter() - t0) * 1000
+            logger.info("stats_run_done", extra={"elapsed_ms": dt})

--- a/tests/test_stats_focus_async.py
+++ b/tests/test_stats_focus_async.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow, StatsWorker
+
+
+def test_stats_focus_async(qtbot, monkeypatch):
+    win = StatsWindow(project_dir=str(Path.cwd()))
+    qtbot.addWidget(win)
+    win.show()
+    win.subject_data = {"s1": {"c1": {"roi": 1.0}}}
+    win.subjects = ["s1"]
+    win.conditions = ["c1"]
+
+    def fake_run(self):
+        self.signals.message.emit("start")
+        self.signals.progress.emit(55)
+        time.sleep(0.01)
+        self.signals.finished.emit({})
+
+    monkeypatch.setattr(StatsWorker, "run", fake_run, raising=False)
+
+    qtbot.mouseClick(win.run_rm_anova_btn, Qt.LeftButton)
+    assert not win.run_rm_anova_btn.isEnabled()
+    qtbot.waitUntil(lambda: win.run_rm_anova_btn.isEnabled(), timeout=1000)
+    assert win._progress_updates
+    assert win._focus_calls >= 2


### PR DESCRIPTION
## Summary
- run RM-ANOVA via background `StatsWorker` with progress and logging
- add spinner and progress bar to Stats window, retaining focus before and after analysis
- add pytest-qt smoke test for focus and responsiveness

## Testing
- `python -m venv .venv && '.venv\Scripts\pip' install -U pip` *(fails: command not found)*
- `.venv\Scripts\pip install PySide6 pytest pytest-qt ruff mypy` *(fails: command not found)*
- `.venv\Scripts\python -m pytest -q` *(fails: command not found)*
- `.venv\Scripts\ruff check .` *(fails: command not found)*
- `.venv\Scripts\mypy src --strict` *(fails: command not found)*
- `python -m venv .venv && .venv/bin/pip install -U pip`
- `.venv/bin/pip install PySide6 pytest pytest-qt ruff mypy`
- `.venv/bin/python -m pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `.venv/bin/ruff check .` *(fails: E402 module level import not at top of file, etc.)*
- `.venv/bin/mypy src --strict` *(fails: Compiler_Script.py invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68c19f18bdac832c8c2e2d6a6bcc17ff