### PR TITLE
Rename between-group ANOVA export label

### DIFF
--- a/src/Tools/Stats/PySide6/stats_ui_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_ui_pyside6.py
@@ -66,7 +66,7 @@ ANOVA_XLS = "RM-ANOVA Results.xlsx"
 LMM_XLS = "Mixed Model Results.xlsx"
 POSTHOC_XLS = "Posthoc Results.xlsx"
 HARMONIC_XLS = "Harmonic Results.xlsx"
-ANOVA_BETWEEN_XLS = "RM-ANOVA Between Groups.xlsx"
+ANOVA_BETWEEN_XLS = "Mixed ANOVA Between Groups.xlsx"
 LMM_BETWEEN_XLS = "Mixed Model Between Groups.xlsx"
 GROUP_CONTRAST_XLS = "Group Contrasts.xlsx"
 


### PR DESCRIPTION
## Summary
- rename the between-group ANOVA export label to use "Mixed ANOVA Between Groups" to match the mixed design

## Testing
- ruff check *(fails: existing lint issues unrelated to change)*
- python -m pytest *(fails: missing dependencies such as PySide6, numpy, pandas)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3c1ec9d4832c81d81a034c4841e4)