### PR TITLE
Add stats pipeline logging scaffolding and smoke tests

### DIFF
--- a/src/Tools/Stats/PySide6/stats_core.py
+++ b/src/Tools/Stats/PySide6/stats_core.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Callable, Final
+
+from Main_App.PySide6_App.Backend.project import STATS_SUBFOLDER_NAME
+
+
+class PipelineId(Enum):
+    SINGLE = auto()
+    BETWEEN = auto()
+
+
+class StepId(Enum):
+    RM_ANOVA = auto()
+    MIXED_MODEL = auto()
+    INTERACTION_POSTHOCS = auto()
+    BETWEEN_GROUP_ANOVA = auto()
+    BETWEEN_GROUP_MIXED_MODEL = auto()
+    GROUP_CONTRASTS = auto()
+    HARMONIC_CHECK = auto()
+
+
+RESULTS_SUBFOLDER_NAME: Final[str] = STATS_SUBFOLDER_NAME
+
+
+@dataclass
+class PipelineStep:
+    id: StepId
+    name: str
+    worker_fn: Callable[..., Any]
+    kwargs: dict
+    handler: Callable[[dict], None]
+
+
+__all__ = [
+    "PipelineId",
+    "StepId",
+    "RESULTS_SUBFOLDER_NAME",
+    "PipelineStep",
+]

--- a/src/Tools/Stats/PySide6/stats_logging.py
+++ b/src/Tools/Stats/PySide6/stats_logging.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Final
+
+
+LOG_TIMESTAMP_FORMAT: Final[str] = "%Y-%m-%d %H:%M:%S"
+
+
+def format_log_line(message: str, *, level: str = "INFO") -> str:
+    timestamp = datetime.now().strftime(LOG_TIMESTAMP_FORMAT)
+    lvl = (level or "INFO").upper()
+    return f"[{timestamp}] [{lvl}] {message}"
+
+
+def format_section_header(title: str) -> str:
+    return f"==== {title} ===="
+
+
+__all__ = ["format_log_line", "format_section_header", "LOG_TIMESTAMP_FORMAT"]

--- a/tests/test_stats_window_smoke_phase0.py
+++ b/tests/test_stats_window_smoke_phase0.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+pytest.importorskip("PySide6")
+from PySide6.QtCore import Qt
+
+from Tools.Stats.PySide6 import stats_ui_pyside6 as stats_mod
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+from Tools.Stats.PySide6.stats_worker import StatsWorker
+
+
+@pytest.fixture
+def app(qapp):
+    """Ensure a QApplication exists for qtbot interactions."""
+    return qapp
+
+
+@pytest.fixture(autouse=True)
+def patch_pipeline_workers(monkeypatch):
+    def stub_worker(_progress_emit, _message_emit, *args, **kwargs):
+        return {}
+
+    for name in [
+        "_rm_anova_calc",
+        "_lmm_calc",
+        "_posthoc_calc",
+        "_between_group_anova_calc",
+        "_group_contrasts_calc",
+    ]:
+        monkeypatch.setattr(stats_mod, name, stub_worker)
+
+    def fast_run(self):  # pragma: no cover - invoked by Qt thread pool
+        self.signals.progress.emit(100)
+        self.signals.finished.emit({})
+
+    monkeypatch.setattr(StatsWorker, "run", fast_run, raising=False)
+
+
+def _prepare_window(win: StatsWindow, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(win, "refresh_rois", lambda: setattr(win, "rois", {"ROI": ["Cz"]}), raising=False)
+    monkeypatch.setattr(win, "_get_analysis_settings", lambda: (6.0, 0.05), raising=False)
+    monkeypatch.setattr(win, "_check_for_open_excel_files", lambda _folder: False, raising=False)
+
+
+@pytest.mark.qt
+def test_single_group_run_smoke(qtbot, tmp_path, monkeypatch, app):
+    win = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(win)
+    win.show()
+
+    _prepare_window(win, monkeypatch)
+    win.subject_data = {"S1": {"CondA": {"ROI": 1.0}}}
+    win.subjects = ["S1"]
+    win.conditions = ["CondA"]
+    win.subject_groups = {"S1": None}
+
+    qtbot.mouseClick(win.analyze_single_btn, Qt.LeftButton)
+
+    qtbot.waitUntil(lambda: win.analyze_single_btn.isEnabled(), timeout=5000)
+    qtbot.waitUntil(lambda: not win.spinner.isVisible(), timeout=5000)
+
+    log_text = win.output_text.toPlainText()
+    assert "Single Group Analysis" in log_text or "Single" in log_text
+
+
+@pytest.mark.qt
+def test_between_group_run_smoke(qtbot, tmp_path, monkeypatch, app):
+    win = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(win)
+    win.show()
+
+    _prepare_window(win, monkeypatch)
+    win.subject_data = {
+        "S1": {"CondA": {"ROI": 1.0}},
+        "S2": {"CondA": {"ROI": 2.0}},
+    }
+    win.subjects = ["S1", "S2"]
+    win.conditions = ["CondA"]
+    win.subject_groups = {"S1": "G1", "S2": "G2"}
+
+    qtbot.mouseClick(win.analyze_between_btn, Qt.LeftButton)
+
+    qtbot.waitUntil(lambda: win.analyze_between_btn.isEnabled(), timeout=5000)
+    qtbot.waitUntil(lambda: not win.spinner.isVisible(), timeout=5000)
+
+    log_text = win.output_text.toPlainText()
+    assert "Between-Group" in log_text or "Between" in log_text


### PR DESCRIPTION
## Summary
- add shared stats_core and stats_logging helpers for pipeline identifiers and log formatting
- instrument stats UI pipeline boundaries with structured logging hooks
- add pytest-qt smoke tests for single and between-group runs

## Testing
- python -m pytest -q tests/test_stats_window_smoke_phase0.py
- ruff check src/Tools/Stats/PySide6/stats_ui_pyside6.py src/Tools/Stats/PySide6/stats_core.py src/Tools/Stats/PySide6/stats_logging.py tests/test_stats_window_smoke_phase0.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f867e682c832cb084ae848b88bd84)