### PR TITLE
Refine preprocessing persistence and worker integration

### DIFF
--- a/src/Main_App/PySide6_App/Backend/preprocessing_settings.py
+++ b/src/Main_App/PySide6_App/Backend/preprocessing_settings.py
@@ -1,0 +1,149 @@
+"""Utilities for coercing and normalizing preprocessing settings."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping
+
+try:  # pragma: no cover - fallback for isolated usage
+    import config  # type: ignore
+except Exception:  # pragma: no cover - fallback when config unavailable
+    class _FallbackConfig:
+        DEFAULT_STIM_CHANNEL = "Status"
+
+    config = _FallbackConfig()  # type: ignore
+
+
+@dataclass(frozen=True)
+class _Field:
+    name: str
+    aliases: tuple[str, ...]
+    default: Any
+    type: str
+
+
+_FLOAT = "float"
+_INT = "int"
+_STR = "str"
+_BOOL = "bool"
+
+
+_FIELDS: tuple[_Field, ...] = (
+    _Field("low_pass", ("low_pass",), 0.1, _FLOAT),
+    _Field("high_pass", ("high_pass",), 50.0, _FLOAT),
+    _Field("downsample", ("downsample", "downsample_rate"), 256, _INT),
+    _Field("rejection_z", ("rejection_z", "reject_thresh", "rejection_thresh"), 5.0, _FLOAT),
+    _Field("epoch_start_s", ("epoch_start_s", "epoch_start"), -1.0, _FLOAT),
+    _Field("epoch_end_s", ("epoch_end_s", "epoch_end"), 125.0, _FLOAT),
+    _Field("ref_chan1", ("ref_chan1", "ref_channel1"), "EXG1", _STR),
+    _Field("ref_chan2", ("ref_chan2", "ref_channel2"), "EXG2", _STR),
+    _Field(
+        "max_chan_idx_keep",
+        ("max_chan_idx_keep", "max_idx_keep", "max_chan_idx"),
+        64,
+        _INT,
+    ),
+    _Field(
+        "max_bad_chans",
+        ("max_bad_chans", "max_bad_channels", "max_bad_channels_alert_thresh"),
+        10,
+        _INT,
+    ),
+    _Field("save_preprocessed_fif", ("save_preprocessed_fif", "save_fif"), False, _BOOL),
+    _Field("stim_channel", ("stim_channel", "stim", "stim_channel_name"), config.DEFAULT_STIM_CHANNEL, _STR),
+)
+
+
+PREPROCESSING_CANONICAL_KEYS: tuple[str, ...] = tuple(field.name for field in _FIELDS)
+
+_ALIASES_FOR_OUTPUT: dict[str, Iterable[str]] = {
+    "downsample": ("downsample_rate",),
+    "rejection_z": ("reject_thresh",),
+    "epoch_start_s": ("epoch_start",),
+    "epoch_end_s": ("epoch_end",),
+    "max_chan_idx_keep": ("max_idx_keep",),
+    "max_bad_chans": ("max_bad_channels_alert_thresh",),
+}
+
+
+def _first_value(data: Mapping[str, Any], aliases: Iterable[str]) -> Any:
+    for alias in aliases:
+        if alias in data:
+            return data[alias]
+    return None
+
+
+def _coerce_float(value: Any, *, default: float, field: str) -> float:
+    if value in (None, ""):
+        return float(default)
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Invalid float for '{field}': {value!r}") from exc
+
+
+def _coerce_int(value: Any, *, default: int, field: str) -> int:
+    if value in (None, ""):
+        return int(default)
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Invalid integer for '{field}': {value!r}") from exc
+
+
+def _coerce_str(value: Any, *, default: str, field: str) -> str:
+    if value in (None, ""):
+        return str(default)
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or str(default)
+    raise ValueError(f"Invalid string for '{field}': {value!r}")  # pragma: no cover
+
+
+def _coerce_bool(value: Any, *, default: bool, field: str) -> bool:
+    if value in (None, ""):
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        if lowered == "":
+            return bool(default)
+    raise ValueError(f"Invalid boolean for '{field}': {value!r}")  # pragma: no cover
+
+
+def normalize_preprocessing_settings(raw: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Normalize preprocessing values into canonical keys and runtime aliases."""
+
+    source: Mapping[str, Any] = raw or {}
+    normalized: Dict[str, Any] = {}
+
+    for field in _FIELDS:
+        raw_value = _first_value(source, field.aliases)
+        if field.type == _FLOAT:
+            normalized[field.name] = _coerce_float(raw_value, default=field.default, field=field.name)
+        elif field.type == _INT:
+            normalized[field.name] = _coerce_int(raw_value, default=field.default, field=field.name)
+        elif field.type == _STR:
+            normalized[field.name] = _coerce_str(raw_value, default=field.default, field=field.name)
+        elif field.type == _BOOL:
+            normalized[field.name] = _coerce_bool(raw_value, default=field.default, field=field.name)
+        else:  # pragma: no cover - defensive guard
+            normalized[field.name] = raw_value if raw_value is not None else field.default
+
+    # Surface runtime aliases expected by legacy helpers without duplicating storage
+    for canonical, aliases in _ALIASES_FOR_OUTPUT.items():
+        for alias in aliases:
+            normalized[alias] = normalized[canonical]
+
+    return normalized
+
+
+__all__ = ["normalize_preprocessing_settings", "PREPROCESSING_CANONICAL_KEYS"]

