### PR TITLE
fix: stabilize stats spinner and worker

### DIFF
--- a/src/Main_App/PySide6_App/widgets/busy_spinner.py
+++ b/src/Main_App/PySide6_App/widgets/busy_spinner.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from PySide6.QtCore import QTimer, QPointF, QSize, Qt
+from PySide6.QtCore import QTimer, QPoint, QSize, Qt
 from PySide6.QtGui import QPainter, QPen
 from PySide6.QtWidgets import QWidget
 
@@ -37,8 +37,7 @@ class BusySpinner(QWidget):
     def paintEvent(self, _e) -> None:  # type: ignore[override]
         p = QPainter(self)
         p.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-        radius = self._diameter / 2
-        center = QPointF(self.width() / 2, self.height() / 2)
+        center = QPoint(self.width() // 2, self.height() // 2)
         pen = QPen(self.palette().highlight().color())
         pen.setWidthF(max(1.5, self.devicePixelRatioF() * 1.25))
         pen.setCapStyle(Qt.PenCapStyle.RoundCap)

--- a/src/Tools/Stats/PySide6/stats_ui_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_ui_pyside6.py
@@ -125,6 +125,8 @@ class StatsWindow(QMainWindow):
         self.setWindowTitle("FPVS Statistical Analysis Tool")
 
         self._guard = OpGuard()
+        if not hasattr(self._guard, "done"):
+            self._guard.done = self._guard.end  # type: ignore[attr-defined]
         self.pool = QThreadPool.globalInstance()
         self._focus_calls = 0
 
@@ -202,7 +204,7 @@ class StatsWindow(QMainWindow):
     @Slot(str)
     def _on_worker_error(self, msg: str) -> None:
         self.results_text.append(f"Error: {msg}")
-        self._guard.end()
+        self._guard.done()
         self._set_running(False)
         self._focus_self()
 
@@ -287,7 +289,7 @@ class StatsWindow(QMainWindow):
         else:
             output_text += "RM-ANOVA did not return any results or the result was empty.\n"
         self.results_text.append(output_text)
-        self._guard.end()
+        self._guard.done()
         self._set_running(False)
         self._focus_self()
 

--- a/src/Tools/Stats/PySide6/stats_worker.py
+++ b/src/Tools/Stats/PySide6/stats_worker.py
@@ -2,11 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from PySide6.QtCore import QObject, Signal, Slot, QRunnable, QThreadPool
-from PySide6.QtWidgets import QWidget, QPushButton, QLabel, QProgressBar
-from PySide6.QtGui import QAction
-
-_qt_refs = (QWidget, QPushButton, QLabel, QProgressBar, QAction, QThreadPool)
+from PySide6.QtCore import QObject, Signal, Slot, QRunnable
 
 logger = logging.getLogger("Tools.Stats")
 

--- a/tests/test_stats_focus_async.py
+++ b/tests/test_stats_focus_async.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 from PySide6.QtCore import Qt
 
-from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow, StatsWorker
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+from Tools.Stats.PySide6.stats_worker import StatsWorker
 
 
 def test_stats_focus_async(qtbot, monkeypatch):


### PR DESCRIPTION
## Summary
- avoid QRect translation crash by using QPoint in BusySpinner
- align StatsWindow with OpGuard.done and reactivate window after async run
- clean up StatsWorker and fix test imports

## Testing
- `ruff check src/Main_App/PySide6_App/widgets/busy_spinner.py src/Tools/Stats/PySide6/stats_ui_pyside6.py src/Tools/Stats/PySide6/stats_worker.py tests/test_stats_focus_async.py`
- `pytest tests/test_stats_focus_async.py -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bc157968832c9a4e1660001397cd