### PR TITLE
Add standalone script to normalize phase subject IDs

### DIFF
--- a/scripts/rename_phase_subject_ids.py
+++ b/scripts/rename_phase_subject_ids.py
@@ -1,159 +1,207 @@
-"""Utility script to standardize phase subject IDs in Excel filenames.
+"""Rename Excel files to normalize subject IDs for phase-aware stats.
 
-Usage example:
-    python -m scripts.rename_phase_subject_ids \
-        "C:\\Path\\To\\BC Follicular\\1 - Excel Data Files" \
-        "C:\\Path\\To\\BC Luteal\\1 - Excel Data Files" \
-        --dry-run
+This standalone script rewrites filenames from patterns like ``P2CGL_Angry_Results.xlsx``
+into ``P2_CGL_Angry_Results.xlsx`` so that existing subject-ID regexes pick up
+phase-agnostic identifiers (e.g., ``P2``) across phases.
 """
 from __future__ import annotations
 
 import argparse
 import logging
+import re
 import sys
 from pathlib import Path
-import re
 from typing import Iterable, List, Tuple
 
+# Regex splits the subject ID into three groups:
+#   prefix: the base subject token (e.g., P2, Sub3, S5)
+#   suffix: trailing letters encoding group/phase (e.g., CGL, BCF)
+#   rest:   anything following (may be empty or start with an underscore)
+PATTERN = re.compile(r"^(?P<prefix>P\d+|Sub\d+|S\d+)(?P<suffix>[A-Za-z]+)(?P<rest>.*)$")
 
-OLD_FORMAT_PATTERN = re.compile(r"^(?P<base>(?:P\d+|Sub\d+|S\d+))(?P<suffix>[A-Za-z]+)$", re.IGNORECASE)
-NEW_FORMAT_PATTERN = re.compile(r"^(?:P\d+|Sub\d+|S\d+)_", re.IGNORECASE)
+logger = logging.getLogger(__name__)
+
+
+def iter_excel_files(root: Path, recursive: bool) -> Iterable[Path]:
+    """Yield .xlsx files from ``root`` optionally traversing subdirectories."""
+    if recursive:
+        yield from root.rglob("*.xlsx")
+    else:
+        for path in root.iterdir():
+            if path.is_file() and path.suffix.lower() == ".xlsx":
+                yield path
+
+
+def plan_renames(excel_roots: List[Path], recursive: bool) -> Tuple[List[Tuple[Path, Path]], int, int]:
+    """Collect planned renames and return (plans, files_seen, files_matched)."""
+    plans: List[Tuple[Path, Path]] = []
+    files_seen = 0
+    files_matched = 0
+
+    for root in excel_roots:
+        for path in iter_excel_files(root, recursive=recursive):
+            if not path.is_file():
+                continue
+
+            files_seen += 1
+            stem = path.stem
+            match = PATTERN.match(stem)
+            if not match:
+                logger.debug("Skipping (pattern mismatch): '%s'", path)
+                continue
+
+            files_matched += 1
+            prefix = match.group("prefix")
+            suffix = match.group("suffix")
+            rest = match.group("rest")
+
+            normalized_prefix = f"{prefix}_{suffix}"
+            # If the basename already starts with ``prefix_suffix``, the file is already
+            # normalized and should be left untouched.
+            if stem.startswith(normalized_prefix):
+                continue
+
+            new_stem = f"{prefix}_{suffix}{rest}"
+            new_path = path.with_name(new_stem + path.suffix)
+
+            if new_path != path:
+                plans.append((path, new_path))
+
+    return plans, files_seen, files_matched
+
+
+def detect_collisions(plans: List[Tuple[Path, Path]]) -> int:
+    """Return the number of collisions detected within planned renames."""
+    collisions = 0
+    targets: dict[Path, Path] = {}
+
+    for old_path, new_path in plans:
+        existing_source = targets.get(new_path)
+        if existing_source and existing_source != old_path:
+            collisions += 1
+            logger.error(
+                "Collision detected: '%s' and '%s' would map to '%s'",
+                existing_source,
+                old_path,
+                new_path,
+            )
+            continue
+
+        if new_path.exists() and new_path.resolve() != old_path.resolve():
+            collisions += 1
+            logger.error(
+                "Collision detected: target '%s' already exists and differs from source '%s'",
+                new_path,
+                old_path,
+            )
+            continue
+
+        targets[new_path] = old_path
+
+    return collisions
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
 
 
 def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description=(
-            "Batch-rename Excel files so subject IDs are phase-agnostic and "
-            "group/phase info is placed after an underscore."
-        )
+        description="Normalize phase/group codes in Excel filenames for FPVS Toolbox stats.",
     )
     parser.add_argument(
         "excel_roots",
         nargs="+",
-        help="One or more Excel root folders to scan for .xlsx files.",
+        help="One or more directories containing Excel files to normalize.",
     )
     parser.add_argument(
         "--dry-run",
+        "-n",
         action="store_true",
-        help="Show intended renames without modifying files.",
         default=False,
+        help="Plan renames without applying changes.",
     )
     parser.add_argument(
-        "--recursive",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Recurse into subdirectories (default: True).",
+        "--no-recursive",
+        action="store_true",
+        default=False,
+        help="Do not descend into subdirectories (process only immediate .xlsx files).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        default=False,
+        help="Enable debug logging.",
     )
     return parser.parse_args(argv)
 
 
-def iter_excel_files(root: Path, recursive: bool) -> Iterable[Path]:
-    if recursive:
-        yield from root.rglob("*.xlsx")
-    else:
-        yield from root.glob("*.xlsx")
-
-
-def plan_renames(excel_roots: List[Path], recursive: bool) -> Tuple[List[Tuple[Path, Path]], List[str], int]:
-    planned: List[Tuple[Path, Path]] = []
-    collisions: List[str] = []
-    processed = 0
-    target_to_source: dict[Path, Path] = {}
-
-    for root in excel_roots:
-        for file_path in iter_excel_files(root, recursive):
-            processed += 1
-            if not file_path.is_file():
-                continue
-
-            basename = file_path.stem
-
-            if NEW_FORMAT_PATTERN.match(basename):
-                logging.debug("Skipping already standardized file: %s", file_path)
-                continue
-
-            old_match = OLD_FORMAT_PATTERN.match(basename)
-            if not old_match:
-                logging.debug("Skipping non-matching filename: %s", file_path)
-                continue
-
-            base_id = old_match.group("base")
-            suffix = old_match.group("suffix")
-            new_basename = f"{base_id}_{suffix}"
-            target_path = file_path.with_name(new_basename + file_path.suffix)
-
-            if target_path in target_to_source and target_to_source[target_path] != file_path:
-                collision_message = (
-                    f"Collision detected: '{file_path}' and planned rename from "
-                    f"'{target_to_source[target_path]}' would share the same target name '{target_path}'."
-                )
-                logging.error(collision_message)
-                collisions.append(collision_message)
-                continue
-
-            if target_path.exists() and target_path.resolve() != file_path.resolve():
-                collision_message = (
-                    f"Collision detected: '{file_path}' and existing '{target_path}' would "
-                    "share the same target name."
-                )
-                logging.error(collision_message)
-                collisions.append(collision_message)
-                continue
-
-            planned.append((file_path, target_path))
-            target_to_source[target_path] = file_path
-
-    return planned, collisions, processed
-
-
-def perform_renames(planned: List[Tuple[Path, Path]], dry_run: bool) -> int:
-    renamed_count = 0
-    for source, target in planned:
-        if dry_run:
-            logging.info("DRY-RUN: would rename '%s' -> '%s'", source, target)
-            renamed_count += 1
-            continue
-
-        target.parent.mkdir(parents=True, exist_ok=True)
-        source.rename(target)
-        logging.info("Renamed '%s' -> '%s'", source, target)
-        renamed_count += 1
-    return renamed_count
-
-
 def main(argv: List[str] | None = None) -> int:
     args = parse_args(argv)
+    configure_logging(args.verbose)
 
     excel_roots = [Path(root) for root in args.excel_roots]
-    for root in excel_roots:
-        if not root.exists() or not root.is_dir():
-            logging.error("Provided root is not a directory: %s", root)
-            return 1
+    recursive = not args.no_recursive
 
-    logging.info(
-        "Starting phase subject ID rename. Roots=%s dry_run=%s recursive=%s",
+    logger.info(
+        "Starting phase subject ID rename. roots=%s dry_run=%s recursive=%s",
         excel_roots,
         args.dry_run,
-        args.recursive,
+        recursive,
     )
 
-    planned, collisions, processed = plan_renames(excel_roots, args.recursive)
+    for root in excel_roots:
+        if not root.exists() or not root.is_dir():
+            logger.error("Invalid root (not a directory): '%s'", root)
+            return 1
+
+    plans, files_seen, files_matched = plan_renames(excel_roots, recursive)
+    collisions = detect_collisions(plans)
 
     if collisions:
-        logging.error("Collisions detected; aborting rename. Count=%d", len(collisions))
+        logger.info(
+            "Completed rename. files_seen=%d, files_matched=%d, files_renamed=%d, collisions=%d",
+            files_seen,
+            files_matched,
+            len(plans),
+            collisions,
+        )
         return 1
 
-    renamed = perform_renames(planned, args.dry_run)
+    if args.dry_run:
+        for old_path, new_path in plans:
+            logger.info("DRY-RUN: would rename '%s' -> '%s'", old_path, new_path)
+    else:
+        for old_path, new_path in plans:
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            old_path.rename(new_path)
+            logger.info("Renamed '%s' -> '%s'", old_path, new_path)
 
-    logging.info(
-        "Completed rename. Files_processed=%d, Files_renamed=%d, Collisions=%d",
-        processed,
-        renamed,
-        len(collisions),
+    logger.info(
+        "Completed rename. files_seen=%d, files_matched=%d, files_renamed=%d, collisions=%d",
+        files_seen,
+        files_matched,
+        len(plans),
+        collisions,
     )
     return 0
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     sys.exit(main())
+
+# Example usage (Windows PowerShell):
+# python -m scripts.rename_phase_subject_ids "C:\\Projects\\BC Follicular\\1 - Excel Data Files" "C:\\Projects\\BC Luteal\\1 - Excel Data Files" --dry-run
+# python -m scripts.rename_phase_subject_ids "C:\\Projects\\BC Follicular\\1 - Excel Data Files" "C:\\Projects\\BC Luteal\\1 - Excel Data Files"
+#
+# This normalization ensures the Stats scanner extracts base IDs like P2, P7, or P10
+# for all phases of the same subject, allowing Lela Mode to intersect subjects
+# across phases without dropping them.


### PR DESCRIPTION
## Summary
- add a standalone maintenance script to normalize subject IDs in Excel filenames
- implement recursive scanning, dry-run support, and collision detection to safely rename files
- document usage and rationale so Stats subject matching treats IDs consistently across phases

## Testing
- pytest *(fails: missing optional dependencies such as PySide6, numpy, pandas in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229750b814832c9ea20cd3583899a3)