--- a/src/Main_App/PySide6_App/Backend/processing_controller.py
+++ b/src/Main_App/PySide6_App/Backend/processing_controller.py
@@ -49,8 +49,8 @@ def start_processing(self) -> None:
             "reject_thresh": p.get("rejection_z"),
             "ref_channel1": p.get("ref_chan1"),
             "ref_channel2": p.get("ref_chan2"),
-            "max_idx_keep": p.get("max_chan_idx"),
-            "stim_channel": self.settings.get("stim", "channel", "Status"),
+            "max_idx_keep": p.get("max_chan_idx_keep"),
+            "stim_channel": p.get("stim_channel") or self.settings.get("stim", "channel", "Status"),
         }
 
         for fp in bdf_files:

--- a/tests/test_gui_preproc_dialog.py
+++ b/tests/test_gui_preproc_dialog.py
@@ -1,0 +1,89 @@
+import importlib.util
+import os
+
+import pytest
+
+if importlib.util.find_spec("PySide6") is None or importlib.util.find_spec("pytestqt") is None:
+    pytest.skip("PySide6 or pytest-qt not available", allow_module_level=True)
+
+from PySide6.QtWidgets import QApplication, QLineEdit
+
+from Main_App.PySide6_App.Backend.project import Project
+from Main_App.PySide6_App.GUI.main_window import MainWindow
+from Main_App.PySide6_App.GUI.settings_panel import SettingsDialog
+
+
+def _prep_project(root):
+    proj_root = root / "project"
+    proj_root.mkdir()
+    project = Project.load(proj_root)
+    project.update_preprocessing(
+        {
+            "low_pass": 0.25,
+            "high_pass": 45.0,
+            "downsample": 512,
+            "rejection_z": 4.0,
+            "epoch_start_s": -0.25,
+            "epoch_end_s": 95.0,
+            "ref_chan1": "Cz",
+            "ref_chan2": "Pz",
+            "max_chan_idx_keep": 32,
+            "max_bad_chans": 5,
+            "save_preprocessed_fif": False,
+            "stim_channel": "Status",
+        }
+    )
+    project.save()
+    return project
+
+
+def test_dialog_loads_saves_project(tmp_path, qtbot):
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+
+    project = _prep_project(tmp_path)
+
+    QApplication.instance() or QApplication([])
+
+    win = MainWindow()
+    qtbot.addWidget(win)
+    win.loadProject(project)
+
+    dlg = SettingsDialog(win.settings, win, project)
+    qtbot.addWidget(dlg)
+
+    assert dlg.preproc_edits[2].text() == "512"
+    assert dlg.stim_edit.text() == "Status"
+    assert dlg.save_fif_check.isChecked() is False
+
+    dlg.preproc_edits[2].setText("256")
+    dlg.preproc_edits[4].setText("3.5")
+    dlg.preproc_edits[5].setText("100")
+    dlg.stim_edit.setText("Trigger")
+    dlg.save_fif_check.setChecked(True)
+
+    dlg._save()
+
+    reloaded = Project.load(project.project_root)
+    assert reloaded.preprocessing["downsample"] == 256
+    assert reloaded.preprocessing["rejection_z"] == 3.5
+    assert reloaded.preprocessing["epoch_end_s"] == 100.0
+    assert reloaded.preprocessing["stim_channel"] == "Trigger"
+    assert reloaded.preprocessing["save_preprocessed_fif"] is True
+
+    dlg2 = SettingsDialog(win.settings, win, reloaded)
+    qtbot.addWidget(dlg2)
+    assert dlg2.preproc_edits[2].text() == "256"
+    assert dlg2.stim_edit.text() == "Trigger"
+    assert dlg2.save_fif_check.isChecked() is True
+
+    win.loadProject(reloaded)
+    first_row = win.event_rows[0].findChildren(QLineEdit)
+    first_row[0].setText("CondA")
+    first_row[1].setText("10")
+
+    params = win._build_validated_params()
+    assert params["downsample"] == 256
+    assert params["reject_thresh"] == 3.5
+    assert params["epoch_end"] == 100.0
+    assert params["stim_channel"] == "Trigger"
+    assert params["save_preprocessed_fif"] is True

