### PR TITLE
Add backup 2x2 reporting for cross-phase LMM

### DIFF
--- a/tests/test_cross_phase_lmm.py
+++ b/tests/test_cross_phase_lmm.py
@@ -90,6 +90,9 @@ def test_cross_phase_lmm_contrasts_and_meta():
     assert result["meta"]["n_subjects"] == len(subjects)
     assert "backup_2x2" in result
     assert "backup_2x2_used" in result["meta"]
+    backup_2x2_results = result.get("backup_2x2_results")
+    assert backup_2x2_results is not None
+    assert isinstance(backup_2x2_results, list)
     fixed_effects = result["fixed_effects"]
     assert fixed_effects and len(fixed_effects) > 0
 


### PR DESCRIPTION
## Summary
- add structured backup 2x2 results to cross-phase LMM JSON output
- export aggregated backup 2x2 results into a dedicated Excel sheet
- extend cross-phase LMM test coverage for the new results key

## Testing
- pytest tests/test_cross_phase_lmm.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235d42e49c832cb46022276163f0fe)