### PR TITLE
Refactor stats text helpers into shared modules

### DIFF
--- a/src/Tools/Stats/PySide6/stats_core.py
+++ b/src/Tools/Stats/PySide6/stats_core.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Shared types and constants for the Stats tool (support layer)."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, auto


### PR DESCRIPTION
## Summary
- Extract RM-ANOVA summary formatting, dataframe normalization, and summary frame building into shared helpers
- Update the stats main window to delegate ANOVA text generation and summary preparation to summary_utils
- Clean up stats_core module header ordering

## Testing
- python -m pytest tests/Tools/Stats *(fails: test path not found)*
- python -m pytest *(fails: missing PySide6/numpy/pandas test dependencies during collection)*
- ruff check src/Tools/Stats/PySide6/stats_main_window.py src/Tools/Stats/PySide6/summary_utils.py src/Tools/Stats/PySide6/stats_core.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692603554f80832ca6fb1c9979783b16)