### PR TITLE
Add Ratio Calculator tool

### DIFF
--- a/src/Main_App/PySide6_App/GUI/menu_bar.py
+++ b/src/Main_App/PySide6_App/GUI/menu_bar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from PySide6.QtWidgets import QMenuBar, QMainWindow
 from PySide6.QtGui import QAction
 from Main_App.Legacy_App.eloreta_launcher import open_eloreta_tool
+from Main_App.PySide6_App.GUI.ratio_calculator_launcher import open_ratio_calculator
 from Tools.Average_Preprocessing.New_PySide6.main_window import AdvancedAveragingWindow  # noqa: F401
 
 def build_menu_bar(parent: QMainWindow) -> QMenuBar:
@@ -32,6 +33,7 @@ def build_menu_bar(parent: QMainWindow) -> QMenuBar:
         ("Image Resizer",                              parent.open_image_resizer),
         ("Generate SNR Plots",                         parent.open_plot_generator),
         ("Average Epochs in Pre-Processing Phase",     parent.open_epoch_averaging),
+        ("Ratio Calculator",                           lambda: open_ratio_calculator(parent)),
     ]
     for text, slot in items:
         action = QAction(text, parent)

--- a/src/Main_App/PySide6_App/GUI/ratio_calculator_launcher.py
+++ b/src/Main_App/PySide6_App/GUI/ratio_calculator_launcher.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from Tools.Ratio_Calculator.PySide6 import create_ratio_calculator_window
+
+
+def open_ratio_calculator(parent: Any) -> None:
+    existing = getattr(parent, "_ratio_calc_win", None)
+    project_root = getattr(getattr(parent, "currentProject", None), "project_root", None)
+    if existing:
+        existing.show()
+        existing.raise_()
+        existing.activateWindow()
+        return
+
+    window = create_ratio_calculator_window(parent=parent, project_root=project_root)
+    parent._ratio_calc_win = window
+    window.show()
+    window.raise_()
+    window.activateWindow()

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -17,6 +17,8 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
 )
 
+from Main_App.PySide6_App.GUI.ratio_calculator_launcher import open_ratio_calculator
+
 # ---- Tunables -------------------------------------------------------------
 ICON_PX = 20          # normalize all icons to the same visual size
 ROW_MIN_HEIGHT = 40   # total button height (card)
@@ -205,6 +207,13 @@ def init_sidebar(self) -> None:
 
     make_button(lay, "btn_image", "Image Resizer", "camera-photo", self.open_image_resizer)
     make_button(lay, "btn_epoch", "Epoch Averaging", "view-refresh", self.open_epoch_averaging)
+    make_button(
+        lay,
+        "btn_ratio",
+        "Ratio Calculator",
+        chart_icon(),
+        lambda: open_ratio_calculator(self),
+    )
 
     # Divider
     divider = QFrame()

--- a/src/Tools/Ratio_Calculator/PySide6/README.md
+++ b/src/Tools/Ratio_Calculator/PySide6/README.md
@@ -1,0 +1,31 @@
+# Ratio Calculator (PySide6)
+
+The Ratio Calculator computes ROI-level SNR ratios between two conditions from already-exported per-condition Excel workbooks.
+
+## Inputs
+- **Excel root folder:** One subfolder per condition containing participant `.xlsx` files.
+- **Conditions:** Discovered via `scan_folder_simple` using `EXCEL_PID_REGEX` for participant IDs.
+- **ROIs:** Loaded from `resolve_active_rois()`; channel membership follows Stats ROI settings.
+- **Sheets used:** `SNR` and `Z Score` with an `Electrode` column plus frequency columns named `{freq:.4f}_Hz`.
+
+## Computation
+1. **Significant harmonics (group level, per ROI):**
+   - For each participant with both conditions, compute ROI-mean Z-scores per harmonic by averaging rows where `Electrode` matches the ROI channels (case-insensitive).
+   - Take the group mean across participants for each harmonic.
+   - Harmonics with mean Z > 1.64 (default threshold) are considered significant.
+2. **Summary SNR (per participant & ROI):** Mean SNR across the significant harmonics for each condition.
+3. **Ratio:** `summary_SNR_A / summary_SNR_B`.
+
+## Output
+- Single-sheet Excel export formatted via `_auto_format_and_write_excel(...)` with rows labeled `{ConditionA} to {ConditionB} - {ROI}`.
+- Participant columns contain per-ROI ratios; summary columns include N, Mean, Median, Std, Variance, CV%, Min, and Max (CV% = (Std / Mean) * 100 when Mean ≠ 0).
+
+## Skip rules and warnings
+- Missing condition files for a participant.
+- Missing `SNR` or `Z Score` sheets.
+- ROI without matching channels in a file.
+- No significant harmonics for an ROI (ratios left blank/NaN).
+- Denominator summary SNR equals zero.
+
+## Future work
+- Individual-level harmonic significance selection is a planned enhancement.

