### PR TITLE
Route legacy loader imports to PySide6 backend loader

### DIFF
--- a/src/Main_App/Performance/process_runner.py
+++ b/src/Main_App/Performance/process_runner.py
@@ -108,7 +108,7 @@ def _process_one_file(
         t0 = time.perf_counter()
 
         # Lazy imports (inside worker only)
-        from Main_App.Legacy_App.load_utils import load_eeg_file  # type: ignore
+        from Main_App.PySide6_App.Backend.loader import load_eeg_file  # type: ignore
         from Main_App.Legacy_App.eeg_preprocessing import perform_preprocessing  # type: ignore
         from Main_App.PySide6_App.adapters.post_export_adapter import (  # type: ignore
             LegacyCtx,

--- a/tests/test_main_window_processing.py
+++ b/tests/test_main_window_processing.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import QApplication
 from Main_App.PySide6_App.Backend.project import Project
 import Main_App.PySide6_App.Backend.project_manager as project_manager
 import Main_App.Legacy_App.validation_mixins as validation_mixins
-import Main_App.Legacy_App.load_utils as load_utils
+import Main_App.PySide6_App.Backend.loader as load_utils
 import Main_App.Legacy_App.app_logic as app_logic
 import Main_App.Legacy_App.eeg_preprocessing as eeg_preprocessing
 import Main_App.PySide6_App.Backend.processing as processing


### PR DESCRIPTION
## Summary
- switch the test harness to import the PySide6 backend loader module instead of the legacy loader helper
- update the process runner worker to use the PySide6 backend loader when reading EEG files

## Testing
- pytest *(fails: missing PySide6, numpy, pandas)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691499e8a304832cb810a9a701686759)