### PR TITLE
Handle missing project roots when opening existing projects

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -815,7 +815,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
         self._on_project_ready()
 
     def open_existing_project(self) -> None:
-        open_existing_project(self)
+        open_existing_project(self, self)
         self._on_project_ready()
 
     def openProjectPath(self, folder: str) -> None:  # noqa: N802 (compat)

--- a/src/Main_App/PySide6_App/config/projects_root.py
+++ b/src/Main_App/PySide6_App/config/projects_root.py
@@ -1,9 +1,37 @@
 """Settings dialog helpers for managing the projects root path."""
 from __future__ import annotations
 
-from PySide6.QtWidgets import QFileDialog, QMessageBox
+from pathlib import Path
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox, QWidget
 
 from Main_App.PySide6_App.utils.settings import get_app_settings
+
+
+def ensure_projects_root(parent: QWidget | None) -> Path | None:
+    """Ensure a valid projects root exists, prompting the user if necessary."""
+
+    settings = get_app_settings()
+    saved_root = settings.value("paths/projectsRoot", "", type=str)
+    if saved_root:
+        root_path = Path(saved_root)
+        if root_path.is_dir():
+            return root_path
+    options = QFileDialog.Options()
+    options |= QFileDialog.ShowDirsOnly
+    options |= QFileDialog.DontResolveSymlinks
+    selected = QFileDialog.getExistingDirectory(
+        parent,
+        "Select Projects Root",
+        saved_root or "",
+        options=options,
+    )
+    if not selected:
+        return None
+    root_path = Path(selected)
+    settings.setValue("paths/projectsRoot", selected)
+    settings.sync()
+    return root_path
 
 
 def changeProjectsRoot(self) -> None:

--- a/tests/test_open_existing_project_dialog.py
+++ b/tests/test_open_existing_project_dialog.py
@@ -1,0 +1,139 @@
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("PySide6") is None or importlib.util.find_spec("pytestqt") is None:
+    pytest.skip("PySide6 or pytest-qt not available", allow_module_level=True)
+
+from PySide6.QtWidgets import QApplication
+
+import Main_App.PySide6_App.Backend.project_manager as project_manager
+import Main_App.PySide6_App.config.projects_root as projects_root
+from Main_App.PySide6_App.utils import settings as settings_mod
+
+
+@pytest.fixture
+def main_window(tmp_path, qtbot, monkeypatch):
+    os.environ["XDG_DATA_HOME"] = str(tmp_path)
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+    settings_mod._SETTINGS_INSTANCE = None
+    settings_mod._MIGRATED = False
+
+    QApplication.instance() or QApplication([])
+
+    monkeypatch.setattr(
+        project_manager,
+        "select_projects_root",
+        lambda self: setattr(self, "projectsRoot", tmp_path),
+    )
+
+    from Main_App.PySide6_App.GUI.main_window import MainWindow
+
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.projectsRoot = tmp_path
+    return window
+
+
+@pytest.fixture
+def message_spy(monkeypatch):
+    captured = {"info": [], "warning": [], "critical": []}
+
+    def _record_info(parent, title, text):  # noqa: ARG001 - pytest-qt stub
+        captured["info"].append((title, text))
+        return None
+
+    def _record_warning(parent, title, text):  # noqa: ARG001
+        captured["warning"].append((title, text))
+        return None
+
+    def _record_critical(parent, title, text):  # noqa: ARG001
+        captured["critical"].append((title, text))
+        return None
+
+    monkeypatch.setattr(project_manager.QMessageBox, "information", _record_info)
+    monkeypatch.setattr(project_manager.QMessageBox, "warning", _record_warning)
+    monkeypatch.setattr(project_manager.QMessageBox, "critical", _record_critical)
+    return captured
+
+
+def test_open_existing_project_missing_root_prompts(monkeypatch, main_window, message_spy):
+    monkeypatch.setattr(
+        projects_root.QFileDialog,
+        "getExistingDirectory",
+        lambda *args, **kwargs: "",
+    )
+
+    settings = settings_mod.get_app_settings()
+    settings.remove("paths/projectsRoot")
+    settings.sync()
+
+    main_window.open_existing_project()
+
+    assert ("Projects Root", "Project root not set.") in message_spy["info"]
+
+
+def test_open_existing_project_empty_root_informs(tmp_path, main_window, monkeypatch, message_spy):
+    monkeypatch.setattr(
+        project_manager,
+        "ensure_projects_root",
+        lambda parent: tmp_path,
+    )
+
+    main_window.open_existing_project()
+
+    assert message_spy["info"]
+    _title, text = message_spy["info"][0]
+    assert "No projects" in text
+    assert str(tmp_path) in text
+
+
+def test_open_existing_project_handles_iterdir_error(tmp_path, main_window, monkeypatch, message_spy, caplog):
+    monkeypatch.setattr(
+        project_manager,
+        "ensure_projects_root",
+        lambda parent: tmp_path,
+    )
+
+    original_iterdir = Path.iterdir
+
+    def _raising_iterdir(self):
+        if self == tmp_path:
+            raise FileNotFoundError("gone")
+        return original_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", _raising_iterdir)
+
+    with caplog.at_level("ERROR", logger=project_manager.logger.name):
+        main_window.open_existing_project()
+
+    assert message_spy["critical"]
+    assert any("Unable to enumerate projects" in rec.message for rec in caplog.records)
+
+
+def test_open_existing_project_cancel_from_dialog(tmp_path, main_window, monkeypatch, message_spy):
+    monkeypatch.setattr(
+        project_manager,
+        "ensure_projects_root",
+        lambda parent: tmp_path,
+    )
+
+    project_dir = tmp_path / "proj1"
+    project_dir.mkdir()
+    (project_dir / "project.json").write_text("{}", encoding="utf-8")
+
+    seen = {}
+
+    def _fake_get_item(parent, title, label, items, current, editable):  # noqa: ARG001
+        seen["items"] = list(items)
+        return "", False
+
+    monkeypatch.setattr(project_manager.QInputDialog, "getItem", _fake_get_item)
+
+    main_window.open_existing_project()
+
+    assert "items" in seen
+    assert seen["items"]
+    assert not message_spy["critical"]


### PR DESCRIPTION
## Summary
- add ensure_projects_root helper to validate and persist the projects root path
- harden open_existing_project with re-entrancy guard, error handling, and parent-aware dialogs
- add pytest-qt coverage for missing roots, filesystem errors, and cancelled project selection

## Testing
- pytest tests/test_open_existing_project_dialog.py *(skipped: PySide6 or pytest-qt not available)*
- ruff check src/Main_App/PySide6_App/config/projects_root.py src/Main_App/PySide6_App/Backend/project_manager.py tests/test_open_existing_project_dialog.py


------
https://chatgpt.com/codex/tasks/task_e_690cbadd344c832caf4ddba8884b51b8