### PR TITLE
Preserve window sizing when toggling log panel

### DIFF
--- a/tests/test_plot_generator_log_collapse.py
+++ b/tests/test_plot_generator_log_collapse.py
@@ -16,10 +16,21 @@ def test_log_panel_collapses_and_expands(app, qtbot):
     w.show()
     qtbot.waitExposed(w)
 
+    top_container_height_before = w._main_splitter.widget(0).height()
+    window_height_before = w.height()
+
     assert w.log_body.isVisible() is True
 
     w.log_toggle_btn.setChecked(False)
     qtbot.waitUntil(lambda: not w.log_body.isVisible(), timeout=1000)
 
+    assert w.height() < window_height_before
+
+    top_container_height_after = w._main_splitter.widget(0).height()
+    tolerance = 4
+    assert top_container_height_after <= top_container_height_before + tolerance
+
     w.log_toggle_btn.setChecked(True)
     qtbot.waitUntil(lambda: w.log_body.isVisible(), timeout=1000)
+
+    assert w.height() >= window_height_before


### PR DESCRIPTION
## Summary
- store splitter sizes and window height when collapsing the log output panel
- collapse the log body without expanding the upper controls by resizing the splitter and window
- extend the log collapse smoke test to cover window and splitter height expectations

## Testing
- pytest tests/test_plot_generator_log_collapse.py *(fails: PySide6 not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694186517c2c832ca5241759acf39de7)