### PR TITLE
Fix Lela Mode phase label collisions

### DIFF
--- a/tests/test_stats_lela_labels.py
+++ b/tests/test_stats_lela_labels.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytest.importorskip("numpy")
+
+from Tools.Stats.PySide6.stats_controller import _unique_label
+
+
+def test_unique_label_adds_suffix_when_duplicate():
+    seen: set[str] = set()
+
+    first = _unique_label("1 - Excel Data Files", seen)
+    second = _unique_label("1 - Excel Data Files", seen)
+
+    assert first == "1 - Excel Data Files"
+    assert second == "1 - Excel Data Files (2)"
+    assert seen == {"1 - Excel Data Files", "1 - Excel Data Files (2)"}


### PR DESCRIPTION
## Summary
- ensure Lela Mode builds distinct phase entries even when folders share names
- add a helper for generating unique phase labels and a unit test to guard against collisions

## Testing
- ruff check . *(fails: existing lint issues unrelated to this change)*
- pytest tests/test_stats_lela_labels.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228abcd4f0832c865e9b3f96eece8a)