### PR TITLE
Refine plot generator layout and scalp title validation

### DIFF
--- a/tests/test_plot_generator_gui_refactor_smoke.py
+++ b/tests/test_plot_generator_gui_refactor_smoke.py
@@ -1,0 +1,57 @@
+import pytest
+
+from Tools.Plot_Generator.gui import PlotGeneratorWindow
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_scalp_title_clearing_disables_generate(qtbot, tmp_path):
+    excel_root = tmp_path / "excel"
+    excel_root.mkdir()
+    (excel_root / "CondA").mkdir()
+    (excel_root / "CondB").mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    win = PlotGeneratorWindow()
+    qtbot.addWidget(win)
+    win.folder_edit.setText(str(excel_root))
+    win._populate_conditions(str(excel_root))
+    win.out_edit.setText(str(out_dir))
+
+    win.condition_combo.setCurrentText("CondA")
+    win.overlay_check.setChecked(True)
+    win.condition_b_combo.setCurrentText("CondB")
+    win.scalp_check.setChecked(True)
+    win.scalp_title_a_edit.setText("Title A")
+    win.scalp_title_b_edit.setText("Title B")
+    win._check_required()
+    assert win.gen_btn.isEnabled()
+
+    win.condition_combo.setCurrentText("CondB")
+    qtbot.wait(50)
+    assert win.scalp_title_a_edit.text() == ""
+    assert not win.gen_btn.isEnabled()
+
+    win.scalp_title_a_edit.setText("Again")
+    qtbot.wait(50)
+    assert win.gen_btn.isEnabled()
+
+    win.condition_b_combo.setCurrentText("CondA")
+    qtbot.wait(50)
+    assert win.scalp_title_b_edit.text() == ""
+    assert not win.gen_btn.isEnabled()
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_log_collapse_keeps_top_height(qtbot):
+    win = PlotGeneratorWindow()
+    qtbot.addWidget(win)
+    win.show()
+    qtbot.waitForWindowShown(win)
+
+    top_height_before = win._top_controls.height()
+    win.log_toggle_btn.setChecked(False)
+    qtbot.wait(100)
+    top_height_after = win._top_controls.height()
+
+    assert top_height_after <= top_height_before + 10


### PR DESCRIPTION
## Summary
- Re-layout the plot generator controls with a compact grid, collapsible Advanced section, and full-width actions footer while keeping log behavior.
- Move scalp range inputs into the Axis Ranges group and cap right-side widths for a tighter UI.
- Add scalp title auto-clearing/validation and new pytest-qt smoke coverage for the updated interactions.

## Testing
- python -m pytest -q *(fails: missing optional dependencies such as PySide6/numpy/pandas in test environment)*
- ruff check . *(fails: pre-existing lint issues outside the touched files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418d7e7228832c861d7ebc9679652e)