### PR TITLE
Use BH FDR for single-group post-hoc tests

### DIFF
--- a/src/Tools/Stats/Legacy/stats_runners.py
+++ b/src/Tools/Stats/Legacy/stats_runners.py
@@ -449,7 +449,7 @@ def run_interaction_posthocs(self):
         summary_section = "============================================================\n"
         summary_section += "             SUMMARY OF SIGNIFICANT FINDINGS\n"
         summary_section += "============================================================\n"
-        summary_section += "(Holm-corrected p-values < 0.05)\n"
+        summary_section += "(FDR-adjusted p-values, Benjamini–Hochberg < 0.05)\n"
 
         for finding_group in significant_findings_for_summary:
             roi = finding_group['roi']
@@ -459,7 +459,7 @@ def run_interaction_posthocs(self):
                 comp_str = f"'{row['Level_A']}' vs. '{row['Level_B']}'"
                 t_val = row['t_statistic']
                 df = row['N_Pairs'] - 1
-                p_corr = row['p_value_corrected']
+                p_corr = row['p_fdr_bh']
                 p_corr_str = "< .0001" if p_corr < 0.0001 else f"{p_corr:.4f}"
 
                 summary_section += f"  - Difference between {comp_str} is significant.\n"


### PR DESCRIPTION
## Summary
- switch single-group post-hoc pairwise tests to Benjamini–Hochberg FDR and expose the p_fdr_bh column for significance decisions
- update interaction post-hoc reporting and legacy UI summaries to reference the new FDR-adjusted values

## Testing
- pytest *(fails: missing PySide6, numpy, pandas dependencies in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e43801514832c9c72b0ed9bae2d91)