### PR TITLE
Refactor stats summaries to use in-memory data and update GUI

### DIFF
--- a/src/Tools/Stats/PySide6/summary_utils.py
+++ b/src/Tools/Stats/PySide6/summary_utils.py
@@ -1,7 +1,7 @@
 """Rule-based summaries of exported statistical results.
 
 This module reads existing Excel exports from the Stats tool and builds a short,
-deterministic summary string suitable for display in the unified output window.
+rule-based summary string suitable for display in the unified output window.
 The summarizer is intentionally conservative: it only reports effects that
 survive Benjamini–Hochberg FDR correction and meet minimum effect-size
 thresholds. Any unexpected files or schemas are handled gracefully by returning
@@ -27,11 +27,22 @@ class SummaryConfig:
     effect_col: str = "effect_size"
 
 
+@dataclass
+class StatsSummaryFrames:
+    single_posthoc: Optional[pd.DataFrame] = None
+    between_contrasts: Optional[pd.DataFrame] = None
+    harmonic_results: Optional[pd.DataFrame] = None
+    anova_terms: Optional[pd.DataFrame] = None
+    mixed_model_terms: Optional[pd.DataFrame] = None
+
+
 POSTHOC_XLS = "Posthoc Results.xlsx"
 GROUP_CONTRAST_XLS = "Group Contrasts.xlsx"
 HARMONIC_XLS = "Harmonic Results.xlsx"
 ANOVA_XLS = "RM-ANOVA Results.xlsx"
 ANOVA_BETWEEN_XLS = "Mixed ANOVA Between Groups.xlsx"
+LMM_XLS = "Mixed Model Results.xlsx"
+LMM_BETWEEN_XLS = "Mixed Model Between Groups.xlsx"
 
 
 def build_summary_from_files(stats_folder: Path, config: SummaryConfig) -> str:
@@ -50,33 +61,78 @@ def build_summary_from_files(stats_folder: Path, config: SummaryConfig) -> str:
         except Exception:
             return None
 
-    single_df = _safe_read(stats_folder / POSTHOC_XLS, "Post-hoc Results")
-    between_df = _safe_read(stats_folder / GROUP_CONTRAST_XLS, "Post-hoc Results")
-    harmonic_df = _safe_read(stats_folder / HARMONIC_XLS, "Significant Harmonics")
+    frames = StatsSummaryFrames(
+        single_posthoc=_safe_read(stats_folder / POSTHOC_XLS, "Post-hoc Results"),
+        between_contrasts=_safe_read(stats_folder / GROUP_CONTRAST_XLS, "Post-hoc Results"),
+        harmonic_results=_safe_read(stats_folder / HARMONIC_XLS, "Significant Harmonics"),
+        mixed_model_terms=_safe_read(stats_folder / LMM_XLS, "Mixed Model"),
+    )
 
-    interaction_df: Optional[pd.DataFrame] = None
     for fname in (ANOVA_BETWEEN_XLS, ANOVA_XLS):
         candidate = _safe_read(stats_folder / fname, "RM-ANOVA Table")
         if candidate is not None:
-            interaction_df = candidate
+            frames.anova_terms = candidate
             break
+
+    candidate_lmm_between = _safe_read(stats_folder / LMM_BETWEEN_XLS, "Mixed Model")
+    if candidate_lmm_between is not None:
+        frames.mixed_model_terms = candidate_lmm_between
+
+    return build_summary_from_frames(frames, config)
+
+
+def build_summary_from_frames(frames: StatsSummaryFrames, config: SummaryConfig) -> str:
+    """
+    Produce a short, human-readable summary based on in-memory DataFrames.
+    Never raises; on missing/invalid data it emits 'no results' lines for
+    the affected sections.
+    """
+
+    try:
+        single_lines = _summarize_single(frames.single_posthoc, config)
+    except Exception:
+        single_lines = ["- No within-group results are available for summary."]
+
+    try:
+        between_lines = _summarize_between(frames.between_contrasts, config)
+    except Exception:
+        between_lines = ["- No between-group results are available for summary."]
+
+    try:
+        mixed_lines = _summarize_mixed_model(frames.mixed_model_terms, config)
+    except Exception:
+        mixed_lines = ["- Mixed model: no summary is available."]
+
+    try:
+        harmonic_lines = _summarize_harmonics(frames.harmonic_results, config)
+    except Exception:
+        harmonic_lines = ["- No harmonic check results are available for summary."]
+
+    try:
+        interaction_lines = _summarize_interactions(frames.anova_terms, config)
+    except Exception:
+        interaction_lines = ["- No interaction summary is available."]
 
     parts = [
         f"--- Summary (α = {config.alpha:.2f}, FDR correction: Benjamini–Hochberg) ---",
         "",
         "Single Group:",
-        *(_summarize_single(single_df, config) or ["- No within-group results are available for summary."]),
+        *(single_lines or ["- No within-group results are available for summary."]),
         "",
         "Between-Group:",
-        *(_summarize_between(between_df, config) or ["- No between-group results are available for summary."]),
+        *(between_lines or ["- No between-group results are available for summary."]),
+        "",
+        "Mixed Model:",
+        *(mixed_lines or ["- Mixed model: no summary is available."]),
         "",
         "Harmonic Check:",
-        *(_summarize_harmonics(harmonic_df, config) or ["- No harmonic check results are available for summary."]),
+        *(harmonic_lines or ["- No harmonic check results are available for summary."]),
         "",
         "Interactions:",
-        *(_summarize_interactions(interaction_df, config) or ["- No interaction summary is available."]),
+        *(interaction_lines or ["- No interaction summary is available."]),
         "",
-        "Please see the newly generated Excel files in the '3 - Statistical Analysis' folder for complete results. Consult your favorite statistics expert (for example, ChatGPT) for help interpreting these findings.",
+        "Please see the newly generated Excel files in the '3 - Statistical Analysis' folder for complete results. Consult your",
+        "favorite statistics expert (for example, ChatGPT) for help interpreting these findings.",
     ]
     return "\n".join(parts)
 
@@ -94,12 +150,14 @@ def _summarize_single(single_posthoc: Optional[pd.DataFrame], cfg: SummaryConfig
 
     p_col = _pick_column(single_posthoc, cfg.p_col, ["p_fdr_bh", "p_value_fdr", "p_fdr"])
     effect_col = _pick_column(single_posthoc, cfg.effect_col, ["cohens_dz", "dz", "effect_size"])
-    required = [p_col, effect_col, "Level_A", "Level_B"]
+    cond_a_col = _pick_column(single_posthoc, "Level_A", ["condition_a"])
+    cond_b_col = _pick_column(single_posthoc, "Level_B", ["condition_b"])
+    required = [p_col, effect_col, cond_a_col, cond_b_col]
     if any(col is None for col in required):
         return ["- No within-group results are available for summary."]
 
     df = single_posthoc.copy()
-    roi_col = "ROI" if "ROI" in df.columns else None
+    roi_col = _pick_column(df, "ROI", ["roi"])
     try:
         df["_abs_eff"] = df[effect_col].abs()
         mask = (df[p_col] < cfg.alpha) & (df["_abs_eff"] >= cfg.min_effect)
@@ -114,8 +172,8 @@ def _summarize_single(single_posthoc: Optional[pd.DataFrame], cfg: SummaryConfig
     for _, row in filtered.iterrows():
         roi = row.get(roi_col) if roi_col else "ROI"
         eff = float(row[effect_col]) if pd.notna(row[effect_col]) else 0.0
-        cond_a = str(row.get("Level_A", "A"))
-        cond_b = str(row.get("Level_B", "B"))
+        cond_a = str(row.get(cond_a_col, "A"))
+        cond_b = str(row.get(cond_b_col, "B"))
         high, low = (cond_a, cond_b) if eff >= 0 else (cond_b, cond_a)
         bullets.append(
             f"- In {roi}, {high} > {low}, p = {float(row[p_col]):.3f}, dz = {eff:.2f}."
@@ -129,7 +187,11 @@ def _summarize_between(between_contrasts: Optional[pd.DataFrame], cfg: SummaryCo
 
     p_col = _pick_column(between_contrasts, cfg.p_col, ["p_fdr_bh", "p_fdr"])
     effect_col = _pick_column(between_contrasts, cfg.effect_col, ["effect_size", "cohens_d", "d"])
-    required = [p_col, effect_col, "condition", "roi", "group_1", "group_2"]
+    cond_col = _pick_column(between_contrasts, "condition", ["Condition"])
+    roi_col = _pick_column(between_contrasts, "roi", ["ROI"])
+    g1_col = _pick_column(between_contrasts, "group_1", ["Group_1", "group1"])
+    g2_col = _pick_column(between_contrasts, "group_2", ["Group_2", "group2"])
+    required = [p_col, effect_col, cond_col, roi_col, g1_col, g2_col]
     if any(col is None for col in required):
         return ["- No between-group results are available for summary."]
 
@@ -142,18 +204,43 @@ def _summarize_between(between_contrasts: Optional[pd.DataFrame], cfg: SummaryCo
         return ["- No between-group results are available for summary."]
 
     if filtered.empty:
-        return ["- No between-group differences survived FDR correction at α = 0.05."]
+        return ["- No between-group pairwise contrasts survived FDR correction at α = 0.05."]
 
     bullets: list[str] = []
     for _, row in filtered.iterrows():
         eff = float(row[effect_col]) if pd.notna(row[effect_col]) else 0.0
-        g1, g2 = str(row.get("group_1", "Group 1")), str(row.get("group_2", "Group 2"))
+        g1, g2 = str(row.get(g1_col, "Group 1")), str(row.get(g2_col, "Group 2"))
         high, low = (g1, g2) if eff >= 0 else (g2, g1)
-        roi = row.get("roi", "ROI")
-        cond = row.get("condition", "Condition")
+        roi = row.get(roi_col, "ROI")
+        cond = row.get(cond_col, "Condition")
         bullets.append(
             f"- Between groups, {high} > {low} in {roi} for {cond}, p = {float(row[p_col]):.3f}, d = {eff:.2f}."
         )
+    return bullets
+
+
+def _summarize_mixed_model(mixed_model_terms: Optional[pd.DataFrame], cfg: SummaryConfig) -> list[str]:
+    if mixed_model_terms is None or not isinstance(mixed_model_terms, pd.DataFrame):
+        return ["- Mixed model: no summary is available."]
+
+    p_col = _pick_column(mixed_model_terms, cfg.p_col, ["p_fdr_bh", "p_value_fdr", "p_value", "p_fdr"])
+    term_col = _pick_column(mixed_model_terms, "term", ["Effect", "Term", "fixed_effect"])
+    if p_col is None or term_col is None:
+        return ["- Mixed model: no summary is available."]
+
+    df = mixed_model_terms.copy()
+    try:
+        filtered = df[df[p_col] < cfg.alpha].sort_values(p_col).head(cfg.max_bullets)
+    except Exception:
+        return ["- Mixed model: no summary is available."]
+
+    if filtered.empty:
+        return ["- Mixed model: no fixed effects were significant after FDR correction."]
+
+    bullets: list[str] = []
+    for _, row in filtered.iterrows():
+        term = str(row.get(term_col, "effect")).strip()
+        bullets.append(f"- Mixed model: significant {term} effect (p = {float(row[p_col]):.3f}).")
     return bullets
 
 
@@ -161,51 +248,62 @@ def _summarize_harmonics(harmonic_results: Optional[pd.DataFrame], cfg: SummaryC
     if harmonic_results is None or not isinstance(harmonic_results, pd.DataFrame):
         return ["- No harmonic check results are available for summary."]
 
-    roi_col = _pick_column(harmonic_results, "ROI", [])
-    freq_col = _pick_column(harmonic_results, "Frequency_Hz", ["Frequency", "freq_hz"])
-    condition_col = _pick_column(harmonic_results, "Condition", [])
+    roi_col = _pick_column(harmonic_results, "ROI", ["roi"])
     sig_col = _pick_column(harmonic_results, "Significant", ["is_significant"])
+    z_col = _pick_column(
+        harmonic_results,
+        "Mean_Z_Score",
+        ["Z", "z_score", "z", "Mean_Z", "mean"],
+    )
+    p_col = _pick_column(
+        harmonic_results,
+        cfg.p_col,
+        ["P_Value_FDR_BH", "p_corr", "P_Value_HOLM", "P_Value", "p_fdr"],
+    )
 
-    if roi_col is None or freq_col is None:
+    if roi_col is None:
         return ["- No harmonic check results are available for summary."]
 
     df = harmonic_results.copy()
-    if sig_col in df.columns:
-        df = df[df[sig_col] == True]  # noqa: E712
+    sig_mask = None
+    if sig_col and sig_col in df.columns:
+        try:
+            sig_mask = df[sig_col].astype(bool)
+        except Exception:
+            sig_mask = None
+    if sig_mask is None and z_col and p_col and z_col in df.columns and p_col in df.columns:
+        try:
+            sig_mask = (df[z_col] >= cfg.z_threshold) & (df[p_col] < cfg.alpha)
+        except Exception:
+            sig_mask = None
 
-    if df.empty:
-        return [f"- No harmonics met the significance criteria (Z ≥ {cfg.z_threshold}, FDR-corrected p < 0.05)."]
+    if sig_mask is None:
+        return ["- No harmonic check results are available for summary."]
 
-    groups = {}
-    for _, row in df.iterrows():
-        roi = row.get(roi_col, "ROI")
-        freq = row.get(freq_col)
-        if pd.notna(freq):
-            freq_val = f"{float(freq):.2f}" if isinstance(freq, (int, float)) else str(freq)
-            groups.setdefault(roi, []).append(freq_val)
+    sig_df = df[sig_mask]
+    if sig_df.empty:
+        return [
+            f"- No harmonics met the significance criteria (Z ≥ {cfg.z_threshold}, FDR-corrected p < {cfg.alpha:.2f})."
+        ]
 
-    if not groups:
-        return [f"- No harmonics met the significance criteria (Z ≥ {cfg.z_threshold}, FDR-corrected p < 0.05)."]
+    rois = sorted(set(sig_df[roi_col].dropna().astype(str)))
+    if not rois:
+        return [
+            f"- No harmonics met the significance criteria (Z ≥ {cfg.z_threshold}, FDR-corrected p < {cfg.alpha:.2f})."
+        ]
 
-    sorted_rois = sorted(groups.items(), key=lambda kv: len(kv[1]), reverse=True)[: cfg.max_bullets]
-    segments = []
-    for roi, freqs in sorted_rois:
-        unique_freqs = sorted(set(freqs), key=lambda v: float(v.split()[0]) if str(v).replace('.', '', 1).isdigit() else v)
-        cond_prefix = ""
-        if condition_col and condition_col in df.columns:
-            conds = sorted(set(df.loc[df[roi_col] == roi, condition_col].dropna().astype(str)))
-            if conds:
-                cond_prefix = f" ({', '.join(conds)})"
-        segments.append(f"{roi}{cond_prefix} at {', '.join(unique_freqs)} Hz")
-
-    return [f"- Significant harmonics in " + "; ".join(segments) + "."]
+    rois_text = ", ".join(rois)
+    return [
+        "- Significant responses detected at oddball and harmonic frequencies in the following ROIs: "
+        f"{rois_text}; see the harmonic check Excel file for full details."
+    ]
 
 
 def _summarize_interactions(interaction_anova: Optional[pd.DataFrame], cfg: SummaryConfig) -> list[str]:
     if interaction_anova is None or not isinstance(interaction_anova, pd.DataFrame):
         return ["- No interaction summary is available."]
 
-    p_col = _pick_column(interaction_anova, cfg.p_col, ["p_fdr_bh", "p_fdr"])
+    p_col = _pick_column(interaction_anova, cfg.p_col, ["p_fdr_bh", "p_fdr", "p_value", "p_value_fdr"])
     term_col = _pick_column(interaction_anova, "Effect", ["term", "Term"])
     if p_col is None or term_col is None:
         return ["- No interaction summary is available."]
@@ -224,6 +322,7 @@ def _summarize_interactions(interaction_anova: Optional[pd.DataFrame], cfg: Summ
     bullets = []
     for _, row in significant.iterrows():
         term = str(row.get(term_col, "interaction")).strip()
-        bullets.append(f"- A significant {term} interaction was detected (p = {float(row[p_col]):.3f}); inspect detailed tables and plots for the pattern.")
+        bullets.append(
+            f"- A significant {term} interaction was detected (p = {float(row[p_col]):.3f}); inspect detailed tables and plots for the pattern."
+        )
     return bullets
-


### PR DESCRIPTION
## Summary
- add StatsSummaryFrames container and in-memory summary builder with mixed model and streamlined harmonic reporting
- update the stats GUI to collect DataFrames from recent runs, render summaries in the QTextEdit log with a bold header, and drop the verbose contrasts preview
- preserve existing exports while keeping concise explanatory logging for between-group contrasts

## Testing
- Not run (environment does not support tests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f78e93bc4832ca1e5a325ce8e4cff)