### PR TITLE
Consolidate stats worker implementation

### DIFF
--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -59,7 +59,7 @@ from Tools.Stats.PySide6.stats_data_loader import (
     resolve_project_subfolder,
 )
 from Tools.Stats.PySide6.stats_logging import format_log_line, format_section_header
-from Tools.Stats.PySide6.stats_worker import StatsWorker
+from Tools.Stats.PySide6.stats_workers import StatsWorker
 from Tools.Stats.PySide6.summary_utils import (
     StatsSummaryFrames,
     SummaryConfig,

--- a/src/Tools/Stats/PySide6/stats_worker.py
+++ b/src/Tools/Stats/PySide6/stats_worker.py
@@ -1,56 +1,12 @@
-# src/Tools/Stats/PySide6/stats_worker.py
+"""
+Backwards-compatibility shim for StatsWorker.
+
+StatsWorker is now defined in stats_workers.py.
+New code should import from src.Tools.Stats.PySide6.stats_workers instead.
+"""
+
 from __future__ import annotations
 
-import logging
-import time
-from typing import Any, Callable, Dict
-from PySide6.QtCore import QObject, Signal, Slot, QRunnable
+from .stats_workers import StatsWorker
 
-logger = logging.getLogger("Tools.Stats")
-
-
-class StatsWorker(QRunnable):
-    """
-    QRunnable that executes a callable with (progress_emit, message_emit, *args, **kwargs)
-    and emits results via signals. Drop-in compatible with the previous version.
-    """
-
-    class Signals(QObject):
-        progress = Signal(int)
-        message = Signal(str)
-        error = Signal(str)
-        finished = Signal(dict)
-
-    def __init__(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
-        super().__init__()
-        self.setAutoDelete(True)  # avoid lingering runnables
-        self.signals = self.Signals()
-        self._fn: Callable[..., Any] = fn
-        self._args = args
-        # Optional op name for structured logs; removed from kwargs before calling fn
-        self._op: str = kwargs.pop("_op", getattr(fn, "__name__", "stats_op"))
-        self._kwargs = kwargs
-
-    @Slot()
-    def run(self) -> None:
-        t0 = time.perf_counter()
-        logger.info("stats_run_start", extra={"op": self._op})
-        progress_emit = self.signals.progress.emit
-        message_emit = self.signals.message.emit
-        try:
-            result = self._fn(progress_emit, message_emit, *self._args, **self._kwargs)
-            payload: Dict[str, Any] = result if isinstance(result, dict) else {"result": result}
-            try:
-                self.signals.finished.emit(payload)
-            except Exception as emit_exc:  # noqa: BLE001
-                logger.exception(
-                    "stats_run_emit_failed",
-                    extra={"op": self._op, "exc_type": type(emit_exc).__name__},
-                )
-                self.signals.error.emit(str(emit_exc))
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("stats_run_failed", extra={"op": self._op, "exc_type": type(exc).__name__})
-            self.signals.error.emit(str(exc))
-        finally:
-            dt_ms = (time.perf_counter() - t0) * 1000.0
-            logger.info("stats_run_done", extra={"op": self._op, "elapsed_ms": dt_ms})
+__all__ = ["StatsWorker"]

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1,8 +1,21 @@
+"""
+Worker jobs and runner for the Stats tool.
+
+This module defines:
+  * StatsWorker: QRunnable wrapper that executes a single stats job in a worker
+    thread and emits signals back to the controller/view.
+  * Job functions: pure computational routines for ANOVA, mixed models, group
+    contrasts, harmonics, etc., used by the stats pipelines.
+"""
+
 from __future__ import annotations
 
-from typing import Dict
+import logging
+import time
+from typing import Any, Callable, Dict
 
 import pandas as pd
+from PySide6.QtCore import QObject, QRunnable, Signal, Slot
 
 from Tools.Stats.Legacy.interpretation_helpers import generate_lme_summary
 from Tools.Stats.Legacy.group_contrasts import compute_group_contrasts
@@ -15,6 +28,55 @@ from Tools.Stats.Legacy.stats_analysis import (
     run_rm_anova as analysis_run_rm_anova,
     set_rois,
 )
+
+logger = logging.getLogger("Tools.Stats")
+
+
+class StatsWorker(QRunnable):
+    """
+    QRunnable that executes a callable with (progress_emit, message_emit, *args, **kwargs)
+    and emits results via signals. Drop-in compatible with the previous version.
+    """
+
+    class Signals(QObject):
+        progress = Signal(int)
+        message = Signal(str)
+        error = Signal(str)
+        finished = Signal(dict)
+
+    def __init__(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        super().__init__()
+        self.setAutoDelete(True)  # avoid lingering runnables
+        self.signals = self.Signals()
+        self._fn: Callable[..., Any] = fn
+        self._args = args
+        # Optional op name for structured logs; removed from kwargs before calling fn
+        self._op: str = kwargs.pop("_op", getattr(fn, "__name__", "stats_op"))
+        self._kwargs = kwargs
+
+    @Slot()
+    def run(self) -> None:
+        t0 = time.perf_counter()
+        logger.info("stats_run_start", extra={"op": self._op})
+        progress_emit = self.signals.progress.emit
+        message_emit = self.signals.message.emit
+        try:
+            result = self._fn(progress_emit, message_emit, *self._args, **self._kwargs)
+            payload: Dict[str, Any] = result if isinstance(result, dict) else {"result": result}
+            try:
+                self.signals.finished.emit(payload)
+            except Exception as emit_exc:  # noqa: BLE001
+                logger.exception(
+                    "stats_run_emit_failed",
+                    extra={"op": self._op, "exc_type": type(emit_exc).__name__},
+                )
+                self.signals.error.emit(str(emit_exc))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("stats_run_failed", extra={"op": self._op, "exc_type": type(exc).__name__})
+            self.signals.error.emit(str(exc))
+        finally:
+            dt_ms = (time.perf_counter() - t0) * 1000.0
+            logger.info("stats_run_done", extra={"op": self._op, "elapsed_ms": dt_ms})
 
 
 def _long_format_from_bca(

--- a/tests/test_stats_focus_async.py
+++ b/tests/test_stats_focus_async.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from PySide6.QtCore import Qt
 
 from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
-from Tools.Stats.PySide6.stats_worker import StatsWorker
+from Tools.Stats.PySide6.stats_workers import StatsWorker
 
 
 def test_stats_focus_async(qtbot, monkeypatch):

--- a/tests/test_stats_window_errors_stats.py
+++ b/tests/test_stats_window_errors_stats.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QMessageBox
 from Tools.Stats.Legacy import stats_analysis, stats_helpers
 from Tools.Stats.PySide6 import stats_workers
 from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
-from Tools.Stats.PySide6.stats_worker import StatsWorker
+from Tools.Stats.PySide6.stats_workers import StatsWorker
 
 
 def _prepare_window(win: StatsWindow, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_stats_window_smoke_phase0.py
+++ b/tests/test_stats_window_smoke_phase0.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 
 from Tools.Stats.PySide6 import stats_ui_pyside6 as stats_mod
 from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
-from Tools.Stats.PySide6.stats_worker import StatsWorker
+from Tools.Stats.PySide6.stats_workers import StatsWorker
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- move the StatsWorker QRunnable into the canonical stats_workers module alongside the existing job functions
- leave stats_worker as a backwards-compatible shim while updating internal imports and tests to use stats_workers directly
- keep the stats job implementations unchanged while clarifying the module’s role with documentation

## Testing
- python -m pytest tests/test_stats_pipeline_smoke.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692082480aa4832c8d745d8e5901c676)