### PR TITLE
Fix typo in feature list

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ The FPVS Toolbox is a work-in-progress software solution for use with BioSemi EE
 - Automated data cleaning and post processing
 - Automated statistical analysis with the ability to detect significant neural responses to experimental stimuli
 - Easy generation of publication quality figures & 3D heatmaps of brain activity
-- Automated BCA, SNR, and FFT calcuations
+- Automated BCA, SNR, and FFT calculations
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- correct a spelling error in the FPVS Toolbox feature list documentation

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690cd117fe84832c98bcfa56f1c1b8e9