### PR TITLE
Handle cancellations cleanly in legacy finalize

### DIFF
--- a/src/Main_App/Legacy_App/processing_utils.py
+++ b/src/Main_App/Legacy_App/processing_utils.py
@@ -160,6 +160,15 @@ class ProcessingMixin:
 
     def _finalize_processing(self, success):
         """Finalize the batch/single processing: show completion dialog and reset state."""
+        # PySide6 sets _suppress_completion_dialogs only when the user cancels a run.
+        # Treat this flag as the indicator that a cancellation occurred so we don't
+        # mis-report the run as an error when the user explicitly cancelled it.
+        cancelled = bool(getattr(self, "_suppress_completion_dialogs", False))
+
+        if cancelled and not success:
+            self.log("--- Processing Run Cancelled by User ---")
+            return
+
         if success:
             self.log("--- Processing Run Completed Successfully ---")
             if self.validated_params and self.data_paths:


### PR DESCRIPTION
## Summary
- detect when the PySide6 GUI suppresses completion dialogs to infer that the user cancelled processing
- short-circuit the legacy finalize path on cancellations so it logs a clear message and skips the error dialog while leaving the success and error flows unchanged

## Testing
- ruff check *(fails: existing repo lint violations unrelated to this change)*
- pytest *(fails: missing third-party dependencies such as PySide6, numpy, and pandas)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a31339e00832c876460d316d74c41)