--- a/tests/test_preproc_persistence.py
+++ b/tests/test_preproc_persistence.py
@@ -1,0 +1,77 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("PySide6") is None:
+    pytest.skip("PySide6 not available", allow_module_level=True)
+
+from Main_App.PySide6_App.Backend.project import Project
+from Main_App.PySide6_App.Backend.preprocessing_settings import PREPROCESSING_CANONICAL_KEYS
+
+
+def test_normalization_and_roundtrip(tmp_path):
+    manifest_path = Path(tmp_path) / "project.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "preprocessing": {
+                    "low_pass": "0.25",
+                    "high_pass": "45",
+                    "downsample_rate": "512",
+                    "reject_thresh": "4.2",
+                    "epoch_start": "-0.5",
+                    "epoch_end": "110",
+                    "ref_chan1": "Cz",
+                    "ref_chan2": "Pz",
+                    "max_idx_keep": "32",
+                    "max_bad_chans": "4",
+                    "save_preprocessed_fif": "true",
+                    "stim_channel": "Status",
+                }
+            }
+        )
+    )
+
+    project = Project.load(tmp_path)
+    normalized = project.preprocessing
+
+    assert normalized["downsample"] == 512
+    assert normalized["rejection_z"] == 4.2
+    assert normalized["epoch_start_s"] == -0.5
+    assert normalized["epoch_end_s"] == 110.0
+    assert normalized["ref_chan1"] == "Cz"
+    assert normalized["ref_chan2"] == "Pz"
+    assert normalized["max_chan_idx_keep"] == 32
+    assert normalized["max_bad_chans"] == 4
+    assert normalized["save_preprocessed_fif"] is True
+    assert normalized["stim_channel"] == "Status"
+
+    project.update_preprocessing(
+        {
+            "low_pass": 0.5,
+            "high_pass": 30,
+            "downsample": 256,
+            "rejection_z": 3.0,
+            "epoch_start_s": -1.0,
+            "epoch_end_s": 120.0,
+            "ref_chan1": "EXG1",
+            "ref_chan2": "EXG2",
+            "max_chan_idx_keep": 64,
+            "max_bad_chans": 8,
+            "save_preprocessed_fif": False,
+            "stim_channel": "Status",
+        }
+    )
+    project.save()
+
+    saved = json.loads(manifest_path.read_text())
+    stored_keys = set(saved["preprocessing"].keys())
+    assert stored_keys == set(PREPROCESSING_CANONICAL_KEYS)
+    assert saved["preprocessing"]["downsample"] == 256
+    assert "downsample_rate" not in saved["preprocessing"]
+
+    fresh = Project.load(tmp_path)
+    assert fresh.preprocessing["max_chan_idx_keep"] == 64
+    assert fresh.preprocessing["save_preprocessed_fif"] is False

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -1,0 +1,68 @@
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("PySide6") is None or importlib.util.find_spec("pytestqt") is None:
+    pytest.skip("PySide6 or pytest-qt not available", allow_module_level=True)
+
+from PySide6.QtWidgets import QApplication
+
+from Main_App.PySide6_App.Backend.project import Project
+from Main_App.PySide6_App.GUI.main_window import MainWindow
+from Main_App.PySide6_App.workers.mp_runner_bridge import MpRunnerBridge
+
+
+def _build_worker_project(root: Path) -> Project:
+    project = Project.load(root)
+    project.update_preprocessing(
+        {
+            "low_pass": 0.2,
+            "high_pass": 50.0,
+            "downsample": 256,
+            "rejection_z": 5.0,
+            "epoch_start_s": -1.0,
+            "epoch_end_s": 125.0,
+            "ref_chan1": "EXG1",
+            "ref_chan2": "EXG2",
+            "max_chan_idx_keep": 64,
+            "max_bad_chans": 10,
+            "save_preprocessed_fif": True,
+            "stim_channel": "StimA",
+        }
+    )
+    project.event_map = {"CondA": 11}
+    project.save()
+    input_dir = Path(project.input_folder)
+    input_dir.mkdir(parents=True, exist_ok=True)
+    (input_dir / "sample.bdf").write_bytes(b"")
+    return project
+
+
+def test_worker_receives_project_params(tmp_path, qtbot, monkeypatch):
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+
+    project = _build_worker_project(tmp_path / "proj")
+
+    QApplication.instance() or QApplication([])
+
+    win = MainWindow()
+    qtbot.addWidget(win)
+    win.loadProject(project)
+
+    captured: dict = {}
+
+    def fake_start(self, project_root, data_files, settings, event_map, save_folder, max_workers):
+        captured["settings"] = settings
+        captured["event_map"] = event_map
+        self.finished.emit({"files": len(data_files)})
+
+    monkeypatch.setattr(MpRunnerBridge, "start", fake_start, raising=False)
+
+    win.start_processing()
+    qtbot.waitUntil(lambda: not getattr(win, "_run_active", False), timeout=2000)
+
+    assert captured["event_map"] == {"CondA": 11}
+    assert captured["settings"]["stim_channel"] == "StimA"
+    assert captured["settings"]["save_preprocessed_fif"] is True


### PR DESCRIPTION
## Summary
- add a shared preprocessing normalizer and persist normalized data in project manifests
- update the settings dialog and main window to source parameters from project.json and pass save_preprocessed_fif/stim_channel through processing
- extend the post-export adapter and add regression tests covering normalization, dialog persistence, and worker wiring

## Testing
- pytest tests/test_preproc_persistence.py tests/test_gui_preproc_dialog.py tests/test_worker_integration.py
- ruff check src/Main_App/PySide6_App/Backend/preprocessing_settings.py src/Main_App/PySide6_App/Backend/project.py src/Main_App/PySide6_App/Backend/processing_controller.py src/Main_App/PySide6_App/GUI/main_window.py src/Main_App/PySide6_App/GUI/settings_panel.py src/Main_App/PySide6_App/adapters/post_export_adapter.py tests/test_preproc_persistence.py tests/test_gui_preproc_dialog.py tests/test_worker_integration.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691375a3067c832cb9b2ed7925b81aae)