### PR TITLE
Disable LORETA toggle in PySide6 GUI

### DIFF
--- a/src/Main_App/PySide6_App/Backend/processing.py
+++ b/src/Main_App/PySide6_App/Backend/processing.py
@@ -25,4 +25,5 @@ def process_data(raw: Optional[mne.io.BaseRaw], output_dir: str, run_loreta: boo
         Whether to run LORETA source localization (reserved for future hook).
     """
     # Placeholder: keep for compatibility; real work is handled elsewhere.
+    # LORETA processing is not implemented; run_loreta is currently ignored.
     return

--- a/src/Main_App/PySide6_App/Backend/processing_controller.py
+++ b/src/Main_App/PySide6_App/Backend/processing_controller.py
@@ -310,7 +310,7 @@ def start_processing(self) -> None:
     try:
         project: Project = self.currentProject
         input_dir = Path(project.input_folder)
-        run_loreta = bool(getattr(self, "cb_loreta", None) and self.cb_loreta.isChecked())
+        run_loreta = False
 
         batch_mode = bool(getattr(self, "rb_batch", None) and self.rb_batch.isChecked())
 
@@ -477,7 +477,9 @@ def start_processing(self) -> None:
                 self.currentProject.project_root
                 / self.currentProject.subfolders["excel"]
             )
-            self.log(f"Running main processing (run_loreta={run_loreta})")
+            self.log(
+                f"Running main processing (run_loreta={run_loreta}; LORETA disabled in GUI)"
+            )
             logger.debug(
                 "start_processing_call_process_data",
                 extra={"file": str(fp), "out_dir": out_dir, "run_loreta": run_loreta},

--- a/src/Main_App/PySide6_App/Backend/project_manager.py
+++ b/src/Main_App/PySide6_App/Backend/project_manager.py
@@ -258,7 +258,6 @@ def loadProject(self, project: Project) -> None:
     mode = project.options.get("mode", "batch").lower()
     self.rb_single.setChecked(mode == "single")
     self.rb_batch.setChecked(mode == "batch")
-    self.cb_loreta.setChecked(bool(project.options.get("run_loreta", False)))
 
     for row in list(self.event_rows):
         row.setParent(None)

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -201,7 +201,6 @@ class _QtEntryAdapter:
                 "btn_select_input_file", "le_input_file",
                 "btn_select_input_folder", "le_input_folder",
                 "btn_add_event", "btn_add_row", "btn_detect",
-                "cb_loreta",
                 "btn_create_project", "btn_open_project",
         ):
             _safe_enable(n)
@@ -386,7 +385,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
         self._start_guard = OpGuard()
 
         # Flags/vars the mixin expects
-        self.run_loreta_var = SimpleNamespace(get=lambda: self.cb_loreta.isChecked())
+        self.run_loreta_var = SimpleNamespace(get=lambda: False)
         self.save_fif_var = SimpleNamespace(get=lambda: True)
         self.save_folder_path = SimpleNamespace(get=lambda: "", set=lambda v: None)
         self.file_mode = SimpleNamespace(get=lambda: "Batch")
@@ -1550,8 +1549,8 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
                 if getattr(self, "rb_single", None) and self.rb_single.isChecked()
                 else "batch"
             )
-            # Keep existing schema key as-is
-            opts["run_loreta"] = bool(self.cb_loreta.isChecked()) if hasattr(self, "cb_loreta") else False
+            # Keep existing schema key but hard-disable LORETA in the PySide6 GUI
+            opts["run_loreta"] = False
             self.currentProject.options = opts
 
             # Build event map in one pass: {label: int(id)}
@@ -1703,7 +1702,6 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
                 "btn_select_input_file", "le_input_file",
                 "btn_select_input_folder", "le_input_folder",
                 "btn_add_event", "btn_add_row", "btn_detect",
-                "cb_loreta",
                 "btn_create_project", "btn_open_project",
         ):
             _safe_enable(n)

--- a/src/Main_App/PySide6_App/GUI/ui_main.py
+++ b/src/Main_App/PySide6_App/GUI/ui_main.py
@@ -12,7 +12,6 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QGridLayout,
     QRadioButton,
-    QCheckBox,
     QButtonGroup,
     QScrollArea,
     QPushButton,
@@ -189,8 +188,6 @@ def init_ui(self) -> None:
     self.rb_batch = QRadioButton("Batch Folder", grp_proc)
     gl.addWidget(self.rb_single, 0, 1)
     gl.addWidget(self.rb_batch, 0, 2)
-    self.cb_loreta = QCheckBox("Run LORETA during processing?", grp_proc)
-    gl.addWidget(self.cb_loreta, 1, 0, 1, 3)
     self.mode_group = QButtonGroup(self)
     self.mode_group.setExclusive(True)
     self.mode_group.addButton(self.rb_single)
@@ -215,7 +212,7 @@ def init_ui(self) -> None:
     single_hl.addWidget(self.le_input_file, 1)
     single_hl.addWidget(self.btn_select_input_file)
     # Place directly under the Mode row within Processing Options
-    gl.addWidget(self.row_single_file, 2, 0, 1, 3)
+    gl.addWidget(self.row_single_file, 1, 0, 1, 3)
     self.row_single_file.setVisible(False)  # default hidden; toggled by _on_mode_changed
     # Let main window decide when Start is enabled
     try:
@@ -227,9 +224,6 @@ def init_ui(self) -> None:
     # Load saved processing options
     mode = self.settings.get("processing", "mode", "batch").lower()
     (self.rb_batch if mode == "batch" else self.rb_single).setChecked(True)
-    self.cb_loreta.setChecked(
-        self.settings.get("processing", "run_loreta", "False").lower() == "true"
-    )
     # Ensure initial Start-button state matches mode
     try:
         self._update_start_enabled()


### PR DESCRIPTION
## Summary
- remove the LORETA checkbox from the PySide6 processing options layout and stop loading its saved state
- hard-disable the LORETA flag when persisting project options and starting processing, while updating logging accordingly
- clarify that the processing entry point still accepts `run_loreta` but currently ignores it

## Testing
- python -m pytest -q *(fails: missing PySide6/numpy/pandas dependencies in test environment)*
- ruff check . *(fails: pre-existing lint errors outside this change)*
- mypy src --strict *(fails: existing syntax error in src/Compiler_Script.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693211038c14832c86c79d5807582b77)