### PR TITLE
Refine Stats PySide6 layout and document MVC roles

### DIFF
--- a/src/Tools/Stats/PySide6/README.md
+++ b/src/Tools/Stats/PySide6/README.md
@@ -1,0 +1,28 @@
+# Stats (PySide6) overview
+
+The PySide6 Stats layer wraps the legacy statistical routines with a Qt-based UI and worker orchestration.
+This package stays thin: the view only renders widgets and forwards user actions, while workers and legacy
+code handle the calculations.
+
+## Internal structure (MVC-ish)
+
+* **View**
+  * `stats_main_window.py` – QMainWindow that lays out controls and renders logs.
+  * `stats_ui_pyside6.py` – Thin entry point that exposes `StatsWindow` and legacy worker hooks for tests.
+* **Controller**
+  * `stats_controller.py` – Coordinates the Single and Between pipelines, run state, and worker scheduling.
+* **Model/services**
+  * `stats_data_loader.py` – Scans projects/manifests and normalizes metadata.
+  * `stats_workers.py` – Worker runner and pure statistical job functions.
+  * `summary_utils.py` – Builds rule-based summaries from exported results.
+* **Support**
+  * `stats_core.py` – Shared enums, data classes, and constants.
+  * `stats_logging.py` – Formatting helpers for UI log lines and structured logging.
+  * `stats_file_scanner_pyside6.py` – PySide6-specific project scanning utilities.
+
+### Pipeline flow
+
+`Analyze` button → `StatsController` launches pipeline → `StatsWorker` executes legacy stats code →
+DataFrames/exports → `summary_utils` builds summaries → `StatsWindow` displays status/log updates.
+
+Worker logic and legacy statistical math intentionally stay GUI-agnostic to keep the view simple.

--- a/src/Tools/Stats/PySide6/__init__.py
+++ b/src/Tools/Stats/PySide6/__init__.py
@@ -1,0 +1,5 @@
+"""PySide6 layer for the Stats tool.
+
+This package contains the view (StatsWindow), controller, and supporting
+services that wrap legacy statistical routines in a Qt-friendly API.
+"""

--- a/src/Tools/Stats/PySide6/stats_controller.py
+++ b/src/Tools/Stats/PySide6/stats_controller.py
@@ -1,6 +1,14 @@
 # src/Tools/Stats/PySide6/stats_controller.py
 from __future__ import annotations
 
+"""Controller layer for coordinating Stats pipelines.
+
+StatsController orchestrates the Single and Between pipelines, owns run state,
+schedules workers, and routes progress back to the view (StatsWindow). The
+controller contains orchestration only; computational work lives in
+stats_workers and legacy analysis modules.
+"""
+
 import logging
 import time
 from dataclasses import dataclass, field

--- a/src/Tools/Stats/PySide6/stats_core.py
+++ b/src/Tools/Stats/PySide6/stats_core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Shared types and constants for the Stats tool (support layer)."""
+
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Callable, Final

--- a/src/Tools/Stats/PySide6/stats_data_loader.py
+++ b/src/Tools/Stats/PySide6/stats_data_loader.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Data loading helpers for the Stats pipelines.
+
+This module belongs to the model/service layer. It scans FPVS project folders,
+validates manifests, and provides normalized metadata to the controller and
+workers while remaining GUI-agnostic.
+"""
+
 import glob
 import json
 import os

