### PR TITLE
Add centralized light theme helper

### DIFF
--- a/src/Main_App/PySide6_App/utils/theme.py
+++ b/src/Main_App/PySide6_App/utils/theme.py
@@ -1,0 +1,29 @@
+"""Utilities for applying consistent theming across PySide6 entry points."""
+
+from __future__ import annotations
+
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import QApplication
+
+
+def apply_light_palette(app: QApplication) -> None:
+    """Apply a deterministic Fusion + light palette regardless of OS theme."""
+    app.setStyle("Fusion")
+    palette = app.palette()
+
+    palette.setColor(QPalette.Window, QColor("white"))
+    palette.setColor(QPalette.Base, QColor("white"))
+    palette.setColor(QPalette.AlternateBase, QColor(245, 245, 245))
+    palette.setColor(QPalette.Text, QColor("black"))
+    palette.setColor(QPalette.WindowText, QColor("black"))
+    palette.setColor(QPalette.Button, QColor(240, 240, 240))
+    palette.setColor(QPalette.ButtonText, QColor("black"))
+    palette.setColor(QPalette.ToolTipBase, QColor(255, 255, 220))
+    palette.setColor(QPalette.ToolTipText, QColor("black"))
+    palette.setColor(QPalette.Highlight, QColor(0, 120, 215))
+    palette.setColor(QPalette.HighlightedText, QColor("white"))
+
+    palette.setColor(QPalette.Disabled, QPalette.Text, QColor(128, 128, 128))
+    palette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor(128, 128, 128))
+
+    app.setPalette(palette)

--- a/src/Tools/Image_Resizer/pyside_resizer.py
+++ b/src/Tools/Image_Resizer/pyside_resizer.py
@@ -13,7 +13,6 @@ import sys
 from typing import List, Tuple
 
 from PySide6.QtCore import QObject, QThread, Signal
-from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -28,6 +27,8 @@ from PySide6.QtWidgets import (
     QPlainTextEdit,
     QWidget,
 )
+
+from Main_App.PySide6_App.utils.theme import apply_light_palette
 
 try:  # pragma: no cover - fallback for running as a script
     from .image_resize_core import process_images_in_folder  # type: ignore
@@ -95,25 +96,7 @@ class FPVSImageResizerQt(QWidget):
         self._thread: QThread | None = None
         self._worker: _Worker | None = None
 
-        self._apply_light_theme()
         self._build_ui()
-
-    def _apply_light_theme(self) -> None:
-        app = QApplication.instance()
-        if not app:
-            return
-        app.setStyle("Fusion")
-        palette = app.palette()
-        palette.setColor(QPalette.Window, QColor("white"))
-        palette.setColor(QPalette.Base, QColor("white"))
-        palette.setColor(QPalette.AlternateBase, QColor(245, 245, 245))
-        palette.setColor(QPalette.Text, QColor("black"))
-        palette.setColor(QPalette.WindowText, QColor("black"))
-        palette.setColor(QPalette.Button, QColor(240, 240, 240))
-        palette.setColor(QPalette.ButtonText, QColor("black"))
-        palette.setColor(QPalette.Highlight, QColor(76, 163, 224))
-        palette.setColor(QPalette.HighlightedText, QColor("white"))
-        app.setPalette(palette)
 
     def _build_ui(self) -> None:
         layout = QGridLayout(self)
@@ -283,6 +266,7 @@ class FPVSImageResizerQt(QWidget):
 def main() -> None:
     """Launch the Qt-based FPVS image resizer."""
     app = QApplication(sys.argv)
+    apply_light_palette(app)
     win = FPVSImageResizerQt()
     win.show()
     app.exec()

--- a/src/Tools/Plot_Generator/plot_generator.py
+++ b/src/Tools/Plot_Generator/plot_generator.py
@@ -10,6 +10,8 @@ if __package__ is None:  # pragma: no cover - executed when run as script
 
 from PySide6.QtWidgets import QApplication
 
+from Main_App.PySide6_App.utils.theme import apply_light_palette
+
 from Tools.Plot_Generator.worker import _Worker
 from Tools.Plot_Generator.gui import PlotGeneratorWindow
 
@@ -18,6 +20,7 @@ __all__ = ["_Worker", "PlotGeneratorWindow", "main"]
 
 def main() -> None:
     app = QApplication([])
+    apply_light_palette(app)
     win = PlotGeneratorWindow()
     win.show()
     app.exec()

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from ctypes import windll
 
 from PySide6.QtCore import QCoreApplication
 from config import FPVS_TOOLBOX_VERSION
-from Main_App.PySide6_App.utils.paths import bundle_path
+from Main_App.PySide6_App.utils.theme import apply_light_palette
 
 try:
     windll.shcore.SetProcessDpiAwareness(1)  # type: ignore[attr-defined]
@@ -46,11 +46,7 @@ def run_app() -> int:
     from Main_App.PySide6_App.GUI.main_window import MainWindow
 
     app = QApplication([])
-
-    qss_path = bundle_path("..", "..", "..", "qdark_sidebar.qss")
-    if qss_path.exists():
-        with open(qss_path, "r", encoding="utf-8") as f:
-            app.setStyleSheet(f.read())
+    apply_light_palette(app)
 
     window = MainWindow()
     window.show()


### PR DESCRIPTION
## Summary
- add a reusable theme helper that enforces a Fusion-based light palette
- update the main entry point plus the Image Resizer and Plot Generator tools to call the helper so they ignore Windows Dark Mode

## Testing
- `pytest tests/test_settings_and_status.py` *(fails: PySide6 not installed in the test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9bc30f84832cbb6ce235fb332f85)