--- a/src/Tools/Ratio_Calculator/PySide6/__init__.py
+++ b/src/Tools/Ratio_Calculator/PySide6/__init__.py
@@ -1,0 +1,26 @@
+"""PySide6 implementation of the Ratio Calculator tool."""
+
+from pathlib import Path
+
+from .controller import RatioCalculatorController
+from .view import RatioCalculatorWindow
+
+__all__ = [
+    "RatioCalculatorWindow",
+    "RatioCalculatorController",
+    "create_ratio_calculator_window",
+]
+
+
+def create_ratio_calculator_window(
+    parent=None, project_root: Path | None = None
+) -> RatioCalculatorWindow:
+    view = RatioCalculatorWindow(parent=parent, project_root=project_root)
+    controller = RatioCalculatorController(view)
+    view.compute_requested.connect(controller.compute_ratios)
+    view.excel_root_changed.connect(controller.set_excel_root)
+    view.controller = controller  # type: ignore[attr-defined]
+    initial_root = Path(view.excel_path_edit.text())
+    if initial_root.exists():
+        controller.set_excel_root(initial_root)
+    return view

--- a/src/Tools/Ratio_Calculator/PySide6/controller.py
+++ b/src/Tools/Ratio_Calculator/PySide6/controller.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from PySide6.QtCore import QObject, QThread
+
+from Main_App.PySide6_App.utils.op_guard import OpGuard
+from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs, RatioCalcResult
+from Tools.Ratio_Calculator.PySide6.worker import RatioCalcWorker, compute_ratios
+from Tools.Stats.PySide6.stats_data_loader import ScanError, scan_folder_simple
+from Tools.Stats.roi_resolver import resolve_active_rois
+
+logger = logging.getLogger(__name__)
+
+
+class RatioCalculatorController(QObject):
+    def __init__(self, view: QObject) -> None:
+        super().__init__(view)
+        self.view = view
+        self._guard = OpGuard()
+        self._thread: QThread | None = None
+        self._worker: RatioCalcWorker | None = None
+
+    def set_excel_root(self, path: Path) -> None:
+        try:
+            subjects, conditions, _ = scan_folder_simple(str(path))
+        except ScanError as exc:
+            msg = f"Failed to scan Excel root: {exc}"
+            logger.error(msg)
+            if hasattr(self.view, "append_log"):
+                self.view.append_log(msg)
+            return
+
+        conds = [c for c in conditions if c.lower() != "all conditions"]
+        if hasattr(self.view, "set_conditions"):
+            self.view.set_conditions(conds)
+        try:
+            rois = resolve_active_rois()
+            roi_names = ["All ROIs", *[r.name for r in rois]]
+            if hasattr(self.view, "set_rois"):
+                self.view.set_rois(roi_names)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to load ROIs: %s", exc)
+            if hasattr(self.view, "append_log"):
+                self.view.append_log(f"Failed to load ROIs: {exc}")
+        if hasattr(self.view, "append_log"):
+            self.view.append_log(
+                f"Detected {len(subjects)} participant(s) and {len(conds)} condition(s)."
+            )
+
+    def compute_ratios(self, inputs: RatioCalcInputs) -> None:
+        if not self._guard.start():
+            if hasattr(self.view, "append_log"):
+                self.view.append_log("Computation already in progress.")
+            return
+        start = time.perf_counter()
+        if hasattr(self.view, "set_busy"):
+            self.view.set_busy(True)
+        if hasattr(self.view, "set_progress"):
+            self.view.set_progress(0)
+
+        worker = RatioCalcWorker(inputs)
+        thread = QThread()
+        worker.moveToThread(thread)
+        worker.progress.connect(getattr(self.view, "set_progress"))
+        worker.error.connect(getattr(self.view, "append_log"))
+        worker.finished.connect(self._on_finished)
+        thread.started.connect(worker.run)
+        worker.finished.connect(thread.quit)
+        worker.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(lambda: self._on_thread_done(start))
+
+        self._thread = thread
+        self._worker = worker
+        thread.start()
+
+    def compute_ratios_sync(self, inputs: RatioCalcInputs) -> RatioCalcResult:
+        return compute_ratios(inputs)
+
+    def _on_thread_done(self, started_at: float) -> None:
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        if hasattr(self.view, "append_log"):
+            self.view.append_log(f"Finished in {elapsed_ms:.1f} ms")
+        if hasattr(self.view, "set_busy"):
+            self.view.set_busy(False)
+        self._guard.end()
+
+    def _on_finished(self, result: RatioCalcResult) -> None:
+        for warning in result.warnings:
+            if hasattr(self.view, "status_message"):
+                self.view.status_message(warning)
+        if hasattr(self.view, "handle_result"):
+            self.view.handle_result(result)

