### PR TITLE
Make plot generator log panel collapsible

### DIFF
--- a/tests/test_plot_generator_log_collapse.py
+++ b/tests/test_plot_generator_log_collapse.py
@@ -1,0 +1,25 @@
+import sys
+import pytest
+from PySide6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def test_log_panel_collapses_and_expands(app, qtbot):
+    from Tools.Plot_Generator.gui import PlotGeneratorWindow
+
+    w = PlotGeneratorWindow()
+    qtbot.addWidget(w)
+    w.show()
+    qtbot.waitExposed(w)
+
+    assert w.log_body.isVisible() is True
+
+    w.log_toggle_btn.setChecked(False)
+    qtbot.waitUntil(lambda: not w.log_body.isVisible(), timeout=1000)
+
+    w.log_toggle_btn.setChecked(True)
+    qtbot.waitUntil(lambda: w.log_body.isVisible(), timeout=1000)


### PR DESCRIPTION
## Summary
- add a collapsible header for the Plot Generator log output and hide/show the log body via a toggle button
- store splitter sizing to reclaim space when the log is collapsed and restore sizing on expand
- add a pytest-qt smoke test covering collapse/expand behavior

## Testing
- python -m compileall src *(fails: existing SyntaxError in src/Compiler_Script.py)*
- python -m pytest -q *(fails: missing optional dependencies such as PySide6, numpy, pandas)*
- ruff check . *(fails: pre-existing lint issues outside the touched files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941840147e0832cbc9eec1c25b3471b)