### PR TITLE
Refactor Stats data loading and worker plumbing

### DIFF
--- a/src/Tools/Stats/PySide6/stats_data_loader.py
+++ b/src/Tools/Stats/PySide6/stats_data_loader.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+# Folders to ignore during scanning (case-insensitive)
+IGNORED_FOLDERS = {".fif files", "loreta results"}
+
+EXCEL_PID_REGEX = re.compile(
+    r"(P\d+[A-Za-z]*|Sub\d+[A-Za-z]*|S\d+[A-Za-z]*)",
+    re.IGNORECASE,
+)
+
+
+class ScanError(Exception):
+    """Exception raised when scanning fails due to invalid folder or permissions."""
+
+
+@dataclass
+class ProjectScanResult:
+    subjects: List[str]
+    conditions: List[str]
+    subject_data: Dict[str, Dict[str, str]]
+    manifest: dict | None
+    participants_map: Dict[str, str]
+    subject_groups: Dict[str, str | None]
+    multi_group_manifest: bool
+
+
+def auto_detect_project_dir() -> str:
+    """Walk upward to find a folder containing project.json."""
+
+    path = Path.cwd()
+    while not (path / "project.json").is_file():
+        if path.parent == path:
+            return str(Path.cwd())
+        path = path.parent
+    return str(path)
+
+
+def load_manifest_data(project_root: Path, cfg: dict | None = None) -> tuple[str | None, dict[str, str]]:
+    if cfg is None:
+        manifest = project_root / "project.json"
+        if not manifest.is_file():
+            return None, {}
+        cfg = json.loads(manifest.read_text(encoding="utf-8"))
+    results_folder = cfg.get("results_folder")
+    if not isinstance(results_folder, str):
+        results_folder = None
+    subfolders = cfg.get("subfolders", {})
+    if not isinstance(subfolders, dict):
+        subfolders = {}
+    normalized: dict[str, str] = {}
+    for key, value in subfolders.items():
+        if isinstance(value, str):
+            normalized[key] = value
+    return results_folder, normalized
+
+
+def _resolve_results_root(project_root: Path, results_folder: str | None) -> Path:
+    if results_folder:
+        base = Path(results_folder)
+        if not base.is_absolute():
+            base = project_root / base
+    else:
+        base = project_root
+    return base.resolve()
+
+
+def resolve_project_subfolder(
+    project_root: Path,
+    results_folder: str | None,
+    subfolders: dict[str, str],
+    key: str,
+    default_name: str,
+) -> Path:
+    name = subfolders.get(key, default_name)
+    candidate = Path(name)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (_resolve_results_root(project_root, results_folder) / candidate).resolve()
+
+
+def load_project_manifest_for_excel_root(excel_root: Path) -> dict | None:
+    """Walk upward from an Excel folder to locate and load project.json."""
+
+    try:
+        current = excel_root.resolve()
+    except Exception:
+        current = excel_root
+    for candidate in (current, *current.parents):
+        manifest = candidate / "project.json"
+        if manifest.is_file():
+            try:
+                cfg = json.loads(manifest.read_text(encoding="utf-8"))
+            except Exception as exc:  # noqa: BLE001
+                import logging
+
+                logging.getLogger(__name__).warning("Failed to load manifest %s: %s", manifest, exc)
+                return None
+            try:
+                results_folder, subfolders = load_manifest_data(candidate, cfg)
+                expected_excel = resolve_project_subfolder(
+                    candidate,
+                    results_folder,
+                    subfolders,
+                    "excel",
+                    "1 - Excel Data Files",
+                )
+                expected_resolved = expected_excel.resolve()
+            except Exception:
+                expected_resolved = None
+            if expected_resolved is not None:
+                allowed = {current, *current.parents}
+                if expected_resolved not in allowed:
+                    continue
+            return cfg
+    return None
+
+
+def normalize_participants_map(manifest: dict | None) -> dict[str, str]:
+    """Return {SUBJECT_ID -> group_name} using upper-case participant IDs."""
+
+    if not isinstance(manifest, dict):
+        return {}
+    participants = manifest.get("participants", {})
+    if not isinstance(participants, dict):
+        return {}
+    normalized: dict[str, str] = {}
+    for pid, info in participants.items():
+        if not isinstance(pid, str) or not pid.strip():
+            continue
+        if not isinstance(info, dict):
+            continue
+        group = info.get("group")
+        if not isinstance(group, str) or not group.strip():
+            continue
+        normalized[pid.strip().upper()] = group.strip()
+    return normalized
+
+
+def map_subjects_to_groups(subjects: Iterable[str], participants_map: dict[str, str]) -> dict[str, str | None]:
+    return {pid: participants_map.get(pid.upper()) for pid in subjects}
+
+
+def has_multi_groups(manifest: dict | None) -> bool:
+    if not isinstance(manifest, dict):
+        return False
+    groups = manifest.get("groups")
+    return isinstance(groups, dict) and bool(groups)
+
+
+def scan_folder_simple(parent_folder: str) -> Tuple[List[str], List[str], Dict[str, Dict[str, str]]]:
+    """
+    Scans the given parent folder for subject Excel files and condition subfolders.
+
+    Args:
+        parent_folder: Path to the folder containing one subfolder per condition.
+
+    Returns:
+        subjects: sorted list of subject IDs (e.g., ["P01", "P02", ...])
+        conditions: sorted list of condition names (folder names cleaned)
+        subject_data: mapping {subject_id: {condition_name: full_file_path}}
+
+    Raises:
+        ScanError: if the folder is invalid or access is denied.
+    """
+
+    if not parent_folder or not os.path.isdir(parent_folder):
+        raise ScanError(f"Invalid or missing parent folder: {parent_folder}")
+
+    subjects_set = set()
+    conditions_set = set()
+    subject_data: Dict[str, Dict[str, str]] = {}
+
+    pid_pattern = EXCEL_PID_REGEX
+
+    try:
+        for entry in os.listdir(parent_folder):
+            entry_path = os.path.join(parent_folder, entry)
+            if not os.path.isdir(entry_path):
+                continue
+            if entry.lower() in IGNORED_FOLDERS:
+                continue
+
+            condition_clean = re.sub(r"^\d+\s*[-_]*\s*", "", entry).strip()
+            if not condition_clean:
+                continue
+
+            pattern = os.path.join(entry_path, "*.xlsx")
+            for filepath in glob.glob(pattern):
+                filename = os.path.basename(filepath)
+                match = pid_pattern.search(filename)
+                if not match:
+                    continue
+                pid = match.group(1).upper()
+                subjects_set.add(pid)
+                conditions_set.add(condition_clean)
+
+                subject_data.setdefault(pid, {})
+                subject_data[pid][condition_clean] = filepath
+    except PermissionError as e:  # noqa: PERF203
+        raise ScanError(f"Permission denied to access folder: {parent_folder}\n{e}")
+    except Exception as e:  # noqa: BLE001
+        raise ScanError(f"Error scanning folder '{parent_folder}': {e}")
+
+    subjects = sorted(subjects_set)
+    conditions = sorted(conditions_set)
+    return subjects, conditions, subject_data
+
+
+def load_project_scan(folder: str) -> ProjectScanResult:
+    subjects, conditions, data = scan_folder_simple(folder)
+    manifest = load_project_manifest_for_excel_root(Path(folder))
+    participants_map = normalize_participants_map(manifest)
+    subject_groups = map_subjects_to_groups(subjects, participants_map)
+    multi_group_manifest = has_multi_groups(manifest)
+    return ProjectScanResult(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=data,
+        manifest=manifest,
+        participants_map=participants_map,
+        subject_groups=subject_groups,
+        multi_group_manifest=multi_group_manifest,
+    )
+

