### PR TITLE
Add scalp map option and reposition legends in plot generator

### DIFF
--- a/src/Tools/Plot_Generator/plot_settings.py
+++ b/src/Tools/Plot_Generator/plot_settings.py
@@ -2,15 +2,15 @@ import configparser
 import os
 from pathlib import Path
 
-INI_NAME = 'plot_settings.ini'
+INI_NAME = "plot_settings.ini"
 
 
 def _default_ini_path() -> Path:
-    if os.name == 'nt':
-        base = Path(os.environ.get('APPDATA', Path.home()))
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA", Path.home()))
     else:
-        base = Path(os.environ.get('XDG_CONFIG_HOME', Path.home() / '.config'))
-    return base / 'FPVS_Toolbox' / INI_NAME
+        base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return base / "FPVS_Toolbox" / INI_NAME
 
 
 class PlotSettingsManager:
@@ -24,17 +24,32 @@ class PlotSettingsManager:
             self.set("plot", "stem_color", "red")
         if not self.config.has_option("plot", "stem_color_b"):
             self.set("plot", "stem_color_b", "blue")
+        if not self.config.has_option("plot", "include_scalp_maps"):
+            self.set("plot", "include_scalp_maps", "false")
+        if not self.config.has_option("plot", "scalp_min"):
+            self.set("plot", "scalp_min", "-1.0")
+        if not self.config.has_option("plot", "scalp_max"):
+            self.set("plot", "scalp_max", "1.0")
 
     def load(self) -> None:
         self.config.read(self.ini_path)
 
     def save(self) -> None:
         self.ini_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.ini_path, 'w', encoding='utf-8') as f:
+        with open(self.ini_path, "w", encoding="utf-8") as f:
             self.config.write(f)
 
-    def get(self, section: str, option: str, fallback: str = '') -> str:
+    def get(self, section: str, option: str, fallback: str = "") -> str:
         return self.config.get(section, option, fallback=fallback)
+
+    def get_bool(self, section: str, option: str, fallback: bool = False) -> bool:
+        return self.config.getboolean(section, option, fallback=fallback)
+
+    def get_float(self, section: str, option: str, fallback: float = 0.0) -> float:
+        try:
+            return self.config.getfloat(section, option, fallback=fallback)
+        except ValueError:
+            return fallback
 
     def get_stem_color(self) -> str:
         """Return the stored stem plot line color."""
@@ -56,3 +71,20 @@ class PlotSettingsManager:
     def set_second_color(self, color: str) -> None:
         """Persist the second stem plot line color."""
         self.set("plot", "stem_color_b", color)
+
+    def get_scalp_bounds(self) -> tuple[float, float]:
+        """Return stored scalp vmin/vmax bounds."""
+
+        vmin = self.get_float("plot", "scalp_min", -1.0)
+        vmax = self.get_float("plot", "scalp_max", 1.0)
+        return vmin, vmax
+
+    def set_scalp_bounds(self, vmin: float, vmax: float) -> None:
+        self.set("plot", "scalp_min", str(vmin))
+        self.set("plot", "scalp_max", str(vmax))
+
+    def include_scalp_maps(self) -> bool:
+        return self.get_bool("plot", "include_scalp_maps", False)
+
+    def set_include_scalp_maps(self, enabled: bool) -> None:
+        self.set("plot", "include_scalp_maps", str(enabled))