--- a/src/Tools/Ratio_Calculator/PySide6/model.py
+++ b/src/Tools/Ratio_Calculator/PySide6/model.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class RatioCalcInputs:
+    excel_root: Path
+    cond_a: str
+    cond_b: str
+    roi_name: Optional[str]
+    z_threshold: float
+    output_path: Path
+
+
+@dataclass
+class RatioCalcResult:
+    dataframe: pd.DataFrame
+    significant_freqs_by_roi: dict[str, list[float]]
+    warnings: list[str]
+    output_path: Path

--- a/src/Tools/Ratio_Calculator/PySide6/view.py
+++ b/src/Tools/Ratio_Calculator/PySide6/view.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QCloseEvent
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QPushButton,
+    QProgressBar,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs, RatioCalcResult
+
+
+class RatioCalculatorWindow(QMainWindow):
+    compute_requested = Signal(RatioCalcInputs)
+    excel_root_changed = Signal(Path)
+
+    def __init__(self, parent: QWidget | None = None, project_root: Path | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Ratio Calculator")
+        self._project_root = project_root or Path(os.environ.get("FPVS_PROJECT_ROOT", Path.cwd()))
+        self._busy = False
+        self._last_df: pd.DataFrame | None = None
+
+        central = QWidget(self)
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        layout.addWidget(self._build_input_group())
+        layout.addWidget(self._build_params_group())
+        layout.addWidget(self._build_advanced_group())
+        layout.addWidget(self._build_output_group())
+
+        self.progress = QProgressBar(self)
+        self.progress.setRange(0, 100)
+        self.progress.setValue(0)
+        layout.addWidget(self.progress)
+
+        layout.addWidget(self._build_log_group())
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch(1)
+        self.compute_btn = QPushButton("Compute", self)
+        self.compute_btn.clicked.connect(self._on_compute)
+        btn_row.addWidget(self.compute_btn)
+        layout.addLayout(btn_row)
+
+        self.statusBar().showMessage("Ready")
+
+    def _build_input_group(self) -> QGroupBox:
+        group = QGroupBox("Excel Root", self)
+        form = QFormLayout(group)
+        form.setLabelAlignment(Qt.AlignLeft)
+
+        self.excel_path_edit = QLineEdit(str(self._project_root))
+        self.excel_path_edit.setReadOnly(True)
+        self.excel_browse_btn = QPushButton("Browse…", group)
+        self.excel_browse_btn.clicked.connect(self._select_excel_root)
+
+        row = QHBoxLayout()
+        row.addWidget(self.excel_path_edit)
+        row.addWidget(self.excel_browse_btn)
+        form.addRow(QLabel("Excel folder:"), row)
+        return group
+
+    def _build_params_group(self) -> QGroupBox:
+        group = QGroupBox("Parameters", self)
+        form = QFormLayout(group)
+        form.setLabelAlignment(Qt.AlignLeft)
+
+        self.cond_a_combo = QComboBox(group)
+        self.cond_b_combo = QComboBox(group)
+        form.addRow(QLabel("Condition A (numerator):"), self.cond_a_combo)
+        form.addRow(QLabel("Condition B (denominator):"), self.cond_b_combo)
+
+        self.roi_combo = QComboBox(group)
+        form.addRow(QLabel("ROI:"), self.roi_combo)
+
+        return group
+
+    def _build_advanced_group(self) -> QGroupBox:
+        group = QGroupBox("Advanced", self)
+        form = QFormLayout(group)
+        form.setLabelAlignment(Qt.AlignLeft)
+
+        self.threshold_spin = QDoubleSpinBox(group)
+        self.threshold_spin.setDecimals(2)
+        self.threshold_spin.setRange(0.0, 10.0)
+        self.threshold_spin.setSingleStep(0.01)
+        self.threshold_spin.setValue(1.64)
+        self.threshold_spin.setEnabled(False)
+        form.addRow(QLabel("Z-score threshold:"), self.threshold_spin)
+        return group
+
+    def _build_output_group(self) -> QGroupBox:
+        group = QGroupBox("Output", self)
+        form = QFormLayout(group)
+        form.setLabelAlignment(Qt.AlignLeft)
+
+        self.output_edit = QLineEdit(str(self._default_output_path()))
+        self.output_edit.setReadOnly(True)
+        self.output_browse_btn = QPushButton("Browse…", group)
+        self.output_browse_btn.clicked.connect(self._select_output_file)
+
+        row = QHBoxLayout()
+        row.addWidget(self.output_edit)
+        row.addWidget(self.output_browse_btn)
+        form.addRow(QLabel("Output Excel:"), row)
+        return group
+
+    def _build_log_group(self) -> QGroupBox:
+        group = QGroupBox("Logs", self)
+        group.setCheckable(True)
+        group.setChecked(True)
+        layout = QVBoxLayout(group)
+        self.log_view = QTextEdit(group)
+        self.log_view.setReadOnly(True)
+        layout.addWidget(self.log_view)
+
+        def _toggle(checked: bool) -> None:
+            self.log_view.setVisible(checked)
+
+        group.toggled.connect(_toggle)
+        return group
+
+    def _default_output_path(self) -> Path:
+        return self._project_root / "ratio_results.xlsx"
+
+    # View API for controller -------------------------------------------------
+    def set_conditions(self, conditions: Iterable[str]) -> None:
+        self.cond_a_combo.blockSignals(True)
+        self.cond_b_combo.blockSignals(True)
+        self.cond_a_combo.clear()
+        self.cond_b_combo.clear()
+        for cond in conditions:
+            self.cond_a_combo.addItem(cond)
+            self.cond_b_combo.addItem(cond)
+        self.cond_a_combo.blockSignals(False)
+        self.cond_b_combo.blockSignals(False)
+
+    def set_rois(self, rois: Iterable[str]) -> None:
+        self.roi_combo.blockSignals(True)
+        self.roi_combo.clear()
+        for roi in rois:
+            self.roi_combo.addItem(roi)
+        self.roi_combo.blockSignals(False)
+
+    def append_log(self, message: str) -> None:
+        self.log_view.append(message)
+        self.statusBar().showMessage(message, 5000)
+
+    def set_busy(self, busy: bool) -> None:
+        self._busy = busy
+        for widget in (
+            self.excel_path_edit,
+            self.excel_browse_btn,
+            self.cond_a_combo,
+            self.cond_b_combo,
+            self.roi_combo,
+            self.output_edit,
+            self.output_browse_btn,
+            self.compute_btn,
+        ):
+            widget.setEnabled(not busy)
+        self.progress.setVisible(busy or self.progress.value() > 0)
+
+    def set_progress(self, value: int) -> None:
+        self.progress.setValue(value)
+
+    def status_message(self, message: str) -> None:
+        self.statusBar().showMessage(message, 5000)
+        self.append_log(message)
+
+    def handle_result(self, result: RatioCalcResult) -> None:
+        self._last_df = result.dataframe
+        self.append_log(f"Saved results to {result.output_path}")
+        self.statusBar().showMessage("Completed", 3000)
+
+    # UI events --------------------------------------------------------------
+    def _select_excel_root(self) -> None:
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select Excel root",
+            str(self._project_root),
+            options=QFileDialog.ShowDirsOnly,
+        )
+        if not directory:
+            return
+        self.excel_path_edit.setText(directory)
+        self.output_edit.setText(str(Path(directory) / "ratio_results.xlsx"))
+        self.excel_root_changed.emit(Path(directory))
+
+    def _select_output_file(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save output Excel",
+            str(self._default_output_path()),
+            "Excel Files (*.xlsx)",
+        )
+        if not path:
+            return
+        self.output_edit.setText(path)
+
+    def _on_compute(self) -> None:
+        if self._busy:
+            self.append_log("A computation is already running.")
+            return
+        excel_root = Path(self.excel_path_edit.text())
+        if not excel_root.exists():
+            self.append_log("Please select a valid Excel root folder.")
+            return
+        cond_a = self.cond_a_combo.currentText()
+        cond_b = self.cond_b_combo.currentText()
+        if not cond_a or not cond_b or cond_a == cond_b:
+            self.append_log("Please select two different conditions.")
+            return
+        roi_name = self.roi_combo.currentText() or None
+        threshold = float(self.threshold_spin.value())
+        output_path = Path(self.output_edit.text())
+        inputs = RatioCalcInputs(
+            excel_root=excel_root,
+            cond_a=cond_a,
+            cond_b=cond_b,
+            roi_name=roi_name,
+            z_threshold=threshold,
+            output_path=output_path,
+        )
+        self.compute_requested.emit(inputs)
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802
+        if self._busy:
+            event.ignore()
+            self.append_log("Cannot close while computation is running.")
+            return
+        super().closeEvent(event)

