### PR TITLE
Fix Lela mode run guard handling in Stats tool

### DIFF
--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -1314,6 +1314,24 @@ class StatsWindow(QMainWindow):
         self._apply_harmonic_results(payload, pipeline_id=pipeline_id)
         self._end_run()
 
+    @Slot(object)
+    def _on_lela_mode_finished(self, stats_folder: Path | None = None) -> None:
+        try:
+            section = self._section_label(PipelineId.BETWEEN)
+            self.append_log(section, "[Between] Lela Mode: complete — see Cross-Phase LMM Analysis.xlsx")
+            if stats_folder:
+                self.append_log(section, f"  • Excel: {stats_folder}")
+        finally:
+            self._end_run()
+
+    @Slot(str)
+    def _on_lela_mode_error(self, message: str) -> None:
+        try:
+            section = self._section_label(PipelineId.BETWEEN)
+            self.append_log(section, f"[Between] Lela Mode error: {message}", level="error")
+        finally:
+            self._end_run()
+
     # --------------------------- UI building ---------------------------
 
     def _init_ui(self) -> None:


### PR DESCRIPTION
## Summary
- add dedicated Lela mode completion and error handlers in the Stats window that always release the UI run guard
- adjust Lela worker callbacks in the controller to delegate to the view while reliably clearing busy state and the running flag

## Testing
- python -m pytest *(fails: missing PySide6/numpy/pandas test dependencies in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272b9f29c8832c8aca15296c296a25)