### PR TITLE
Add preprocessing audit instrumentation and reporting

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -6,6 +6,7 @@ import queue
 import subprocess
 import sys
 from Main_App.Legacy_App.post_process import post_process as _legacy_post_process
+from Main_App.PySide6_App.utils.audit import format_audit_summary, write_audit_json
 from typing import Callable
 from datetime import datetime
 from pathlib import Path
@@ -457,14 +458,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
                         self._start_guard.end(),
                     )
                 )
-                self._mp.finished.connect(
-                    lambda _p: (
-                        (self._busy_stop() if hasattr(self, "_busy_stop") else None),
-                        self._finalize_processing(True),
-                        setattr(self, "_run_active", False),
-                        self._start_guard.end(),
-                    )
-                )
+                self._mp.finished.connect(self._on_processing_finished)
 
                 self._mp.start(
                     project_root=project_root,
@@ -512,8 +506,45 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
 
     # --------------------------------
 
-    def _on_processing_finished(self, _payload: dict | None = None) -> None:
-        # Process-mode completion
+    def _on_processing_finished(self, payload: dict | None = None) -> None:
+        # Process-mode completion with audit logging
+        results = []
+        if isinstance(payload, dict):
+            results = payload.get("results") or []
+
+        try:
+            debug_on = self.settings.debug_enabled()
+        except Exception:
+            debug_on = False
+
+        params_snapshot = dict(getattr(self, "validated_params", {}))
+        audit_root: Path | None = None
+        if debug_on and hasattr(self, "save_folder_path"):
+            try:
+                save_root = Path(self.save_folder_path.get()).resolve()
+                audit_root = save_root.parent / "audit"
+            except Exception:
+                audit_root = None
+
+        for result in results:
+            audit = result.get("audit") or {}
+            problems = result.get("problems") or []
+            line, is_warning = format_audit_summary(audit, problems)
+            self.log(line, level=logging.WARNING if is_warning else logging.INFO)
+            if debug_on and audit_root and audit:
+                try:
+                    raw_file = audit.get("file") or result.get("file", "")
+                    basename = Path(raw_file).stem if raw_file else "unknown"
+                    write_audit_json(
+                        audit_root,
+                        basename=basename,
+                        audit=audit,
+                        params=params_snapshot,
+                        problems=problems,
+                    )
+                except Exception as exc:
+                    self.log(f"Audit JSON write failed: {exc}", level=logging.WARNING)
+
         self._busy_stop()
         self._finalize_processing(True)
         self._run_active = False

--- a/src/Main_App/PySide6_App/adapters/post_export_adapter.py
+++ b/src/Main_App/PySide6_App/adapters/post_export_adapter.py
@@ -108,7 +108,7 @@ def _write_missing_fifs(ctx: LegacyCtx, save_root: Path, labels: List[str]) -> i
     return written
 
 
-def run_post_export(ctx: LegacyCtx, labels: List[str]) -> None:
+def run_post_export(ctx: LegacyCtx, labels: List[str]) -> int:
     """
     Execute legacy export. Then, for this specific file and labels,
     write any missing -epo.fif files (per-file fallback).
@@ -124,7 +124,7 @@ def run_post_export(ctx: LegacyCtx, labels: List[str]) -> None:
         raise
 
     # Per-file FIF fallback (only writes files that are missing)
-    _write_missing_fifs(ctx, save_root, labels)
+    return _write_missing_fifs(ctx, save_root, labels)
 
 
 def _coerce_bool(value: Any, default: bool = False) -> bool:

--- a/src/Main_App/PySide6_App/utils/audit.py
+++ b/src/Main_App/PySide6_App/utils/audit.py
@@ -1,0 +1,283 @@
+"""Preprocessing audit helpers for the PySide6 application."""
+from __future__ import annotations
+
+from datetime import datetime
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+import numpy as np
+
+K_EEG = 8
+N_SAMPLES = 100_000
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        val = float(value)
+        if np.isnan(val):  # type: ignore[arg-type]
+            return None
+        return val
+    except (TypeError, ValueError):
+        return None
+
+
+def start_preproc_audit(raw: Any, params: Mapping[str, Any]) -> Dict[str, Any]:
+    """Capture the initial Raw metadata before preprocessing mutates it."""
+    info = getattr(raw, "info", {})
+    ch_names = list(getattr(raw, "ch_names", []))
+    return {
+        "sfreq": _to_float(info.get("sfreq")),
+        "lowpass": _to_float(info.get("lowpass")),
+        "highpass": _to_float(info.get("highpass")),
+        "n_channels": len(ch_names),
+        "ch_names": ch_names,
+        "ref_applied": bool(info.get("custom_ref_applied", False)),
+        "params_snapshot": dict(params),
+    }
+
+
+def fingerprint(raw: Any) -> str:
+    """Return a SHA256 digest of the first EEG channels and samples."""
+    try:
+        channel_types = list(raw.get_channel_types())  # type: ignore[attr-defined]
+        eeg_indices = [idx for idx, kind in enumerate(channel_types) if kind == "eeg"]
+    except Exception:
+        return "NA"
+
+    if not eeg_indices:
+        return "NA"
+
+    picks = eeg_indices[:K_EEG]
+    try:
+        n_times = int(getattr(raw, "n_times", 0))
+    except Exception:
+        n_times = 0
+    stop = min(N_SAMPLES, max(0, n_times))
+    if stop <= 0:
+        return "NA"
+
+    try:
+        data = raw.get_data(picks=picks, start=0, stop=stop)  # type: ignore[attr-defined]
+    except Exception:
+        return "NA"
+
+    if data.size == 0:
+        return "NA"
+
+    digest = hashlib.sha256(np.ascontiguousarray(data.astype(np.float32)).tobytes()).hexdigest()
+    return digest
+
+
+def end_preproc_audit(
+    raw: Any,
+    params: Mapping[str, Any],
+    *,
+    filename: str,
+    events_info: Mapping[str, Any] | None = None,
+    fif_written: int = 0,
+    n_rejected: int = 0,
+) -> Dict[str, Any]:
+    """Capture the final state after preprocessing is complete."""
+    info = getattr(raw, "info", {})
+    stim_channel = str(
+        (events_info or {}).get("stim_channel")
+        or params.get("stim_channel")
+        or ""
+    )
+    n_events = int((events_info or {}).get("n_events", 0))
+    ref_candidates = [c for c in (params.get("ref_channel1"), params.get("ref_channel2")) if c]
+    audit = {
+        "file": filename,
+        "sfreq": float(_to_float(info.get("sfreq")) or 0.0),
+        "lowpass": _to_float(info.get("lowpass")),
+        "highpass": _to_float(info.get("highpass")),
+        "ref_applied": bool(info.get("custom_ref_applied", False)),
+        "ref_chans": ref_candidates or None,
+        "n_channels": int(len(getattr(raw, "ch_names", []))),
+        "ch_names": list(getattr(raw, "ch_names", [])),
+        "n_events": n_events,
+        "n_rejected": int(n_rejected),
+        "stim_channel": stim_channel,
+        "save_preprocessed_fif": bool(params.get("save_preprocessed_fif", False)),
+        "fif_written": int(fif_written),
+        "sha256_head": fingerprint(raw),
+    }
+    return audit
+
+
+def compare_preproc(
+    before: Mapping[str, Any] | None,
+    after: Mapping[str, Any],
+    params: Mapping[str, Any],
+    *,
+    events_info: Mapping[str, Any] | None = None,
+) -> List[str]:
+    """Return human-readable mismatches between requested and observed settings."""
+    problems: List[str] = []
+
+    target_ds = _to_float(params.get("downsample") or params.get("downsample_rate"))
+    if target_ds and target_ds > 0:
+        if abs(float(after.get("sfreq", 0.0)) - target_ds) > 0.05:
+            problems.append(
+                f"downsample expected {target_ds:g} got {float(after.get('sfreq', 0.0)):.2f}"
+            )
+
+    target_hp = _to_float(params.get("low_pass"))
+    if target_hp and target_hp > 0:
+        actual_hp = _to_float(after.get("highpass"))
+        if actual_hp is None or abs(actual_hp - target_hp) > 0.1:
+            problems.append(
+                f"highpass expected {target_hp:g} got {actual_hp if actual_hp is not None else 'NA'}"
+            )
+
+    target_lp = _to_float(params.get("high_pass"))
+    if target_lp and target_lp > 0:
+        actual_lp = _to_float(after.get("lowpass"))
+        if actual_lp is None or abs(actual_lp - target_lp) > 0.1:
+            problems.append(
+                f"lowpass expected {target_lp:g} got {actual_lp if actual_lp is not None else 'NA'}"
+            )
+
+    ref_expected = [c for c in (params.get("ref_channel1"), params.get("ref_channel2")) if c]
+    if ref_expected:
+        if not after.get("ref_applied"):
+            problems.append("reference requested but custom_ref_applied=False")
+        else:
+            applied = after.get("ref_chans") or []
+            if set(applied) != set(ref_expected):
+                problems.append(
+                    f"reference channels expected {tuple(ref_expected)} got {tuple(applied)}"
+                )
+
+    max_keep = params.get("max_idx_keep")
+    if max_keep not in (None, "", 0):
+        try:
+            max_keep_int = int(max_keep)
+        except (TypeError, ValueError):
+            max_keep_int = None
+        if max_keep_int and max_keep_int > 0:
+            actual_ch = int(after.get("n_channels", 0))
+            stim_channel = after.get("stim_channel")
+            ch_names_before = set((before or {}).get("ch_names", []))
+            if actual_ch > max_keep_int:
+                allowed = max_keep_int
+                stim_exception = (
+                    stim_channel
+                    and stim_channel in ch_names_before
+                    and actual_ch == allowed + 1
+                )
+                if not stim_exception:
+                    problems.append(
+                        f"channel cap {max_keep_int} but {actual_ch} channels remain"
+                    )
+
+    n_rejected = after.get("n_rejected")
+    if n_rejected is None or int(n_rejected) < 0:
+        problems.append("kurtosis reject count missing")
+
+    stim_channel = after.get("stim_channel")
+    if stim_channel:
+        ch_names_after = set((after.get("ch_names") or []))
+        ch_names_before = set((before or {}).get("ch_names", []))
+        stim_found_initial = stim_channel in ch_names_before or stim_channel in ch_names_after
+        if not stim_found_initial:
+            problems.append(f"stim '{stim_channel}' not found in channels")
+        n_events = int(after.get("n_events", 0))
+        if n_events <= 0:
+            problems.append(f"stim '{stim_channel}' produced 0 events")
+        if events_info and events_info.get("source") == "annotations":
+            problems.append(f"stim '{stim_channel}' fallback to annotations")
+
+    fif_flag = bool(after.get("save_preprocessed_fif"))
+    fif_written = int(after.get("fif_written", 0))
+    if fif_flag:
+        if fif_written <= 0:
+            problems.append("save_preprocessed_fif=True but no FIF outputs recorded")
+    else:
+        if fif_written > 0:
+            problems.append("save_preprocessed_fif=False but FIF outputs were written")
+
+    return problems
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def write_audit_json(
+    root: Path,
+    *,
+    basename: str,
+    audit: Mapping[str, Any],
+    params: Mapping[str, Any],
+    problems: Sequence[str],
+) -> Path:
+    """Write the audit payload to disk and return the file path."""
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S_%f")
+    safe = basename.replace(" ", "_") if basename else "unknown"
+    safe = safe.replace("/", "_").replace("\\", "_")
+    out_path = root / f"preproc_{timestamp}_{safe}.json"
+    payload = {
+        "file": audit.get("file") or basename,
+        "params": _json_safe(dict(params)),
+        "audit": _json_safe(dict(audit)),
+        "problems": list(problems),
+    }
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    return out_path
+
+
+def format_audit_summary(audit: Mapping[str, Any] | None, problems: Sequence[str] | None) -> tuple[str, bool]:
+    """Return the GUI log line and whether it should be treated as a warning."""
+    if not audit:
+        return "[AUDIT WARNING] audit data missing", True
+
+    problems = list(problems or [])
+    if problems:
+        return "[AUDIT WARNING] " + "; ".join(problems), True
+
+    sfreq = _to_float(audit.get("sfreq")) or 0.0
+    hp = _to_float(audit.get("highpass"))
+    lp = _to_float(audit.get("lowpass"))
+    ref = audit.get("ref_chans")
+    stim = audit.get("stim_channel") or ""
+    hp_str = f"{hp:g}" if hp is not None else "DC"
+    lp_str = f"{lp:g}" if lp is not None else "Nyq"
+
+    line = (
+        "[AUDIT] "
+        f"DS={sfreq:.1f}Hz "
+        f"HP={hp_str} "
+        f"LP={lp_str} "
+        f"ref={tuple(ref) if ref else 'None'} "
+        f"ch={audit.get('n_channels', 'NA')} "
+        f"events={audit.get('n_events', 'NA')} "
+        f"reject={audit.get('n_rejected', 'NA')} "
+        f"stim='{stim}' "
+        f"FIF={bool(audit.get('save_preprocessed_fif'))}"
+    )
+    return line, False
+
+
+__all__ = [
+    "start_preproc_audit",
+    "end_preproc_audit",
+    "compare_preproc",
+    "fingerprint",
+    "write_audit_json",
+    "format_audit_summary",
+]

--- a/tests/test_audit_json_toggle.py
+++ b/tests/test_audit_json_toggle.py
@@ -1,0 +1,56 @@
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from Main_App.PySide6_App.GUI.main_window import MainWindow  # noqa: E402
+
+
+@pytest.fixture
+def main_window(qtbot):
+    win = MainWindow()
+    qtbot.addWidget(win)
+    return win
+
+
+def _payload(tmp_path: Path) -> dict:
+    audit = {
+        "file": str(tmp_path / "demo.bdf"),
+        "sfreq": 256.0,
+        "highpass": 0.1,
+        "lowpass": 50.0,
+        "ref_chans": ["EXG1", "EXG2"],
+        "n_channels": 8,
+        "n_events": 2,
+        "n_rejected": 0,
+        "stim_channel": "Status",
+        "save_preprocessed_fif": False,
+        "fif_written": 0,
+        "sha256_head": "deadbeef",
+    }
+    return {"results": [{"file": str(tmp_path / "demo.bdf"), "audit": audit, "problems": []}]}
+
+
+def test_audit_json_toggle(tmp_path, main_window, monkeypatch):
+    logs: list[tuple[str, int]] = []
+    main_window.log = lambda message, level=logging.INFO: logs.append((message, level))
+    results_dir = tmp_path / "Results" / "Excel"
+    results_dir.mkdir(parents=True)
+    main_window.save_folder_path = SimpleNamespace(get=lambda: str(results_dir))
+    main_window.validated_params = {"downsample": 256}
+
+    monkeypatch.setattr(main_window.settings, "debug_enabled", lambda: False)
+    main_window._on_processing_finished(_payload(tmp_path))
+    assert any(msg.startswith("[AUDIT]") for msg, _ in logs)
+    audit_dir = results_dir.parent / "audit"
+    assert (not audit_dir.exists()) or (not any(audit_dir.iterdir()))
+
+    logs.clear()
+    monkeypatch.setattr(main_window.settings, "debug_enabled", lambda: True)
+    main_window._on_processing_finished(_payload(tmp_path))
+    created = list((results_dir.parent / "audit").glob("*.json"))
+    assert created
+    assert any(msg.startswith("[AUDIT]") for msg, _ in logs)

--- a/tests/test_fif_flag_audit.py
+++ b/tests/test_fif_flag_audit.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+mne = pytest.importorskip("mne")
+
+from Main_App.PySide6_App.Backend.preprocess import (  # noqa: E402
+    begin_preproc_audit,
+    finalize_preproc_audit,
+    perform_preprocessing,
+)
+
+
+def _build_raw():
+    sfreq = 256.0
+    samples = int(sfreq)
+    ch_names = ["EXG1", "EXG2", "Pz", "Status"]
+    ch_types = ["eeg", "eeg", "eeg", "stim"]
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    data = np.random.RandomState(7).randn(len(ch_names), samples)
+    stim = np.zeros(samples)
+    stim[10] = 3
+    data[-1] = stim
+    return mne.io.RawArray(data, info)
+
+
+def test_fif_flag_audit_reports_zero(tmp_path):
+    raw = _build_raw()
+    params = {
+        "downsample": 256,
+        "downsample_rate": 256,
+        "low_pass": 0.0,
+        "high_pass": 50.0,
+        "reject_thresh": 0.0,
+        "ref_channel1": "EXG1",
+        "ref_channel2": "EXG2",
+        "max_idx_keep": 3,
+        "stim_channel": "Status",
+        "save_preprocessed_fif": False,
+    }
+
+    before = begin_preproc_audit(raw, params, "flag.bdf")
+    processed, rejected = perform_preprocessing(raw, params, lambda msg: None, "flag.bdf")
+    assert processed is not None
+    events = mne.find_events(processed, stim_channel="Status", shortest_event=1)
+    audit, problems = finalize_preproc_audit(
+        before,
+        processed,
+        params,
+        "flag.bdf",
+        events_info={"stim_channel": "Status", "n_events": int(len(events)), "source": "stim"},
+        fif_written=0,
+        n_rejected=rejected,
+    )
+
+    assert audit["save_preprocessed_fif"] is False
+    assert audit["fif_written"] == 0
+    assert problems == []

--- a/tests/test_postprocess_worker_qt.py
+++ b/tests/test_postprocess_worker_qt.py
@@ -12,7 +12,7 @@ def test_post_worker_keeps_ui_responsive(app, qtbot, monkeypatch):
     from Main_App.PySide6_App.GUI.main_window import MainWindow
     import Main_App.PySide6_App.adapters.post_export_adapter as adapter
     # Stub heavy legacy call
-    monkeypatch.setattr(adapter, "run_post_export", lambda ctx, labels: QThread.msleep(50))
+    monkeypatch.setattr(adapter, "run_post_export", lambda ctx, labels: (QThread.msleep(50) or 0))
 
     win = MainWindow()
     qtbot.addWidget(win)

--- a/tests/test_preproc_audit.py
+++ b/tests/test_preproc_audit.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+mne = pytest.importorskip("mne")
+
+from Main_App.PySide6_App.Backend.preprocess import (  # noqa: E402
+    begin_preproc_audit,
+    finalize_preproc_audit,
+    perform_preprocessing,
+)
+
+
+def _synth_raw():
+    sfreq = 512.0
+    samples = int(sfreq * 2)
+    ch_names = ["EXG1", "EXG2"] + [f"E{i}" for i in range(1, 9)] + ["Status"]
+    ch_types = ["eeg", "eeg"] + ["eeg"] * 8 + ["stim"]
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    data = np.random.RandomState(42).randn(len(ch_names), samples)
+    stim_idx = ch_names.index("Status")
+    stim = np.zeros(samples)
+    stim[100] = 5
+    stim[400] = 7
+    data[stim_idx] = stim
+    return mne.io.RawArray(data, info)
+
+
+def test_preproc_audit_round_trip():
+    raw = _synth_raw()
+    params = {
+        "downsample": 256,
+        "downsample_rate": 256,
+        "low_pass": 0.1,
+        "high_pass": 50.0,
+        "reject_thresh": 3.0,
+        "ref_channel1": "EXG1",
+        "ref_channel2": "EXG2",
+        "max_idx_keep": 8,
+        "stim_channel": "Status",
+        "save_preprocessed_fif": False,
+    }
+
+    before = begin_preproc_audit(raw, params, "demo.bdf")
+    processed, rejected = perform_preprocessing(raw, params, lambda msg: None, "demo.bdf")
+    assert processed is not None
+
+    events = mne.find_events(processed, stim_channel="Status", shortest_event=1)
+    audit, problems = finalize_preproc_audit(
+        before,
+        processed,
+        params,
+        "demo.bdf",
+        events_info={"stim_channel": "Status", "n_events": int(len(events)), "source": "stim"},
+        fif_written=0,
+        n_rejected=rejected,
+    )
+
+    assert problems == []
+    assert abs(audit["sfreq"] - 256.0) < 0.05
+    assert audit["stim_channel"] == "Status"
+    assert audit["sha256_head"] not in {"", "NA"}


### PR DESCRIPTION
## Summary
- add a reusable preprocessing audit utility with fingerprinting, comparison, and JSON helpers
- record audit telemetry in the multiprocessing runner, PySide6 backend helpers, and GUI to log results and optional artifacts
- include new regression tests to cover audit success, FIF flag handling, and debug JSON toggling

## Testing
- `ruff check src/Main_App/PySide6_App/utils/audit.py tests/test_preproc_audit.py tests/test_audit_json_toggle.py tests/test_fif_flag_audit.py`
- `pytest` *(fails: missing PySide6, numpy, pandas in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138fb8c788832cb715e4cf36bf7209)