--- a/src/Tools/Plot_Generator/scalp_utils.py
+++ b/src/Tools/Plot_Generator/scalp_utils.py
@@ -1,0 +1,131 @@
+"""Utilities for scalp map preparation."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Iterable, Sequence
+
+import mne
+import numpy as np
+import pandas as pd
+
+ODDBALL_THRESHOLD = 1.64
+
+
+@dataclass
+class ScalpInputs:
+    """Container for scalp map inputs."""
+
+    data: np.ndarray
+    info: mne.io.Info
+
+
+def _freq_columns(df: pd.DataFrame) -> dict[float, str]:
+    mapping: dict[float, str] = {}
+    for col in df.columns:
+        if isinstance(col, str) and col.endswith("_Hz"):
+            try:
+                freq_val = float(col.split("_")[0])
+            except ValueError:
+                continue
+            mapping[round(freq_val, 4)] = col
+    return mapping
+
+
+def _is_base_harmonic(freq: float, base_freq: float) -> bool:
+    if base_freq <= 0:
+        return False
+    ratio = freq / base_freq
+    nearest = round(ratio)
+    return math.isclose(ratio, nearest, rel_tol=1e-3, abs_tol=1e-3) and nearest > 0
+
+
+def select_oddball_harmonics(
+    configured: Iterable[float],
+    *,
+    base_freq: float,
+) -> list[float]:
+    """Return oddball harmonics excluding base-rate harmonics."""
+
+    oddballs: list[float] = []
+    for freq in configured:
+        if _is_base_harmonic(freq, base_freq):
+            continue
+        if not math.isfinite(freq):
+            continue
+        oddballs.append(freq)
+    return oddballs
+
+
+def _electrode_row(df: pd.DataFrame, electrode: str) -> pd.Series | None:
+    mask = df["Electrode"].astype(str).str.upper() == electrode
+    if not mask.any():
+        return None
+    return df.loc[mask].iloc[0]
+
+
+def summarize_subject_scalp(
+    df_bca: pd.DataFrame,
+    df_z: pd.DataFrame,
+    oddballs: Sequence[float],
+) -> dict[str, float]:
+    """Compute per-electrode oddball sums for a subject."""
+
+    freq_cols_bca = _freq_columns(df_bca)
+    freq_cols_z = _freq_columns(df_z)
+    values: dict[str, float] = {}
+    electrodes = df_bca["Electrode"].astype(str).str.upper()
+    for electrode in electrodes:
+        bca_row = _electrode_row(df_bca, electrode)
+        z_row = _electrode_row(df_z, electrode)
+        if bca_row is None or z_row is None:
+            continue
+        total = 0.0
+        for freq in oddballs:
+            key = round(freq, 4)
+            bca_col = freq_cols_bca.get(key)
+            z_col = freq_cols_z.get(key)
+            if not bca_col or not z_col:
+                continue
+            try:
+                z_val = float(z_row[z_col])
+                bca_val = float(bca_row[bca_col])
+            except Exception:
+                continue
+            if z_val >= ODDBALL_THRESHOLD:
+                total += bca_val
+        values[electrode] = total
+    return values
+
+
+def prepare_scalp_inputs(
+    subject_maps: Dict[str, Dict[str, float]],
+    roi_channels: Sequence[str],
+) -> ScalpInputs | None:
+    """Aggregate subject scalp maps and return data aligned to BioSemi64."""
+
+    if not subject_maps:
+        return None
+
+    montage = mne.channels.make_standard_montage("biosemi64")
+    info = mne.create_info(ch_names=montage.ch_names, sfreq=100, ch_types="eeg")
+    info.set_montage(montage)
+    name_to_idx = {name.upper(): idx for idx, name in enumerate(info.ch_names)}
+
+    data_matrix = np.full((len(subject_maps), len(info.ch_names)), np.nan)
+    for row_idx, electrode_map in enumerate(subject_maps.values()):
+        for name, value in electrode_map.items():
+            idx = name_to_idx.get(name.upper())
+            if idx is None:
+                continue
+            data_matrix[row_idx, idx] = value
+
+    mean_values = np.nanmean(data_matrix, axis=0)
+    if np.isnan(mean_values).all():
+        return None
+
+    mean_values = np.nan_to_num(mean_values, nan=0.0)
+    roi_set = {c.upper() for c in roi_channels}
+    mask = [name.upper() not in roi_set for name in info.ch_names]
+    mean_values[mask] = 0.0
+    return ScalpInputs(data=mean_values, info=info)

--- a/tests/test_plot_generator_gui.py
+++ b/tests/test_plot_generator_gui.py
@@ -1,0 +1,38 @@
+import pytest
+
+from Tools.Plot_Generator.gui import PlotGeneratorWindow
+from Tools.Plot_Generator.plot_settings import PlotSettingsManager
+
+
+@pytest.mark.parametrize("initial_checked", [False, True])
+def test_scalp_controls_toggle_and_persistence(qtbot, tmp_path, initial_checked):
+    ini_path = tmp_path / "plot.ini"
+    mgr = PlotSettingsManager(ini_path)
+    mgr.set_include_scalp_maps(initial_checked)
+    mgr.set_scalp_bounds(-1.0, 1.0)
+    mgr.save()
+
+    window = PlotGeneratorWindow(plot_mgr=mgr)
+    qtbot.addWidget(window)
+
+    assert window.scalp_check.isChecked() is initial_checked
+    assert window.scalp_min_spin.isEnabled() is initial_checked
+    assert window.scalp_max_spin.isEnabled() is initial_checked
+
+    window.scalp_check.setChecked(not initial_checked)
+    assert window.scalp_min_spin.isEnabled() is (not initial_checked)
+    assert window.scalp_max_spin.isEnabled() is (not initial_checked)
+    window.close()
+
+    mgr.set_include_scalp_maps(True)
+    mgr.set_scalp_bounds(-2.5, 2.5)
+    mgr.save()
+
+    restored_mgr = PlotSettingsManager(ini_path)
+    restored_window = PlotGeneratorWindow(plot_mgr=restored_mgr)
+    qtbot.addWidget(restored_window)
+
+    assert restored_window.scalp_check.isChecked() is True
+    assert restored_window.scalp_min_spin.value() == pytest.approx(-2.5)
+    assert restored_window.scalp_max_spin.value() == pytest.approx(2.5)
+    restored_window.close()


### PR DESCRIPTION
## Summary
- add persisted scalp map controls to the plot generator GUI and pass settings to the worker
- render optional ROI-masked scalp maps from BCA/Z data alongside SNR plots while moving legends inside axes
- introduce scalp utilities and a pytest-qt smoke test for the new controls

## Testing
- python -m pytest -q *(fails: missing PySide6, numpy, pandas dependencies in test environment)*
- ruff check . *(fails: pre-existing lint issues outside the plot generator scope)*
- mypy src --strict *(fails: existing syntax error in src/Compiler_Script.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940318c0920832caae3620401858a44)