--- a/src/Tools/Stats/PySide6/stats_logging.py
+++ b/src/Tools/Stats/PySide6/stats_logging.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Shared logging utilities for the Stats tool (support layer)."""
+
 from datetime import datetime
 from typing import Final
 

--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -1,6 +1,14 @@
 # src/Tools/Stats/PySide6/stats_main_window.py
 from __future__ import annotations
 
+"""View layer for the PySide6 Stats tool.
+
+StatsWindow renders the Stats UI, wires user gestures to StatsController entry
+points, and reflects pipeline progress and logs for the user. All analysis logic
+is delegated to the controller and workers; this module focuses on layout and
+signal wiring only.
+"""
+
 import json
 import logging
 import os
@@ -1187,29 +1195,10 @@ class StatsWindow(QMainWindow):
         tools_row.addStretch(1)
         main_layout.addLayout(tools_row)
 
-        # status + ROI labels
-        self.lbl_status = QLabel("Select a folder containing FPVS results.")
-        self.lbl_status.setWordWrap(True)
-        self.lbl_status.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
-        main_layout.addWidget(self.lbl_status)
-
-        self.lbl_rois = QLabel("")
-        self.lbl_rois.setWordWrap(True)
-        self.lbl_rois.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
-        main_layout.addWidget(self.lbl_rois)
-
-        # spinner
-        prog_row = QHBoxLayout()
-        self.spinner = BusySpinner()
-        self.spinner.setFixedSize(18, 18)
-        self.spinner.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.spinner.hide()
-        prog_row.addWidget(self.spinner, alignment=Qt.AlignLeft)
-        prog_row.addStretch(1)
-        main_layout.addLayout(prog_row)
-
-        sections_layout = QHBoxLayout()
-        sections_layout.setSpacing(10)
+        analysis_box = QGroupBox("Analysis Controls")
+        analysis_box.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed))
+        analysis_layout = QVBoxLayout(analysis_box)
+        analysis_layout.setSpacing(8)
 
         # single group section
         single_group_box = QGroupBox("Single Group Analysis")
@@ -1217,7 +1206,6 @@ class StatsWindow(QMainWindow):
         single_layout = QVBoxLayout(single_group_box)
 
         single_action_row = QHBoxLayout()
-        single_action_row.addStretch(1)
         self.analyze_single_btn = QPushButton("Analyze Single Group")
         self.analyze_single_btn.clicked.connect(self.on_analyze_single_group_clicked)
         single_action_row.addWidget(self.analyze_single_btn)
@@ -1225,7 +1213,6 @@ class StatsWindow(QMainWindow):
         self.single_advanced_btn = QPushButton("Advanced…")
         self.single_advanced_btn.clicked.connect(self.on_single_advanced_clicked)
         single_action_row.addWidget(self.single_advanced_btn)
-        single_action_row.addStretch(1)
         single_layout.addLayout(single_action_row)
 
         self.single_status_lbl = QLabel("Idle")
@@ -1238,7 +1225,6 @@ class StatsWindow(QMainWindow):
         between_layout = QVBoxLayout(between_box)
 
         between_action_row = QHBoxLayout()
-        between_action_row.addStretch(1)
         self.analyze_between_btn = QPushButton("Analyze Group Differences")
         self.analyze_between_btn.clicked.connect(self.on_analyze_between_groups_clicked)
         between_action_row.addWidget(self.analyze_between_btn)
@@ -1246,16 +1232,34 @@ class StatsWindow(QMainWindow):
         self.between_advanced_btn = QPushButton("Advanced…")
         self.between_advanced_btn.clicked.connect(self.on_between_advanced_clicked)
         between_action_row.addWidget(self.between_advanced_btn)
-        between_action_row.addStretch(1)
         between_layout.addLayout(between_action_row)
 
         self.between_status_lbl = QLabel("Idle")
         self.between_status_lbl.setWordWrap(True)
         between_layout.addWidget(self.between_status_lbl)
 
-        sections_layout.addWidget(single_group_box)
-        sections_layout.addWidget(between_box)
-        main_layout.addLayout(sections_layout)
+        analysis_layout.addWidget(single_group_box)
+        analysis_layout.addWidget(between_box)
+        main_layout.addWidget(analysis_box)
+
+        # status + ROI labels with spinner
+        status_row = QHBoxLayout()
+        self.spinner = BusySpinner()
+        self.spinner.setFixedSize(18, 18)
+        self.spinner.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.spinner.hide()
+        status_row.addWidget(self.spinner, alignment=Qt.AlignLeft)
+
+        self.lbl_status = QLabel("Select a folder containing FPVS results.")
+        self.lbl_status.setWordWrap(True)
+        self.lbl_status.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        status_row.addWidget(self.lbl_status, 1)
+        main_layout.addLayout(status_row)
+
+        self.lbl_rois = QLabel("")
+        self.lbl_rois.setWordWrap(True)
+        self.lbl_rois.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        main_layout.addWidget(self.lbl_rois)
 
         # output pane
         self.output_text = QTextEdit()
@@ -1263,15 +1267,15 @@ class StatsWindow(QMainWindow):
         self.output_text.setAcceptRichText(True)
         self.output_text.setPlaceholderText("Analysis output")
         self.output_text.setMinimumHeight(140)
+        self.output_text.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         main_layout.addWidget(self.output_text, 1)
 
         main_layout.setStretch(0, 0)  # folder row
         main_layout.setStretch(1, 0)  # tools row
-        main_layout.setStretch(2, 0)  # status label
-        main_layout.setStretch(3, 0)  # ROI label
-        main_layout.setStretch(4, 0)  # spinner row
-        main_layout.setStretch(5, 0)  # analysis sections row
-        main_layout.setStretch(6, 1)  # unified output pane
+        main_layout.setStretch(2, 0)  # analysis controls
+        main_layout.setStretch(3, 0)  # status row
+        main_layout.setStretch(4, 0)  # ROI label
+        main_layout.setStretch(5, 1)  # output pane
 
         # initialize export buttons
         self._update_export_buttons()

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1,11 +1,14 @@
 """
