### PR TITLE
Align project results folders with manifest

### DIFF
--- a/src/Main_App/PySide6_App/Backend/project.py
+++ b/src/Main_App/PySide6_App/Backend/project.py
@@ -11,10 +11,14 @@ from .preprocessing_settings import (
     normalize_preprocessing_settings,
 )
 
+EXCEL_SUBFOLDER_NAME = "1 - Excel Data Files"
+SNR_SUBFOLDER_NAME = "2 - SNR Plots"
+STATS_SUBFOLDER_NAME = "3 - Statistical Analysis Results"
+
 # Stable defaults used by GUI/processing
 DEFAULTS: Dict[str, Any] = {
     "input_folder": "Input",
-    "results_folder": "Results",
+    "results_folder": ".",
     "options": {
         "mode": "single",
         "loreta": False,
@@ -25,9 +29,9 @@ DEFAULTS: Dict[str, Any] = {
     "event_map": {},
     # Result subfolders relative to results_folder
     "subfolders": {
-        "excel": "Excel",
-        "snr": "SNR",
-        "stats": "Stats",
+        "excel": EXCEL_SUBFOLDER_NAME,
+        "snr": SNR_SUBFOLDER_NAME,
+        "stats": STATS_SUBFOLDER_NAME,
     },
     # Preprocessing parameters expected by GUI (dict)
     "preprocessing": {},

--- a/tests/test_plot_generator_project_defaults.py
+++ b/tests/test_plot_generator_project_defaults.py
@@ -1,6 +1,7 @@
 import importlib.util
-import os
 import json
+import os
+
 import pytest
 
 if importlib.util.find_spec("matplotlib") is None:
@@ -55,6 +56,33 @@ def test_defaults_loaded_from_env(tmp_path, monkeypatch):
     snr.mkdir()
     data = {
         "name": "EnvTest",
+        "subfolders": {"excel": "1 - Excel Data Files", "snr": "2 - SNR Plots"},
+    }
+    (proj / "project.json").write_text(json.dumps(data))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FPVS_PROJECT_ROOT", str(proj))
+    module = _import_module()
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    win = module.PlotGeneratorWindow()
+    assert win.folder_edit.text() == str(excel)
+    assert win.out_edit.text() == str(snr)
+    app.quit()
+
+
+def test_legacy_results_folder_detected(tmp_path, monkeypatch):
+    proj = tmp_path / "legacy"
+    results = proj / "Results"
+    excel = results / "1 - Excel Data Files"
+    snr = results / "2 - SNR Plots"
+    results.mkdir(parents=True)
+    excel.mkdir()
+    snr.mkdir()
+    data = {
+        "name": "Legacy",
+        "results_folder": "Results",
         "subfolders": {"excel": "1 - Excel Data Files", "snr": "2 - SNR Plots"},
     }
     (proj / "project.json").write_text(json.dumps(data))

--- a/tests/test_project_results_layout.py
+++ b/tests/test_project_results_layout.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+from Main_App.PySide6_App.Backend.project import (
+    EXCEL_SUBFOLDER_NAME,
+    SNR_SUBFOLDER_NAME,
+    STATS_SUBFOLDER_NAME,
+    Project,
+)
+
+
+def test_project_creates_flat_results_layout(tmp_path):
+    proj_dir = tmp_path / "FlatProject"
+    proj_dir.mkdir()
+
+    project = Project.load(proj_dir)
+
+    assert project.results_folder == proj_dir.resolve()
+    assert project.subfolders["excel"] == (proj_dir / EXCEL_SUBFOLDER_NAME).resolve()
+    assert project.subfolders["snr"] == (proj_dir / SNR_SUBFOLDER_NAME).resolve()
+    assert project.subfolders["stats"] == (proj_dir / STATS_SUBFOLDER_NAME).resolve()
+    for subdir in project.subfolders.values():
+        assert subdir.exists()
+
+
+def test_project_honors_legacy_results_folder(tmp_path):
+    proj_dir = tmp_path / "LegacyProject"
+    proj_dir.mkdir()
+    legacy_manifest = {
+        "results_folder": "Results",
+        "subfolders": {
+            "excel": EXCEL_SUBFOLDER_NAME,
+            "snr": SNR_SUBFOLDER_NAME,
+            "stats": STATS_SUBFOLDER_NAME,
+        },
+    }
+    (proj_dir / "project.json").write_text(json.dumps(legacy_manifest))
+
+    project = Project.load(proj_dir)
+
+    legacy_root = (proj_dir / "Results").resolve()
+    assert project.results_folder == legacy_root
+    assert project.subfolders["excel"] == (legacy_root / EXCEL_SUBFOLDER_NAME).resolve()
+    assert project.subfolders["snr"] == (legacy_root / SNR_SUBFOLDER_NAME).resolve()
+    assert project.subfolders["stats"] == (legacy_root / STATS_SUBFOLDER_NAME).resolve()
+    for subdir in project.subfolders.values():
+        assert subdir.exists()

--- a/tests/test_stats_project_paths.py
+++ b/tests/test_stats_project_paths.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from Main_App.PySide6_App.Backend.project import (
+    EXCEL_SUBFOLDER_NAME,
+    STATS_SUBFOLDER_NAME,
+)
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+
+
+def _patch_scan(monkeypatch):
+    def _fake_scan(self):
+        setattr(self, "_scan_called", True)
+
+    monkeypatch.setattr(StatsWindow, "_scan_button_clicked", _fake_scan, raising=False)
+
+
+def _write_manifest(root: Path, data: dict) -> None:
+    (root / "project.json").write_text(json.dumps(data))
+
+
+def test_stats_prefers_flat_layout(tmp_path, qtbot, monkeypatch):
+    _patch_scan(monkeypatch)
+    proj = tmp_path / "Flat"
+    proj.mkdir()
+    excel = proj / EXCEL_SUBFOLDER_NAME
+    stats_dir = proj / STATS_SUBFOLDER_NAME
+    excel.mkdir(parents=True)
+    data = {
+        "results_folder": ".",
+        "subfolders": {
+            "excel": EXCEL_SUBFOLDER_NAME,
+            "stats": STATS_SUBFOLDER_NAME,
+        },
+    }
+    _write_manifest(proj, data)
+
+    win = StatsWindow(project_dir=str(proj))
+    qtbot.addWidget(win)
+    win._load_default_data_folder()
+
+    assert Path(win.le_folder.text()) == excel.resolve()
+    assert Path(win._ensure_results_dir()) == stats_dir.resolve()
+    win.close()
+
+
+def test_stats_handles_legacy_results_root(tmp_path, qtbot, monkeypatch):
+    _patch_scan(monkeypatch)
+    proj = tmp_path / "Legacy"
+    proj.mkdir()
+    results = proj / "Results"
+    excel = results / EXCEL_SUBFOLDER_NAME
+    stats_dir = results / STATS_SUBFOLDER_NAME
+    excel.mkdir(parents=True)
+    data = {
+        "results_folder": "Results",
+        "subfolders": {
+            "excel": EXCEL_SUBFOLDER_NAME,
+            "stats": STATS_SUBFOLDER_NAME,
+        },
+    }
+    _write_manifest(proj, data)
+
+    win = StatsWindow(project_dir=str(proj))
+    qtbot.addWidget(win)
+    win._load_default_data_folder()
+
+    assert Path(win.le_folder.text()) == excel.resolve()
+    assert Path(win._ensure_results_dir()) == stats_dir.resolve()
+    win.close()


### PR DESCRIPTION
## Summary
- switch the project defaults to create the three numbered result folders directly under each project and expose canonical folder names for reuse
- teach the Plot Generator and Stats tools to resolve their Excel/SNR/Stats paths via the project manifest so both the new flat layout and legacy `Results` containers work
- add targeted tests that cover both folder styles for the project model, plot defaults, and stats UI defaults

## Testing
- `ruff check src/Main_App/PySide6_App/Backend/project.py src/Tools/Plot_Generator/gui.py src/Tools/Stats/PySide6/stats_ui_pyside6.py tests/test_plot_generator_project_defaults.py tests/test_project_results_layout.py tests/test_stats_project_paths.py`
- `QT_QPA_PLATFORM=offscreen pytest tests/test_project_results_layout.py tests/test_plot_generator_project_defaults.py tests/test_stats_project_paths.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5feb4984832c9556e45eef374bdf)