### PR TITLE
Add analysis info dialog to stats UI

### DIFF
--- a/src/Tools/Stats/PySide6/stats_ui_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_ui_pyside6.py
@@ -1242,6 +1242,9 @@ class StatsWindow(QMainWindow):
         fm = QFontMetrics(self.btn_open_results.font())
         self.btn_open_results.setMinimumWidth(fm.horizontalAdvance(self.btn_open_results.text()) + 24)
         tools_row.addWidget(self.btn_open_results)
+        self.info_button = QPushButton("Analysis Info")
+        self.info_button.clicked.connect(self.on_show_analysis_info)
+        tools_row.addWidget(self.info_button)
         tools_row.addStretch(1)
         main_layout.addLayout(tools_row)
 
@@ -1392,6 +1395,51 @@ class StatsWindow(QMainWindow):
         self._update_export_buttons()
 
     # --------------------------- actions ---------------------------
+
+    def on_show_analysis_info(self) -> None:
+        """
+        Show a brief summary of the statistical methods used in the Stats tool.
+        This is read-only and does not modify any data or settings.
+        """
+        text = (
+            "FPVS Toolbox – Statistical Pipeline Overview\n\n"
+            "Data analyzed\n"
+            "• All analyses use the summed baseline-corrected oddball amplitude "
+            "(Summed BCA) per subject × condition × ROI.\n\n"
+            "Single-group analyses\n"
+            "• RM-ANOVA: Repeated-measures ANOVA with within-subject factors "
+            "condition and ROI. When available, Pingouin's rm_anova is used and "
+            "both uncorrected and Greenhouse–Geisser/Huynh–Feldt corrected p-values "
+            "are reported; otherwise statsmodels' AnovaRM is used (uncorrected p-values).\n"
+            "• Post-hoc tests: Paired t-tests between conditions, run separately within "
+            "each ROI. P-values are corrected for multiple comparisons using the "
+            "Benjamini–Hochberg false discovery rate (FDR) procedure; exports include "
+            "raw p and FDR-adjusted p (p_fdr_bh) plus effect sizes.\n"
+            "• Mixed model: Linear mixed-effects model with a random intercept for each "
+            "subject and fixed effects for condition, ROI, and their interaction. No "
+            "additional multiple-comparison correction is applied to these coefficients.\n\n"
+            "Multi-group analyses\n"
+            "• Between-group ANOVA: Mixed ANOVA with group as a between-subject factor "
+            "and condition as a within-subject factor on Summed BCA (ROI collapsed). "
+            "Pingouin's mixed_anova is used when available.\n"
+            "• Between-group mixed model: Linear mixed-effects model on Summed BCA with "
+            "fixed effects for group, condition, ROI, and their interactions, plus a "
+            "random intercept per subject.\n"
+            "• Group contrasts: Pairwise group comparisons (Welch's t-tests) computed "
+            "separately for each condition × ROI. P-values are corrected for multiple "
+            "comparisons using Benjamini–Hochberg FDR, and effect sizes (Cohen's d) "
+            "are reported.\n\n"
+            "General notes\n"
+            "• Unless otherwise noted, the default alpha level is 0.05.\n"
+            "• Excel exports in the '3 - Statistical Analysis Results' folder contain "
+            "the full tables for all analyses, including raw and corrected p-values.\n"
+        )
+
+        QMessageBox.information(
+            self,
+            "FPVS Toolbox – Analysis Info",
+            text,
+        )
 
     def _check_for_open_excel_files(self, folder_path: str) -> bool:
         """Best-effort check to avoid writing to open Excel files."""


### PR DESCRIPTION
## Summary
- add an Analysis Info button to the Stats PySide6 UI controls
- display a read-only dialog outlining single- and multi-group statistical methods

## Testing
- ruff check src/Tools/Stats/PySide6/stats_ui_pyside6.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e475b8b58832cbe52f1d5a34537a8)