### PR TITLE
Refactor PySide6 stats helpers

### DIFF
--- a/src/Tools/Stats/PySide6/stats_core.py
+++ b/src/Tools/Stats/PySide6/stats_core.py
@@ -26,6 +26,14 @@ class StepId(Enum):
 
 RESULTS_SUBFOLDER_NAME: Final[str] = STATS_SUBFOLDER_NAME
 
+ANOVA_XLS: Final[str] = "RM-ANOVA Results.xlsx"
+LMM_XLS: Final[str] = "Mixed Model Results.xlsx"
+POSTHOC_XLS: Final[str] = "Posthoc Results.xlsx"
+HARMONIC_XLS: Final[str] = "Harmonic Results.xlsx"
+ANOVA_BETWEEN_XLS: Final[str] = "Mixed ANOVA Between Groups.xlsx"
+LMM_BETWEEN_XLS: Final[str] = "Mixed Model Between Groups.xlsx"
+GROUP_CONTRAST_XLS: Final[str] = "Group Contrasts.xlsx"
+
 
 @dataclass
 class PipelineStep:
@@ -40,5 +48,12 @@ __all__ = [
     "PipelineId",
     "StepId",
     "RESULTS_SUBFOLDER_NAME",
+    "ANOVA_XLS",
+    "LMM_XLS",
+    "POSTHOC_XLS",
+    "HARMONIC_XLS",
+    "ANOVA_BETWEEN_XLS",
+    "LMM_BETWEEN_XLS",
+    "GROUP_CONTRAST_XLS",
     "PipelineStep",
 ]

--- a/src/Tools/Stats/PySide6/summary_utils.py
+++ b/src/Tools/Stats/PySide6/summary_utils.py
@@ -18,7 +18,16 @@ from typing import Iterable, Optional
 import numpy as np
 import pandas as pd
 
-from Tools.Stats.PySide6.stats_core import PipelineId
+from Tools.Stats.PySide6.stats_core import (
+    ANOVA_BETWEEN_XLS,
+    ANOVA_XLS,
+    GROUP_CONTRAST_XLS,
+    HARMONIC_XLS,
+    LMM_BETWEEN_XLS,
+    LMM_XLS,
+    POSTHOC_XLS,
+    PipelineId,
+)
 
 
 @dataclass
@@ -38,15 +47,6 @@ class StatsSummaryFrames:
     harmonic_results: Optional[pd.DataFrame] = None
     anova_terms: Optional[pd.DataFrame] = None
     mixed_model_terms: Optional[pd.DataFrame] = None
-
-
-POSTHOC_XLS = "Posthoc Results.xlsx"
-GROUP_CONTRAST_XLS = "Group Contrasts.xlsx"
-HARMONIC_XLS = "Harmonic Results.xlsx"
-ANOVA_XLS = "RM-ANOVA Results.xlsx"
-ANOVA_BETWEEN_XLS = "Mixed ANOVA Between Groups.xlsx"
-LMM_XLS = "Mixed Model Results.xlsx"
-LMM_BETWEEN_XLS = "Mixed Model Between Groups.xlsx"
 
 
 def build_summary_from_files(stats_folder: Path, config: SummaryConfig) -> str:


### PR DESCRIPTION
## Summary
- centralize Excel export filename constants in stats_core and update PySide6 stats modules to import them
- delegate ANOVA summary text and DataFrame handling from the view to summary_utils helpers
- move path/export utilities into stats_data_loader and keep StatsWindow wrappers thin

## Testing
- ruff check src/Tools/Stats/PySide6/stats_core.py src/Tools/Stats/PySide6/stats_main_window.py src/Tools/Stats/PySide6/summary_utils.py src/Tools/Stats/PySide6/stats_data_loader.py
- pytest *(fails: missing PySide6, numpy, pandas test dependencies in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692609cc92f4832cafaedfb74ce6ac88)