### PR TITLE
Remove detailed argument from pingouin mixed_anova

### DIFF
--- a/src/Tools/Stats/Legacy/mixed_group_anova.py
+++ b/src/Tools/Stats/Legacy/mixed_group_anova.py
@@ -110,7 +110,6 @@ def run_mixed_group_anova(
             between=between_col,
             subject=subject_col,
             data=df,
-            detailed=True,
         )
         return _tidy_pingouin_table(pg_table)
     except ImportError:


### PR DESCRIPTION
## Summary
- remove unsupported detailed argument when calling pingouin.mixed_anova to prevent runtime errors

## Testing
- pytest (fails: missing optional dependencies such as PySide6, numpy, pandas)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e317c0dc8832c9e3190b964b5c14e)