### PR TITLE
Add whole-head scalp map templates and GUI controls

### DIFF
--- a/src/Tools/Plot_Generator/plot_settings.py
+++ b/src/Tools/Plot_Generator/plot_settings.py
@@ -30,6 +30,16 @@ class PlotSettingsManager:
             self.set("plot", "scalp_min", "-1.0")
         if not self.config.has_option("plot", "scalp_max"):
             self.set("plot", "scalp_max", "1.0")
+        if not self.config.has_option("scalp", "title_a_template"):
+            self.set("scalp", "title_a_template", "{condition} {roi} scalp map")
+        if not self.config.has_option("scalp", "title_b_template"):
+            self.set("scalp", "title_b_template", "{condition} {roi} scalp map")
+        if not self.config.has_option("scalp", "include_scalp_maps"):
+            self.set("scalp", "include_scalp_maps", self.get("plot", "include_scalp_maps", "false"))
+        if not self.config.has_option("scalp", "scalp_min"):
+            self.set("scalp", "scalp_min", self.get("plot", "scalp_min", "-1.0"))
+        if not self.config.has_option("scalp", "scalp_max"):
+            self.set("scalp", "scalp_max", self.get("plot", "scalp_max", "1.0"))
 
     def load(self) -> None:
         self.config.read(self.ini_path)
@@ -75,16 +85,33 @@ class PlotSettingsManager:
     def get_scalp_bounds(self) -> tuple[float, float]:
         """Return stored scalp vmin/vmax bounds."""
 
-        vmin = self.get_float("plot", "scalp_min", -1.0)
-        vmax = self.get_float("plot", "scalp_max", 1.0)
+        vmin = self.get_float("scalp", "scalp_min", self.get_float("plot", "scalp_min", -1.0))
+        vmax = self.get_float("scalp", "scalp_max", self.get_float("plot", "scalp_max", 1.0))
         return vmin, vmax
 
     def set_scalp_bounds(self, vmin: float, vmax: float) -> None:
         self.set("plot", "scalp_min", str(vmin))
         self.set("plot", "scalp_max", str(vmax))
+        self.set("scalp", "scalp_min", str(vmin))
+        self.set("scalp", "scalp_max", str(vmax))
 
     def include_scalp_maps(self) -> bool:
-        return self.get_bool("plot", "include_scalp_maps", False)
+        return self.get_bool(
+            "scalp", "include_scalp_maps", self.get_bool("plot", "include_scalp_maps", False)
+        )
 
     def set_include_scalp_maps(self, enabled: bool) -> None:
         self.set("plot", "include_scalp_maps", str(enabled))
+        self.set("scalp", "include_scalp_maps", str(enabled))
+
+    def get_scalp_title_a_template(self) -> str:
+        return self.get("scalp", "title_a_template", "{condition} {roi} scalp map")
+
+    def get_scalp_title_b_template(self) -> str:
+        return self.get("scalp", "title_b_template", "{condition} {roi} scalp map")
+
+    def set_scalp_title_a_template(self, template: str) -> None:
+        self.set("scalp", "title_a_template", template)
+
+    def set_scalp_title_b_template(self, template: str) -> None:
+        self.set("scalp", "title_b_template", template)

--- a/tests/test_plot_generator_gui.py
+++ b/tests/test_plot_generator_gui.py
@@ -10,6 +10,8 @@ def test_scalp_controls_toggle_and_persistence(qtbot, tmp_path, initial_checked)
     mgr = PlotSettingsManager(ini_path)
     mgr.set_include_scalp_maps(initial_checked)
     mgr.set_scalp_bounds(-1.0, 1.0)
+    mgr.set_scalp_title_a_template("{condition} {roi} scalp map")
+    mgr.set_scalp_title_b_template("B: {condition} {roi}")
     mgr.save()
 
     window = PlotGeneratorWindow(plot_mgr=mgr)
@@ -18,14 +20,25 @@ def test_scalp_controls_toggle_and_persistence(qtbot, tmp_path, initial_checked)
     assert window.scalp_check.isChecked() is initial_checked
     assert window.scalp_min_spin.isEnabled() is initial_checked
     assert window.scalp_max_spin.isEnabled() is initial_checked
+    assert window.scalp_title_a_edit.isEnabled() is initial_checked
+    assert window.scalp_title_b_edit.isVisible() is False
 
     window.scalp_check.setChecked(not initial_checked)
     assert window.scalp_min_spin.isEnabled() is (not initial_checked)
     assert window.scalp_max_spin.isEnabled() is (not initial_checked)
+    assert window.scalp_title_a_edit.isEnabled() is (not initial_checked)
+    window.overlay_check.setChecked(True)
+    assert window.scalp_title_b_edit.isVisible() is window.scalp_check.isChecked()
+    window.scalp_check.setChecked(True)
+    assert window.scalp_title_b_edit.isVisible() is True
+    window.scalp_check.setChecked(False)
+    assert window.scalp_title_b_edit.isVisible() is False
     window.close()
 
     mgr.set_include_scalp_maps(True)
     mgr.set_scalp_bounds(-2.5, 2.5)
+    mgr.set_scalp_title_a_template("Custom {roi}")
+    mgr.set_scalp_title_b_template("Second {condition}")
     mgr.save()
 
     restored_mgr = PlotSettingsManager(ini_path)
@@ -35,4 +48,17 @@ def test_scalp_controls_toggle_and_persistence(qtbot, tmp_path, initial_checked)
     assert restored_window.scalp_check.isChecked() is True
     assert restored_window.scalp_min_spin.value() == pytest.approx(-2.5)
     assert restored_window.scalp_max_spin.value() == pytest.approx(2.5)
+    assert restored_window.scalp_title_a_edit.text() == "Custom {roi}"
+    assert restored_window.scalp_title_b_edit.text() == "Second {condition}"
+
+    restored_window.scalp_title_a_edit.setText("Persist A")
+    restored_window.scalp_title_b_edit.setText("Persist B {condition}")
+    restored_window.scalp_min_spin.setValue(-4.2)
+    restored_window.scalp_max_spin.setValue(4.2)
+    restored_window._persist_scalp_settings(save=True)
+
+    reloaded_mgr = PlotSettingsManager(ini_path)
+    assert reloaded_mgr.get_scalp_title_a_template() == "Persist A"
+    assert reloaded_mgr.get_scalp_title_b_template() == "Persist B {condition}"
+    assert reloaded_mgr.get_scalp_bounds() == (-4.2, 4.2)
     restored_window.close()


### PR DESCRIPTION
## Summary
- switch scalp topomap generation to whole-head values and reuse per-condition inputs
- add GUI fields and persisted settings for scalp map title templates and scaling controls
- ensure scalp map options flow through overlay and batch generation paths

## Testing
- python -m compileall src *(fails: pre-existing syntax error in src/Compiler_Script.py)*
- pytest -q *(fails: missing optional test dependencies such as PySide6, numpy, pandas)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404281e400832cbd9a3e3217a11bbf)