### PR TITLE
Fix import for SNR utils test

### DIFF
--- a/tests/test_snr_utils.py
+++ b/tests/test_snr_utils.py
@@ -1,4 +1,4 @@
-import importlib.util
+import importlib
 import os
 
 def _import_snr_utils():


### PR DESCRIPTION
## Summary
- ensure snr utils test imports the importlib module required for importlib.util

## Testing
- pytest tests/test_snr_utils.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8dead5d0832c88afc48294007d2b)