-Worker jobs and runner for the Stats tool.
+Worker jobs and runner for the Stats tool (model/service layer).
 
 This module defines:
   * StatsWorker: QRunnable wrapper that executes a single stats job in a worker
     thread and emits signals back to the controller/view.
   * Job functions: pure computational routines for ANOVA, mixed models, group
     contrasts, harmonics, etc., used by the stats pipelines.
+
+The functions and worker stay GUI-agnostic; StatsWindow triggers them through
+StatsController.
 """
 
 from __future__ import annotations

--- a/src/Tools/Stats/PySide6/summary_utils.py
+++ b/src/Tools/Stats/PySide6/summary_utils.py
@@ -5,7 +5,8 @@ rule-based summary string suitable for display in the unified output window.
 The summarizer is intentionally conservative: it only reports effects that
 survive Benjamini–Hochberg FDR correction and meet minimum effect-size
 thresholds. Any unexpected files or schemas are handled gracefully by returning
-fallback messages instead of raising exceptions.
+fallback messages instead of raising exceptions. It is part of the
+model/service layer and remains GUI-agnostic.
 """
 
 from __future__ import annotations

--- a/tests/test_stats_layout_smoke.py
+++ b/tests/test_stats_layout_smoke.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtWidgets import QPushButton, QTextEdit, QVBoxLayout  # noqa: E402
+
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow  # noqa: E402
+
+
+@pytest.fixture
+def app(qapp):
+    """Ensure a QApplication exists for qtbot interactions."""
+    return qapp
+
+
+@pytest.mark.qt
+def test_stats_window_layout_smoke(qtbot, tmp_path, app):
+    window = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(window)
+    window.show()
+
+    layout = window.centralWidget().layout()
+    assert isinstance(layout, QVBoxLayout)
+
+    buttons = window.findChildren(QPushButton)
+    texts = {btn.text() for btn in buttons}
+    assert "Analyze Single Group" in texts
+    assert "Analyze Group Differences" in texts
+
+    log_widget = window.findChild(QTextEdit)
+    assert log_widget is not None
+    assert log_widget.isVisible()


### PR DESCRIPTION
## Summary
- Rework the Stats window into a single-column layout with consolidated analysis controls and better log expansion
- Remove leftover horizontal scaffolding from the previous harmonic controls while keeping existing analysis buttons
- Document the Stats MVC boundaries via module docstrings and a new package README plus a layout smoke test

## Testing
- pytest -q
- ruff check .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208e1e80f8832c91254adef43c5bc8)