### PR TITLE
Fix typo in backend AGENTS instructions

### DIFF
--- a/src/Main_App/PySide6_App/Backend/AGENTS.md
+++ b/src/Main_App/PySide6_App/Backend/AGENTS.md
@@ -1,4 +1,4 @@
-In the backend directory, please ensure that only the functionality and the the core logic of the FPVS Toolbox is 
+In the backend directory, please ensure that only the functionality and the core logic of the FPVS Toolbox is
 present. The GUI code should be kept out of this directory as much as possible and instead be placed in the GUI directory.
 
 []: # 


### PR DESCRIPTION
## Summary
- fix a duplicated word in the backend AGENTS instructions to improve clarity

## Testing
- not run (doc-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5dcffd48832ca2e7a2899cbfa2f5)