--- a/src/Tools/Stats/PySide6/stats_file_scanner_pyside6.py
+++ b/src/Tools/Stats/PySide6/stats_file_scanner_pyside6.py
@@ -1,86 +1,15 @@
-import os
-import glob
-import re
-from typing import List, Dict, Tuple
+from __future__ import annotations
 
-EXCEL_PID_REGEX = re.compile(
-    r"(P\d+[A-Za-z]*|Sub\d+[A-Za-z]*|S\d+[A-Za-z]*)",
-    re.IGNORECASE,
-)
+"""
+Thin compatibility wrapper for stats data loading helpers.
 
+Historically this module housed the scanning helpers that discover subjects and
+conditions from the Excel data folders. The logic now lives in
+``stats_data_loader`` so that it can be reused by non-Qt code. Imports remain
+for backward compatibility.
+"""
 
-# Folders to ignore during scanning (case-insensitive)
-IGNORED_FOLDERS = {".fif files", "loreta results"}
+from Tools.Stats.PySide6.stats_data_loader import ScanError, scan_folder_simple
 
+__all__ = ["ScanError", "scan_folder_simple"]
 
-class ScanError(Exception):
-    """Exception raised when scanning fails due to invalid folder or permissions."""
-    pass
-
-
-def scan_folder_simple(parent_folder: str) -> Tuple[List[str], List[str], Dict[str, Dict[str, str]]]:
-    """
-    Scans the given parent folder for subject Excel files and condition subfolders.
-
-    Args:
-        parent_folder: Path to the folder containing one subfolder per condition.
-
-    Returns:
-        subjects: sorted list of subject IDs (e.g., ["P01", "P02", ...])
-        conditions: sorted list of condition names (folder names cleaned)
-        subject_data: mapping {subject_id: {condition_name: full_file_path}}
-
-    Raises:
-        ScanError: if the folder is invalid or access is denied.
-    """
-    if not parent_folder or not os.path.isdir(parent_folder):
-        raise ScanError(f"Invalid or missing parent folder: {parent_folder}")
-
-    subjects_set = set()
-    conditions_set = set()
-    subject_data: Dict[str, Dict[str, str]] = {}
-
-    # Pattern to match subject IDs in filenames (optional prefix + P<number>), before .xlsx
-    pid_pattern = EXCEL_PID_REGEX
-
-    try:
-        for entry in os.listdir(parent_folder):
-            entry_path = os.path.join(parent_folder, entry)
-            if not os.path.isdir(entry_path):
-                continue
-            if entry.lower() in IGNORED_FOLDERS:
-                continue
-
-            # Clean the folder name: remove leading digits/hyphens/spaces
-            condition_clean = re.sub(r'^\d+\s*[-_]*\s*', '', entry).strip()
-            if not condition_clean:
-                continue
-
-            # Scan for .xlsx files in this condition folder
-            pattern = os.path.join(entry_path, "*.xlsx")
-            found = False
-            for filepath in glob.glob(pattern):
-                filename = os.path.basename(filepath)
-                match = pid_pattern.search(filename)
-                if not match:
-                    continue
-                pid = match.group(1).upper()
-                subjects_set.add(pid)
-                conditions_set.add(condition_clean)
-                found = True
-
-                # Initialize per-subject dict
-                subject_data.setdefault(pid, {})
-                # Store or overwrite
-                subject_data[pid][condition_clean] = filepath
-
-            # Skip empty conditions without raising
-            # (up to caller to interpret missing data)
-    except PermissionError as e:
-        raise ScanError(f"Permission denied to access folder: {parent_folder}\n{e}")
-    except Exception as e:
-        raise ScanError(f"Error scanning folder '{parent_folder}': {e}")
-
-    subjects = sorted(subjects_set)
-    conditions = sorted(conditions_set)
-    return subjects, conditions, subject_data

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from Tools.Stats.Legacy.interpretation_helpers import generate_lme_summary
+from Tools.Stats.Legacy.group_contrasts import compute_group_contrasts
+from Tools.Stats.Legacy.mixed_effects_model import run_mixed_effects_model
+from Tools.Stats.Legacy.mixed_group_anova import run_mixed_group_anova
+from Tools.Stats.Legacy.posthoc_tests import run_interaction_posthocs
+from Tools.Stats.Legacy.stats_analysis import (
+    prepare_all_subject_summed_bca_data,
+    run_harmonic_check as run_harmonic_check_new,
+    run_rm_anova as analysis_run_rm_anova,
+    set_rois,
+)
+
+
+def _long_format_from_bca(
+    all_subject_bca_data: Dict[str, Dict[str, Dict[str, float]]],
+    subject_groups: dict[str, str | None] | None = None,
+) -> pd.DataFrame:
+    """Return a tidy dataframe for downstream models."""
+
+    rows = []
+    groups = subject_groups or {}
+    for pid, cond_data in all_subject_bca_data.items():
+        for cond_name, roi_data in cond_data.items():
+            for roi_name, value in roi_data.items():
+                if not pd.isna(value):
+                    rows.append(
+                        {
+                            "subject": pid,
+                            "condition": cond_name,
+                            "roi": roi_name,
+                            "value": value,
+                            "group": groups.get(pid),
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def run_rm_anova(progress_cb, message_cb, *, subjects, conditions, subject_data, base_freq, rois):
+    set_rois(rois)
+    message_cb("Preparing data for Summed BCA RM-ANOVA…")
+    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        log_func=message_cb,
+    )
+    if not all_subject_bca_data:
+        raise RuntimeError("Data preparation failed (empty).")
+    message_cb("Running RM-ANOVA…")
+    _, anova_df_results = analysis_run_rm_anova(all_subject_bca_data, message_cb)
+    return {"anova_df_results": anova_df_results}
+
+
+def run_between_group_anova(
+    progress_cb,
+    message_cb,
+    *,
+    subjects,
+    conditions,
+    subject_data,
+    base_freq,
+    rois,
+    subject_groups: dict[str, str | None] | None = None,
+):
+    set_rois(rois)
+    message_cb("Preparing data for Between-Group RM-ANOVA…")
+    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        log_func=message_cb,
+    )
+    if not all_subject_bca_data:
+        raise RuntimeError("Data preparation failed (empty).")
+
+    df_long = _long_format_from_bca(all_subject_bca_data, subject_groups)
+    before = len(df_long)
+    df_long = df_long.dropna(subset=["group"])
+    dropped = before - len(df_long)
+    if dropped:
+        message_cb(f"Dropped {dropped} rows without group assignments for mixed ANOVA.")
+    if df_long.empty:
+        raise RuntimeError("No rows with valid group assignments for mixed ANOVA.")
+
+    df_long["group"] = df_long["group"].astype(str)
+    if df_long["group"].nunique() < 2:
+        raise RuntimeError("Mixed ANOVA requires at least two groups with valid data.")
+
+    message_cb("Running Between-Group RM-ANOVA…")
+    results = run_mixed_group_anova(
+        df_long,
+        dv_col="value",
+        subject_col="subject",
+        within_cols=["condition", "roi"],
+        between_col="group",
+    )
+    return {"anova_df_results": results}
+
+
+def run_lmm(
+    progress_cb,
+    message_cb,
+    *,
+    subjects,
+    conditions,
+    subject_data,
+    base_freq,
+    alpha,
+    rois,
+    subject_groups: dict[str, str | None] | None = None,
+    include_group: bool = False,
+):
+    set_rois(rois)
+    prep_label = "Mixed Effects Model" if not include_group else "Between-Group Mixed Model"
+    message_cb(f"Preparing data for {prep_label}…")
+    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        log_func=message_cb,
+    )
+    if not all_subject_bca_data:
+        raise RuntimeError("Data preparation failed (empty).")
+
+    df_long = _long_format_from_bca(all_subject_bca_data, subject_groups)
+    if df_long.empty:
+        raise RuntimeError("No valid rows for mixed model after filtering NaNs.")
+
+    dropped = 0
+    group_levels: list[str] = []
+    if include_group:
+        before = len(df_long)
+        df_long = df_long.dropna(subset=["group"])
+        dropped = before - len(df_long)
+        df_long["group"] = df_long["group"].astype(str)
+        group_levels = sorted(df_long["group"].unique())
+        if dropped:
+            message_cb(
+                f"Dropped {dropped} rows without group assignments for between-group model."
+            )
+        if len(group_levels) < 2:
+            raise RuntimeError(
+                "Between-group mixed model requires at least two groups with valid data."
+            )
+
+    message_cb("Running Mixed Effects Model…")
+
+    fixed_effects = ["condition * roi"]
+    if include_group:
+        fixed_effects = ["group * condition * roi"]
+
+    mixed_results_df = run_mixed_effects_model(
+        data=df_long,
+        dv_col="value",
+        group_col="subject",
+        fixed_effects=fixed_effects,
+    )
+
+    output_text = "============================================================\n"
+    if include_group:
+        output_text += "       Between-Group Mixed-Effects Model Results\n"
+    else:
+        output_text += "       Linear Mixed-Effects Model Results\n"
+    output_text += "       Analysis conducted on: Summed BCA Data\n"
+    output_text += "============================================================\n\n"
+    if include_group:
+        output_text += (
+            "Group was modeled as a between-subject factor interacting with condition\n"
+            "and ROI. Only subjects with known group assignments were included.\n\n"
+        )
+    else:
+        output_text += (
+            "This model accounts for repeated observations from each subject by including\n"
+            "a random intercept. Fixed effects assess how conditions and ROIs influence\n"
+            "Summed BCA values, including their interaction.\n\n"
+        )
+    if mixed_results_df is not None and not mixed_results_df.empty:
+        output_text += "--------------------------------------------\n"
+        output_text += "                 FIXED EFFECTS TABLE\n"
+        output_text += "--------------------------------------------\n"
+        output_text += mixed_results_df.to_string(index=False) + "\n"
+        output_text += generate_lme_summary(mixed_results_df, alpha=alpha)
+    else:
+        output_text += "Mixed effects model returned no rows.\n"
+
+    return {"mixed_results_df": mixed_results_df, "output_text": output_text}
+
+
+def run_posthoc(
+    progress_cb,
+    message_cb,
+    *,
+    subjects,
+    conditions,
+    subject_data,
+    base_freq,
+    alpha,
+    rois,
+    subject_groups: dict[str, str | None] | None = None,
+):
+    set_rois(rois)
+    message_cb("Preparing data for Interaction Post-hoc tests…")
+    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        log_func=message_cb,
+    )
+    if not all_subject_bca_data:
+        raise RuntimeError("Data preparation failed (empty).")
+
+    df_long = _long_format_from_bca(all_subject_bca_data, subject_groups)
+    if df_long.empty:
+        raise RuntimeError("No valid rows for post-hoc tests after filtering NaNs.")
+
+    message_cb("Running post-hoc tests…")
+    output_text, results_df = run_interaction_posthocs(
+        data=df_long,
+        dv_col="value",
+        roi_col="roi",
+        condition_col="condition",
+        subject_col="subject",
+        alpha=alpha,
+    )
+    return {"results_df": results_df, "output_text": output_text}
+
+
+def run_group_contrasts(
+    progress_cb,
+    message_cb,
+    *,
+    subjects,
+    conditions,
+    subject_data,
+    base_freq,
+    alpha,
+    rois,
+    subject_groups: dict[str, str | None] | None = None,
+):
+    set_rois(rois)
+    _ = alpha
+    message_cb("Preparing data for Between-Group Contrasts…")
+    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        log_func=message_cb,
+    )
+    if not all_subject_bca_data:
+        raise RuntimeError("Data preparation failed (empty).")
+
+    df_long = _long_format_from_bca(all_subject_bca_data, subject_groups)
+    df_long = df_long.dropna(subset=["group"])
+    if df_long.empty:
+        raise RuntimeError("No rows with group assignments to compute contrasts.")
+    df_long["group"] = df_long["group"].astype(str)
+    if df_long["group"].nunique() < 2:
+        raise RuntimeError("Group contrasts require at least two groups with data.")
+
+    message_cb("Running Between-Group Contrasts…")
+    results_df = compute_group_contrasts(
+        df_long,
+        subject_col="subject",
+        group_col="group",
+        condition_col="condition",
+        roi_col="roi",
+        dv_col="value",
+    )
+    return {
+        "results_df": results_df,
+        "output_text": "",
+    }
+
+
+def run_harmonic_check(
+    progress_cb,
+    message_cb,
+    *,
+    subject_data,
+    subjects,
+    conditions,
+    selected_metric,
+    mean_value_threshold,
+    base_freq,
+    alpha,
+    rois,
+):
+    set_rois(rois)
+    tail = "greater" if selected_metric in ("Z Score", "SNR") else "two-sided"
+    message_cb("Running harmonic check…")
+    output_text, findings = run_harmonic_check_new(
+        subject_data=subject_data,
+        subjects=subjects,
+        conditions=conditions,
+        selected_metric=selected_metric,
+        mean_value_threshold=mean_value_threshold,
+        base_freq=base_freq,
+        log_func=message_cb,
+        max_freq=None,
+        correction_method="holm",
+        tail=tail,
+        min_subjects=3,
+        do_wilcoxon_sensitivity=True,
+    )
+    return {"output_text": output_text, "findings": findings}
+


### PR DESCRIPTION
## Summary
- add a pure-Python stats_data_loader module for manifest-aware scanning and project discovery
- extract heavy statistical callables into stats_workers for StatsWorker to invoke
- update the PySide6 Stats UI and scanner shim to use the new loaders and workers

## Testing
- ruff check . (fails: existing repository lint issues)
- pytest -q (fails: missing PySide6/numpy/pandas dependencies in environment)
- ruff check src/Tools/Stats/PySide6/stats_ui_pyside6.py src/Tools/Stats/PySide6/stats_data_loader.py src/Tools/Stats/PySide6/stats_workers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f89097dfc832c8c4a53f941730968)