### PR TITLE
Use fpvs_initial_custom_ref in audit metadata

### DIFF
--- a/src/Main_App/PySide6_App/utils/audit.py
+++ b/src/Main_App/PySide6_App/utils/audit.py
@@ -35,7 +35,7 @@ def start_preproc_audit(raw: Any, params: Mapping[str, Any]) -> Dict[str, Any]:
         "highpass": _to_float(info.get("highpass")),
         "n_channels": len(ch_names),
         "ch_names": ch_names,
-        "ref_applied": bool(info.get("custom_ref_applied", False)),
+        "ref_applied": bool(info.get("fpvs_initial_custom_ref", False)),
         "params_snapshot": dict(params),
     }
 
@@ -95,7 +95,7 @@ def end_preproc_audit(
         "sfreq": float(_to_float(info.get("sfreq")) or 0.0),
         "lowpass": _to_float(info.get("lowpass")),
         "highpass": _to_float(info.get("highpass")),
-        "ref_applied": bool(info.get("custom_ref_applied", False)),
+        "ref_applied": bool(info.get("fpvs_initial_custom_ref", False)),
         "ref_chans": ref_candidates or None,
         "n_channels": int(len(getattr(raw, "ch_names", []))),
         "ch_names": list(getattr(raw, "ch_names", [])),


### PR DESCRIPTION
## Summary
- replace audit metadata reads of the legacy `custom_ref_applied` flag with `fpvs_initial_custom_ref`

## Testing
- .venv\Scripts\python -m pytest -q *(fails: command not found in container)*
- .venv\Scripts\ruff check . *(fails: command not found in container)*
- .venv\Scripts\mypy src --strict *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149e94a89c832c93e9bd54742395e3)