### PR TITLE
Update stats scanners PID regex

### DIFF
--- a/src/Tools/Stats/Legacy/stats_file_scanner.py
+++ b/src/Tools/Stats/Legacy/stats_file_scanner.py
@@ -6,6 +6,11 @@ import re
 import traceback
 from tkinter import filedialog, messagebox
 
+EXCEL_PID_REGEX = re.compile(
+    r"(P\d+[A-Za-z]*|Sub\d+[A-Za-z]*|S\d+[A-Za-z]*)",
+    re.IGNORECASE,
+)
+
 # Folders that should always be ignored when scanning for condition
 # subdirectories.  Stored in lower case for case-insensitive matching.
 IGNORED_FOLDERS = {".fif files", "loreta results"}
@@ -39,7 +44,7 @@ def scan_folder(self):
     # Revised PID pattern:
     # Looks for an optional prefix of letters, then P (case-insensitive) followed by digits.
     # Captures the P and digits part.
-    pid_pattern = re.compile(r"(?:[a-zA-Z]*)?(P\d+).*\.xlsx$", re.IGNORECASE)
+    pid_pattern = EXCEL_PID_REGEX
 
     try:
         for item_name in os.listdir(parent_folder):  # These are expected to be condition subfolders

--- a/src/Tools/Stats/PySide6/stats_file_scanner_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_file_scanner_pyside6.py
@@ -3,6 +3,11 @@ import glob
 import re
 from typing import List, Dict, Tuple
 
+EXCEL_PID_REGEX = re.compile(
+    r"(P\d+[A-Za-z]*|Sub\d+[A-Za-z]*|S\d+[A-Za-z]*)",
+    re.IGNORECASE,
+)
+
 
 # Folders to ignore during scanning (case-insensitive)
 IGNORED_FOLDERS = {".fif files", "loreta results"}
@@ -36,7 +41,7 @@ def scan_folder_simple(parent_folder: str) -> Tuple[List[str], List[str], Dict[s
     subject_data: Dict[str, Dict[str, str]] = {}
 
     # Pattern to match subject IDs in filenames (optional prefix + P<number>), before .xlsx
-    pid_pattern = re.compile(r"(?:[A-Za-z]*)?(P\d+).*\.xlsx$", re.IGNORECASE)
+    pid_pattern = EXCEL_PID_REGEX
 
     try:
         for entry in os.listdir(parent_folder):


### PR DESCRIPTION
## Summary
- add a shared Excel PID regex to the stats scanners that retains optional suffix letters
- reuse the shared pattern when parsing subject IDs to keep full IDs like P10BCL

## Testing
- pytest (fails: missing optional test dependencies such as PySide6, numpy, pandas)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2fce0bec832ca0f4ef3988bededf)