### PR TITLE
Fix mixed model summary fallback

### DIFF
--- a/src/Tools/Stats/PySide6/summary_utils.py
+++ b/src/Tools/Stats/PySide6/summary_utils.py
@@ -224,7 +224,11 @@ def _summarize_mixed_model(mixed_model_terms: Optional[pd.DataFrame], cfg: Summa
     if mixed_model_terms is None or not isinstance(mixed_model_terms, pd.DataFrame):
         return ["- Mixed model: no summary is available."]
 
-    p_col = _pick_column(mixed_model_terms, cfg.p_col, ["p_fdr_bh", "p_value_fdr", "p_value", "p_fdr"])
+    p_col = _pick_column(
+        mixed_model_terms,
+        cfg.p_col,
+        ["p_fdr_bh", "p_value_fdr", "p_value", "p_fdr", "P>|z|", "P>|t|"]
+    )
     term_col = _pick_column(mixed_model_terms, "term", ["Effect", "Term", "fixed_effect"])
     if p_col is None or term_col is None:
         return ["- Mixed model: no summary is available."]

--- a/tests/test_summary_utils_mixed_model.py
+++ b/tests/test_summary_utils_mixed_model.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from Tools.Stats.PySide6.summary_utils import (
+    StatsSummaryFrames,
+    SummaryConfig,
+    build_summary_from_frames,
+)
+
+
+def test_mixed_model_summary_populates_when_terms_present():
+    df = pd.DataFrame({
+        "Effect": ["group", "condition"],
+        "P>|z|": [0.01, 0.2],
+    })
+
+    frames = StatsSummaryFrames(mixed_model_terms=df)
+    summary = build_summary_from_frames(frames, SummaryConfig())
+
+    assert "Mixed model: significant group effect" in summary
+    assert "no summary is available" not in summary


### PR DESCRIPTION
## Summary
- allow mixed-model summaries to recognize p-values from statsmodels output columns
- add regression test ensuring mixed-model terms populate the summary text when present

## Testing
- pytest -q *(fails: missing optional dependencies such as PySide6, pandas, numpy in test environment)*
- ruff check . *(fails: pre-existing lint errors outside this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c4b5e290832cac34cc3ef2508f3b)