--- a/src/Tools/Ratio_Calculator/PySide6/worker.py
+++ b/src/Tools/Ratio_Calculator/PySide6/worker.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+import numpy as np
+import pandas as pd
+from PySide6.QtCore import QObject, Signal
+
+from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs, RatioCalcResult
+from Tools.Stats.PySide6.stats_data_loader import ScanError, scan_folder_simple
+from Tools.Stats.Legacy.stats_export import _auto_format_and_write_excel
+from Tools.Stats.roi_resolver import ROI, resolve_active_rois
+
+logger = logging.getLogger(__name__)
+
+
+ProgressCallback = Callable[[int], None]
+LogCallback = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class _ParticipantFiles:
+    pid: str
+    cond_a_file: Path
+    cond_b_file: Path
+
+
+class RatioCalcWorker(QObject):
+    progress = Signal(int)
+    error = Signal(str)
+    finished = Signal(RatioCalcResult)
+
+    def __init__(self, inputs: RatioCalcInputs, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self.inputs = inputs
+
+    def run(self) -> None:
+        try:
+            result = compute_ratios(self.inputs, self.progress.emit, self.error.emit)
+        except Exception as exc:  # noqa: BLE001
+            msg = f"Ratio calculation failed: {exc}"
+            logger.exception(msg)
+            self.error.emit(msg)
+            result = RatioCalcResult(pd.DataFrame(), {}, [msg], self.inputs.output_path)
+        self.finished.emit(result)
+
+
+def compute_ratios(
+    inputs: RatioCalcInputs,
+    progress_cb: ProgressCallback | None = None,
+    error_cb: LogCallback | None = None,
+) -> RatioCalcResult:
+    warnings: list[str] = []
+
+    def log_warning(message: str) -> None:
+        warnings.append(message)
+        if error_cb:
+            error_cb(message)
+
+    def log_info(message: str) -> None:
+        if error_cb:
+            error_cb(message)
+
+    excel_root = inputs.excel_root
+    _emit(progress_cb, 2)
+    try:
+        participants, conditions, subject_data = scan_folder_simple(str(excel_root))
+    except ScanError as exc:
+        raise RuntimeError(f"Folder scan failed: {exc}") from exc
+    _emit(progress_cb, 8)
+
+    if inputs.cond_a not in conditions:
+        log_warning(f"Condition {inputs.cond_a} not found in {excel_root}.")
+    if inputs.cond_b not in conditions:
+        log_warning(f"Condition {inputs.cond_b} not found in {excel_root}.")
+
+    participants_map = _build_participant_files(participants, subject_data, inputs)
+    if not participants_map:
+        log_warning("No participants with both conditions available.")
+        empty_df = _build_output_frame({}, [], inputs.cond_a, inputs.cond_b)
+        return RatioCalcResult(empty_df, {}, warnings, inputs.output_path)
+
+    _emit(progress_cb, 12)
+    rois = resolve_active_rois()
+    if inputs.roi_name and inputs.roi_name.lower() != "all rois":
+        rois = [roi for roi in rois if roi.name == inputs.roi_name]
+    selected_roi_names = [r.name for r in rois]
+    if not rois:
+        log_warning("No ROI definitions available after filtering.")
+        empty_df = _build_output_frame({}, selected_roi_names, inputs.cond_a, inputs.cond_b)
+        return RatioCalcResult(empty_df, {}, warnings, inputs.output_path)
+
+    z_scores = _load_roi_z_scores(participants_map.values(), rois, log_warning)
+    _emit(progress_cb, 40)
+    sig_freqs = _determine_significant_frequencies(z_scores, inputs.z_threshold)
+    if not any(sig_freqs.values()):
+        log_warning("No significant harmonics identified for any ROI.")
+    _emit(progress_cb, 50)
+
+    ratios = _compute_ratio_table(participants_map.values(), rois, sig_freqs, inputs, log_warning)
+    _emit(progress_cb, 85)
+
+    df = _build_output_frame(ratios, selected_roi_names, inputs.cond_a, inputs.cond_b)
+    _emit(progress_cb, 90)
+    _write_excel(df, inputs.output_path, log_info)
+    _emit(progress_cb, 100)
+
+    return RatioCalcResult(df, sig_freqs, warnings, inputs.output_path)
+
+
+def _emit(progress_cb: ProgressCallback | None, value: int) -> None:
+    if progress_cb:
+        progress_cb(int(value))
+
+
+def _build_participant_files(
+    participants: Iterable[str],
+    subject_data: dict[str, dict[str, str]],
+    inputs: RatioCalcInputs,
+) -> dict[str, _ParticipantFiles]:
+    participants_map: dict[str, _ParticipantFiles] = {}
+    for pid in participants:
+        conds = subject_data.get(pid, {})
+        cond_a_file = conds.get(inputs.cond_a)
+        cond_b_file = conds.get(inputs.cond_b)
+        if not cond_a_file or not cond_b_file:
+            continue
+        participants_map[pid] = _ParticipantFiles(
+            pid=pid, cond_a_file=Path(cond_a_file), cond_b_file=Path(cond_b_file)
+        )
+    return participants_map
+
+
+def _load_roi_z_scores(
+    participants: Iterable[_ParticipantFiles],
+    rois: list[ROI],
+    log_warning: LogCallback,
+) -> dict[str, dict[str, pd.Series]]:
+    data: dict[str, dict[str, pd.Series]] = {roi.name: {} for roi in rois}
+    for part in participants:
+        try:
+            df = pd.read_excel(part.cond_a_file, sheet_name="Z Score")
+        except FileNotFoundError:
+            log_warning(f"Missing file for participant {part.pid}: {part.cond_a_file}")
+            continue
+        except Exception as exc:  # noqa: BLE001
+            log_warning(f"Failed to read Z Score sheet for {part.pid}: {exc}")
+            continue
+
+        if "Electrode" not in df.columns:
+            log_warning(f"Electrode column missing in Z Score for {part.pid}.")
+            continue
+
+        freq_cols = [c for c in df.columns if c != "Electrode"]
+        df["Electrode"] = df["Electrode"].astype(str).str.upper()
+        for roi in rois:
+            mask = df["Electrode"].isin([c.upper() for c in roi.channels])
+            if not mask.any():
+                log_warning(f"No matching channels for ROI {roi.name} in Z Score for {part.pid}.")
+                continue
+            mean_series = df.loc[mask, freq_cols].mean(axis=0, skipna=True)
+            data[roi.name][part.pid] = mean_series
+    return data
+
+
+def _determine_significant_frequencies(
+    z_scores: dict[str, dict[str, pd.Series]], threshold: float
+) -> dict[str, list[float]]:
+    sig_freqs: dict[str, list[float]] = {}
+    for roi_name, per_part in z_scores.items():
+        if not per_part:
+            sig_freqs[roi_name] = []
+            continue
+        df_roi = pd.DataFrame(per_part).T
+        means = df_roi.mean(axis=0, skipna=True)
+        selected: list[float] = []
+        for col, value in means.items():
+            try:
+                freq_val = float(str(col).split("_")[0])
+            except (TypeError, ValueError):
+                continue
+            if value > threshold:
+                selected.append(freq_val)
+        sig_freqs[roi_name] = selected
+    return sig_freqs
+
+
+def _compute_ratio_table(
+    participants: Iterable[_ParticipantFiles],
+    rois: list[ROI],
+    sig_freqs: dict[str, list[float]],
+    inputs: RatioCalcInputs,
+    log_warning: LogCallback,
+) -> dict[str, dict[str, float]]:
+    ratios: dict[str, dict[str, float]] = {roi.name: {} for roi in rois}
+    for part in participants:
+        snr_a = _load_snr(part.cond_a_file, rois, log_warning, part.pid)
+        snr_b = _load_snr(part.cond_b_file, rois, log_warning, part.pid)
+
+        for roi in rois:
+            freqs = sig_freqs.get(roi.name, [])
+            if not freqs:
+                log_warning(f"No significant harmonics for ROI {roi.name}; skipping ratios.")
+                ratios.setdefault(roi.name, {})[part.pid] = np.nan
+                continue
+
+            summary_a = _summary_for_roi(snr_a.get(roi.name), freqs)
+            summary_b = _summary_for_roi(snr_b.get(roi.name), freqs)
+
+            if summary_a is None or summary_b is None:
+                log_warning(
+                    f"Missing ROI data for participant {part.pid} in ROI {roi.name}; setting ratio to NaN."
+                )
+                ratios.setdefault(roi.name, {})[part.pid] = np.nan
+                continue
+
+            if summary_b == 0:
+                log_warning(
+                    f"Denominator SNR is zero for participant {part.pid} ROI {roi.name}; ratio undefined."
+                )
+                ratios.setdefault(roi.name, {})[part.pid] = np.nan
+                continue
+            ratios.setdefault(roi.name, {})[part.pid] = summary_a / summary_b
+    return ratios
+
+
+def _load_snr(
+    file_path: Path, rois: list[ROI], log_warning: LogCallback, pid: str
+) -> dict[str, pd.Series]:
+    try:
+        df = pd.read_excel(file_path, sheet_name="SNR")
+    except FileNotFoundError:
+        log_warning(f"Missing file for participant {pid}: {file_path}")
+        return {}
+    except Exception as exc:  # noqa: BLE001
+        log_warning(f"Failed to read SNR sheet for {pid}: {exc}")
+        return {}
+
+    if "Electrode" not in df.columns:
+        log_warning(f"Electrode column missing in SNR for {pid}.")
+        return {}
+
+    freq_cols = [c for c in df.columns if c != "Electrode"]
+    df["Electrode"] = df["Electrode"].astype(str).str.upper()
+    snr_data: dict[str, pd.Series] = {}
+    for roi in rois:
+        mask = df["Electrode"].isin([c.upper() for c in roi.channels])
+        if not mask.any():
+            log_warning(f"No matching channels for ROI {roi.name} in SNR for {pid}.")
+            continue
+        snr_data[roi.name] = df.loc[mask, freq_cols].mean(axis=0, skipna=True)
+    return snr_data
+
+
+def _summary_for_roi(series: pd.Series | None, freqs: list[float]) -> float | None:
+    if series is None:
+        return None
+    values = []
+    for freq in freqs:
+        col = f"{freq:.4f}_Hz"
+        if col not in series.index:
+            continue
+        values.append(series[col])
+    if not values:
+        return None
+    return float(np.nanmean(values))
+
+
+def _build_output_frame(
+    ratios: dict[str, dict[str, float]],
+    roi_filter: list[str],
+    cond_a: str,
+    cond_b: str,
+) -> pd.DataFrame:
+    rows: list[dict[str, float | str | int]] = []
+    all_pids = sorted({pid for roi_data in ratios.values() for pid in roi_data.keys()})
+    roi_names = roi_filter if roi_filter else list(ratios.keys())
+    for roi in roi_names:
+        row: dict[str, float | str | int] = {}
+        label = f"{cond_a} to {cond_b} - {roi}"
+        row["Ratio per ROI"] = label
+        ratios_for_roi = ratios.get(roi, {})
+        series = pd.Series(ratios_for_roi)
+        for pid in all_pids:
+            row[pid] = ratios_for_roi.get(pid, np.nan)
+        n = int(series.count()) if not series.empty else 0
+        row["N"] = n
+        mean = float(series.mean()) if n else np.nan
+        median = float(series.median()) if n else np.nan
+        std = float(series.std()) if n else np.nan
+        variance = float(series.var()) if n else np.nan
+        row["Mean"] = mean
+        row["Median"] = median
+        row["Std"] = std
+        row["Variance"] = variance
+        if mean is not None and not np.isnan(mean) and mean != 0:
+            cv = float((std / mean) * 100) if std is not None else np.nan
+        else:
+            cv = np.nan
+        row["CV%"] = cv if np.isfinite(cv) else np.nan
+        row["Min"] = float(series.min()) if n else np.nan
+        row["Max"] = float(series.max()) if n else np.nan
+        rows.append(row)
+    columns = ["Ratio per ROI", *all_pids, "N", "Mean", "Median", "Std", "Variance", "CV%", "Min", "Max"]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def _write_excel(df: pd.DataFrame, output_path: Path, log_func: LogCallback) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with pd.ExcelWriter(output_path, engine="xlsxwriter") as writer:
+            _auto_format_and_write_excel(writer, df, "Ratio Calculator", log_func)
+    except Exception as exc:  # noqa: BLE001
+        log_func(f"Failed to write Excel file: {exc}")

--- a/src/Tools/Ratio_Calculator/__init__.py
+++ b/src/Tools/Ratio_Calculator/__init__.py
@@ -1,0 +1,1 @@
+"""Ratio Calculator tool package."""

--- a/src/Tools/Ratio_Calculator/ratio_calculator.py
+++ b/src/Tools/Ratio_Calculator/ratio_calculator.py
@@ -1,0 +1,28 @@
+"""Entry point for the Ratio Calculator PySide6 tool."""
+from __future__ import annotations
+
+# Allow running as a script
+if __package__ is None:  # pragma: no cover
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+
+from Main_App.PySide6_App.utils.theme import apply_light_palette
+from Tools.Ratio_Calculator.PySide6 import create_ratio_calculator_window
+
+
+def main() -> None:
+    app = QApplication([])
+    apply_light_palette(app)
+    win = create_ratio_calculator_window(project_root=Path.cwd())
+    win.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ratio_calculator_smoke.py
+++ b/tests/test_ratio_calculator_smoke.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Ratio_Calculator.PySide6.controller import RatioCalculatorController
+from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs
+from Tools.Ratio_Calculator.PySide6.view import RatioCalculatorWindow
+
+
+def _write_participant_file(path: Path, snr_values: list[list[float]], z_values: list[list[float]]) -> None:
+    electrodes = ["O1", "O2", "Oz"]
+    freqs = ["1.2000_Hz", "2.4000_Hz"]
+    snr_df = pd.DataFrame({"Electrode": electrodes})
+    z_df = pd.DataFrame({"Electrode": electrodes})
+    for idx, freq in enumerate(freqs):
+        snr_df[freq] = [row[idx] for row in snr_values]
+        z_df[freq] = [row[idx] for row in z_values]
+    with pd.ExcelWriter(path) as writer:
+        snr_df.to_excel(writer, sheet_name="SNR", index=False)
+        z_df.to_excel(writer, sheet_name="Z Score", index=False)
+
+
+def test_ratio_calculator_smoke(tmp_path, qtbot):
+    excel_root = tmp_path / "excel"
+    cond_a_dir = excel_root / "ConditionA"
+    cond_b_dir = excel_root / "ConditionB"
+    cond_a_dir.mkdir(parents=True)
+    cond_b_dir.mkdir(parents=True)
+
+    participants = {"P01": ([10.0, 8.0], [2.0, 0.5]), "P02": ([12.0, 9.0], [2.5, 0.7])}
+    for pid, (snr_vals, z_vals) in participants.items():
+        _write_participant_file(cond_a_dir / f"{pid}_A.xlsx", snr_values=[snr_vals] * 3, z_values=[z_vals] * 3)
+        _write_participant_file(cond_b_dir / f"{pid}_B.xlsx", snr_values=[[v / 2 for v in snr_vals]] * 3, z_values=[z_vals] * 3)
+
+    view = RatioCalculatorWindow(project_root=excel_root)
+    qtbot.addWidget(view)
+    controller = RatioCalculatorController(view)
+    controller.set_excel_root(excel_root)
+
+    inputs = RatioCalcInputs(
+        excel_root=excel_root,
+        cond_a="ConditionA",
+        cond_b="ConditionB",
+        roi_name="Occipital Lobe",
+        z_threshold=1.64,
+        output_path=tmp_path / "ratio_output.xlsx",
+    )
+
+    result = controller.compute_ratios_sync(inputs)
+
+    assert inputs.output_path.exists()
+    df = result.dataframe
+    assert not df.empty
+    row = df[df["Ratio per ROI"].str.contains("Occipital Lobe")].iloc[0]
+    for pid in participants:
+        assert pid in df.columns
+        assert not pd.isna(row[pid])
+    assert {"N", "Mean", "Median", "Std", "Variance", "CV%", "Min", "Max"}.issubset(df.columns)
+    assert row["N"] == len(participants)


### PR DESCRIPTION
## Summary
- add new Ratio Calculator PySide6 tool with MVC structure, worker thread, and Excel-driven ratio computation
- integrate Ratio Calculator into the PySide6 sidebar and Tools menu with single-instance launcher
- document workflow and add smoke test covering ROI ratio export

## Testing
- python -m pytest -q *(fails: missing dependencies such as PySide6, numpy, pandas in environment)*
- ruff check . *(fails: pre-existing lint errors unrelated to this change)*
- mypy src --strict *(fails: pre-existing syntax error in src/Compiler_Script.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d1478658832c8f1e84214c777505)