### PR TITLE
Fix posthoc and harmonic worker payloads

### DIFF
--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -338,6 +338,7 @@ def run_posthoc(
     alpha,
     rois,
     subject_groups: dict[str, str | None] | None = None,
+    **kwargs,
 ):
     set_rois(rois)
     message_cb("Preparing data for Interaction Post-hoc tests…")
@@ -364,6 +365,7 @@ def run_posthoc(
         subject_col="subject",
         alpha=alpha,
     )
+    message_cb("Post-hoc interaction tests completed.")
     return {"results_df": results_df, "output_text": output_text}
 
 
@@ -435,6 +437,7 @@ def run_harmonic_check(
     base_freq,
     alpha,
     rois,
+    **kwargs,
 ):
     set_rois(rois)
     tail = "greater" if selected_metric in ("Z Score", "SNR") else "two-sided"
@@ -453,6 +456,7 @@ def run_harmonic_check(
         min_subjects=3,
         do_wilcoxon_sensitivity=True,
     )
+    message_cb("Harmonic check completed.")
     return {"output_text": output_text, "findings": findings}
 
 


### PR DESCRIPTION
## Summary
- allow post-hoc and harmonic check workers to accept extra keyword arguments and emit completion messages
- keep interaction post-hoc and harmonic outputs in the dict shapes expected by the view

## Testing
- ruff check src/Tools/Stats/PySide6/stats_workers.py
- pytest tests/test_stats_pipeline_smoke.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692499ac1550832c90eaf35eb7c11d88)