### PR TITLE
Ensure stats tool only uses configured ROIs

### DIFF
--- a/src/Tools/Stats/PySide6/stats_ui_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_ui_pyside6.py
@@ -612,6 +612,9 @@ class StatsWindow(QMainWindow):
             return
         # make sure we are using current ROIs from settings
         self.refresh_rois()
+        if not self.rois:
+            QMessageBox.warning(self, "No ROIs", "Define at least one ROI in Settings before running stats.")
+            return
         try:
             settings = SettingsManager()
             base_freq = float(settings.get("analysis", "base_freq", 6.0))
@@ -646,6 +649,9 @@ class StatsWindow(QMainWindow):
             QMessageBox.warning(self, "No Data", "Please scan a data folder first.")
             return
         self.refresh_rois()
+        if not self.rois:
+            QMessageBox.warning(self, "No ROIs", "Define at least one ROI in Settings before running stats.")
+            return
         try:
             settings = SettingsManager()
             base_freq = float(settings.get("analysis", "base_freq", 6.0))
@@ -689,6 +695,9 @@ class StatsWindow(QMainWindow):
             return
 
         self.refresh_rois()
+        if not self.rois:
+            QMessageBox.warning(self, "No ROIs", "Define at least one ROI in Settings before running stats.")
+            return
         try:
             settings = SettingsManager()
             base_freq = float(settings.get("analysis", "base_freq", 6.0))
@@ -725,6 +734,9 @@ class StatsWindow(QMainWindow):
             return
 
         self.refresh_rois()
+        if not self.rois:
+            QMessageBox.warning(self, "No ROIs", "Define at least one ROI in Settings before running stats.")
+            return
         try:
             settings = SettingsManager()
             base_freq = float(settings.get("analysis", "base_freq", 6.0))


### PR DESCRIPTION
## Summary
- update the legacy stats ROI loader to return only Settings-defined entries without injecting defaults
- ensure the PySide6 stats UI refresh uses the live Settings ROIs and blocks run actions when none are defined

## Testing
- ruff check *(fails: existing repository lint violations unrelated to this change)*
- pytest *(fails: missing optional dependencies such as PySide6, numpy, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68cac4c1af10832caea3f6a08a3c84b3