### PR TITLE
Stabilize stats pipeline Excel I/O and BLAS usage

### DIFF
--- a/src/Tools/Stats/Legacy/blas_limits.py
+++ b/src/Tools/Stats/Legacy/blas_limits.py
@@ -1,0 +1,26 @@
+"""Utilities for constraining BLAS thread usage during stats runs."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import importlib.util
+
+_tp_spec = importlib.util.find_spec("threadpoolctl")
+if _tp_spec is not None:  # pragma: no cover - optional dependency at runtime
+    from threadpoolctl import threadpool_limits
+else:  # pragma: no cover - optional dependency at runtime
+    threadpool_limits = None  # type: ignore[assignment]
+
+
+@contextmanager
+def single_threaded_blas():
+    """Force BLAS to use a single thread within this context, if supported."""
+
+    if threadpool_limits is None:
+        yield
+    else:
+        with threadpool_limits(limits=1):
+            yield
+
+
+__all__ = ["single_threaded_blas"]

--- a/src/Tools/Stats/Legacy/excel_io.py
+++ b/src/Tools/Stats/Legacy/excel_io.py
@@ -1,0 +1,51 @@
+"""Thread-safe Excel I/O helpers for Legacy stats modules."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Dict, Tuple
+
+import pandas as pd
+
+_EXCEL_IO_LOCK = threading.Lock()
+
+# Simple per-process cache: (path, sheet_name, index_col) -> DataFrame
+_excel_cache: Dict[Tuple[str, str, str], pd.DataFrame] = {}
+
+
+def _cache_key(path: Path, sheet_name: str, index_col: str | None) -> Tuple[str, str, str]:
+    return (str(path), str(sheet_name), str(index_col or ""))
+
+
+def safe_read_excel(
+    path: str | Path,
+    sheet_name: str,
+    *,
+    index_col: str | None = None,
+    use_cache: bool = True,
+) -> pd.DataFrame:
+    """Thread-serialized Excel reader for Legacy stats.
+
+    - Always uses openpyxl via a short-lived ExcelFile context.
+    - Optionally caches DataFrames for the lifetime of the process.
+    - Safe to call from Qt worker threads.
+    """
+
+    p = Path(path)
+    key = _cache_key(p, sheet_name, index_col)
+
+    if use_cache and key in _excel_cache:
+        return _excel_cache[key].copy()
+
+    with _EXCEL_IO_LOCK:
+        with pd.ExcelFile(str(p), engine="openpyxl") as xls:
+            df = pd.read_excel(xls, sheet_name=sheet_name, index_col=index_col)
+
+    if use_cache:
+        _excel_cache[key] = df.copy()
+
+    return df
+
+
+__all__ = ["safe_read_excel"]


### PR DESCRIPTION
## Summary
- add a shared, cached Excel reader with serialized I/O for legacy stats modules and use it in BCA aggregation and harmonic checks
- wrap between-group ANOVA, mixed model, contrasts, and harmonic calculations in single-threaded BLAS contexts
- improve stats controller logging for harmonic check completion and error visibility

## Testing
- ruff check *(fails: existing lint issues elsewhere in repository)*
- pytest *(fails: missing optional GUI/scientific dependencies such as PySide6, numpy, pandas)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920df3c2da8832ca29aa149c0ba2779)