### PR TITLE
Use filename metadata for Lela Mode cross-phase stats

### DIFF
--- a/tests/test_lela_filename_parser.py
+++ b/tests/test_lela_filename_parser.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from Tools.Stats.Legacy.cross_phase_lmm_core import build_cross_phase_long_df
+from Tools.Stats.PySide6.stats_data_loader import (
+    LelaFilenameParseError,
+    parse_lela_excel_filename,
+    scan_lela_phase_folder,
+)
+
+
+def test_parse_uppercase_filename() -> None:
+    metadata = parse_lela_excel_filename(Path("P2CGF_Angry_Results.xlsx"))
+
+    assert metadata.subject_id == "P2"
+    assert metadata.group_code == "CG"
+    assert metadata.phase_code == "F"
+    assert metadata.condition == "Angry"
+
+
+def test_parse_multiword_condition_and_lowercase() -> None:
+    metadata = parse_lela_excel_filename(Path("p20bcl_angry_control_results.xlsx"))
+
+    assert metadata.subject_id == "P20"
+    assert metadata.group_code == "BC"
+    assert metadata.phase_code == "L"
+    assert metadata.condition == "Angry Control"
+
+
+def test_parse_failure_requires_results_suffix() -> None:
+    with pytest.raises(LelaFilenameParseError):
+        parse_lela_excel_filename(Path("P2CGF_Angry.xlsx"))
+
+
+def test_merge_preserves_subjects_and_groups(tmp_path: Path) -> None:
+    follicular = tmp_path / "Follicular"
+    luteal = tmp_path / "Luteal"
+    follicular.mkdir()
+    luteal.mkdir()
+
+    for name in ["P1CGF_Angry_Results.xlsx", "P2BCF_Angry_Results.xlsx"]:
+        (follicular / name).write_text("", encoding="utf-8")
+    for name in ["P1CGL_Angry_Results.xlsx", "P2BCL_Angry_Results.xlsx"]:
+        (luteal / name).write_text("", encoding="utf-8")
+
+    fol_scan = scan_lela_phase_folder(follicular)
+    lut_scan = scan_lela_phase_folder(luteal)
+
+    phase_data = {
+        "Follicular": {
+            "P1": {"Angry": {"ROI": 1.0}},
+            "P2": {"Angry": {"ROI": 2.0}},
+        },
+        "Luteal": {
+            "P1": {"Angry": {"ROI": 1.5}},
+            "P2": {"Angry": {"ROI": 2.5}},
+        },
+    }
+    phase_group_maps = {
+        "Follicular": fol_scan.group_map,
+        "Luteal": lut_scan.group_map,
+    }
+
+    df = build_cross_phase_long_df(
+        phase_data,
+        phase_group_maps,
+        ("Follicular", "Luteal"),
+        phase_label_to_code={"Follicular": fol_scan.phase_code, "Luteal": lut_scan.phase_code},
+    )
+
+    assert not df.empty
+    assert sorted(df["subject"].unique()) == ["P1", "P2"]
+    assert set(df["group"].unique()) == {"BC", "CG"}
+    assert set(df["phase"].unique()) == {"F", "L"}
+    assert len(df) == 4
+    assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
## Summary
- add a dedicated Lela Excel filename parser and phase scanner to derive canonical subject IDs, group codes, phase codes, and conditions from filenames
- feed filename-derived phase/group metadata into cross-phase LMM with validation for a single phase code per folder and exactly two groups/phases overall, while improving logging
- keep output formatting unchanged and add parser/merge tests to prevent subject drops when group codes are stable

## Testing
- python -m compileall src *(fails: existing syntax error in src/Compiler_Script.py)*
- python -m pytest -q *(fails: missing optional dependencies such as PySide6/numpy/pandas)*
- ruff check . *(fails: pre-existing lint issues outside the touched files)*
- mypy src --strict *(fails: existing syntax error in src/Compiler_Script.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6cce30c8832c96e10c26f3d6b238)