### PR TITLE
Improve Ratio Calculator defaults and export layout

### DIFF
--- a/src/Tools/Ratio_Calculator/PySide6/README.md
+++ b/src/Tools/Ratio_Calculator/PySide6/README.md
@@ -3,7 +3,8 @@
 The Ratio Calculator computes ROI-level SNR ratios between two conditions from already-exported per-condition Excel workbooks.
 
 ## Inputs
-- **Excel root folder:** One subfolder per condition containing participant `.xlsx` files.
+- **Excel root folder:** Defaults to the Stats tool's project folder at `1 - Excel Data Files` (auto-detected via the project's
+  `project.json`); one subfolder per condition containing participant `.xlsx` files.
 - **Conditions:** Discovered via `scan_folder_simple` using `EXCEL_PID_REGEX` for participant IDs.
 - **ROIs:** Loaded from `resolve_active_rois()`; channel membership follows Stats ROI settings.
 - **Sheets used:** `SNR` and `Z Score` with an `Electrode` column plus frequency columns named `{freq:.4f}_Hz`.
@@ -17,8 +18,12 @@ The Ratio Calculator computes ROI-level SNR ratios between two conditions from a
 3. **Ratio:** `summary_SNR_A / summary_SNR_B`.
 
 ## Output
-- Single-sheet Excel export formatted via `_auto_format_and_write_excel(...)` with rows labeled `{ConditionA} to {ConditionB} - {ROI}`.
-- Participant columns contain per-ROI ratios; summary columns include N, Mean, Median, Std, Variance, CV%, Min, and Max (CV% = (Std / Mean) * 100 when Mean ≠ 0).
+- Default output folder: `4 - Ratio Calculator Results` under the active project root (auto-created). You can override the folder
+  and filename; `.xlsx` is appended automatically.
+- Single-sheet Excel export formatted via `_auto_format_and_write_excel(...)` in a **vertical layout**:
+  - Columns: Ratio Label, PID, SNR_A, SNR_B, Ratio, SigHarmonics_N, N, Mean, Median, Std, Variance, CV%, Min, Max.
+  - Participant rows list each PID with its ROI summary SNRs and ratio.
+  - SUMMARY rows appear after each ROI block with per-ROI statistics (blank separator row after each block).
 
 ## Skip rules and warnings
 - Missing condition files for a participant.

--- a/src/Tools/Ratio_Calculator/PySide6/__init__.py
+++ b/src/Tools/Ratio_Calculator/PySide6/__init__.py
@@ -20,7 +20,8 @@ def create_ratio_calculator_window(
     view.compute_requested.connect(controller.compute_ratios)
     view.excel_root_changed.connect(controller.set_excel_root)
     view.controller = controller  # type: ignore[attr-defined]
-    initial_root = Path(view.excel_path_edit.text())
-    if initial_root.exists():
+    initial_root_text = view.excel_path_edit.text().strip()
+    initial_root = Path(initial_root_text) if initial_root_text else None
+    if initial_root and initial_root.exists():
         controller.set_excel_root(initial_root)
     return view

--- a/src/Tools/Ratio_Calculator/PySide6/view.py
+++ b/src/Tools/Ratio_Calculator/PySide6/view.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import os
+import json
+import re
 from pathlib import Path
 from typing import Iterable
 
@@ -24,7 +25,13 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from Main_App.PySide6_App.Backend.project import EXCEL_SUBFOLDER_NAME
 from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs, RatioCalcResult
+from Tools.Stats.PySide6.stats_data_loader import (
+    auto_detect_project_dir,
+    load_manifest_data,
+    resolve_project_subfolder,
+)
 
 
 class RatioCalculatorWindow(QMainWindow):
@@ -34,9 +41,14 @@ class RatioCalculatorWindow(QMainWindow):
     def __init__(self, parent: QWidget | None = None, project_root: Path | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Ratio Calculator")
-        self._project_root = project_root or Path(os.environ.get("FPVS_PROJECT_ROOT", Path.cwd()))
+        self._project_root, self._results_folder_hint, self._subfolder_hints = self._detect_project_context(
+            parent, project_root
+        )
         self._busy = False
         self._last_df: pd.DataFrame | None = None
+        self._filename_user_edited = False
+        self._pending_logs: list[str] = []
+        self._default_excel_root: Path | None = None
 
         central = QWidget(self)
         self.setCentralWidget(central)
@@ -55,6 +67,9 @@ class RatioCalculatorWindow(QMainWindow):
         layout.addWidget(self.progress)
 
         layout.addWidget(self._build_log_group())
+        self._flush_pending_logs()
+
+        self._update_default_filename(force=True)
 
         btn_row = QHBoxLayout()
         btn_row.addStretch(1)
@@ -70,7 +85,9 @@ class RatioCalculatorWindow(QMainWindow):
         form = QFormLayout(group)
         form.setLabelAlignment(Qt.AlignLeft)
 
-        self.excel_path_edit = QLineEdit(str(self._project_root))
+        default_excel_root = self._preferred_excel_root()
+        self._default_excel_root = default_excel_root
+        self.excel_path_edit = QLineEdit(str(default_excel_root) if default_excel_root else "")
         self.excel_path_edit.setReadOnly(True)
         self.excel_browse_btn = QPushButton("Browse…", group)
         self.excel_browse_btn.clicked.connect(self._select_excel_root)
@@ -87,7 +104,9 @@ class RatioCalculatorWindow(QMainWindow):
         form.setLabelAlignment(Qt.AlignLeft)
 
         self.cond_a_combo = QComboBox(group)
+        self.cond_a_combo.currentTextChanged.connect(self._on_conditions_changed)
         self.cond_b_combo = QComboBox(group)
+        self.cond_b_combo.currentTextChanged.connect(self._on_conditions_changed)
         form.addRow(QLabel("Condition A (numerator):"), self.cond_a_combo)
         form.addRow(QLabel("Condition B (denominator):"), self.cond_b_combo)
 
@@ -115,15 +134,22 @@ class RatioCalculatorWindow(QMainWindow):
         form = QFormLayout(group)
         form.setLabelAlignment(Qt.AlignLeft)
 
-        self.output_edit = QLineEdit(str(self._default_output_path()))
-        self.output_edit.setReadOnly(True)
+        default_output_dir = self._default_output_dir(self._default_excel_root)
+        self.output_dir_edit = QLineEdit(str(default_output_dir) if default_output_dir else "")
+        self.output_dir_edit.setReadOnly(True)
         self.output_browse_btn = QPushButton("Browse…", group)
-        self.output_browse_btn.clicked.connect(self._select_output_file)
+        self.output_browse_btn.clicked.connect(self._select_output_dir)
+
+        file_row = QHBoxLayout()
+        self.output_filename_edit = QLineEdit("", group)
+        self.output_filename_edit.textEdited.connect(self._on_filename_edited)
+        file_row.addWidget(self.output_filename_edit)
+        form.addRow(QLabel("Output filename:"), file_row)
 
         row = QHBoxLayout()
-        row.addWidget(self.output_edit)
+        row.addWidget(self.output_dir_edit)
         row.addWidget(self.output_browse_btn)
-        form.addRow(QLabel("Output Excel:"), row)
+        form.addRow(QLabel("Output folder:"), row)
         return group
 
     def _build_log_group(self) -> QGroupBox:
@@ -141,8 +167,74 @@ class RatioCalculatorWindow(QMainWindow):
         group.toggled.connect(_toggle)
         return group
 
+    def _detect_project_context(
+        self, parent: QWidget | None, project_root: Path | None
+    ) -> tuple[Path | None, str | None, dict[str, str]]:
+        if project_root and Path(project_root).exists():
+            root = Path(project_root).resolve()
+        else:
+            proj = getattr(parent, "currentProject", None)
+            if proj and hasattr(proj, "project_root"):
+                root = Path(proj.project_root).resolve()
+            else:
+                root = Path(auto_detect_project_dir()).resolve()
+
+        results_folder_hint: str | None = None
+        subfolder_hints: dict[str, str] = {}
+        manifest_path = root / "project.json"
+        if manifest_path.is_file():
+            try:
+                cfg = json.loads(manifest_path.read_text(encoding="utf-8"))
+                results_folder_hint, subfolder_hints = load_manifest_data(root, cfg)
+            except Exception as exc:  # noqa: BLE001
+                self._queue_log(f"Failed to load project manifest: {exc}")
+        return root, results_folder_hint, subfolder_hints
+
+    def _preferred_excel_root(self) -> Path | None:
+        target = resolve_project_subfolder(
+            self._project_root,
+            self._results_folder_hint,
+            self._subfolder_hints,
+            "excel",
+            EXCEL_SUBFOLDER_NAME,
+        )
+        if target.exists() and target.is_dir():
+            return target
+        self._queue_log(f"Default Excel folder not found at '{target}'. Please select a valid folder.")
+        return None
+
+    def _queue_log(self, message: str) -> None:
+        if hasattr(self, "log_view"):
+            self.append_log(message)
+        else:
+            self._pending_logs.append(message)
+
+    def _flush_pending_logs(self) -> None:
+        for msg in self._pending_logs:
+            self.append_log(msg)
+        self._pending_logs.clear()
+
     def _default_output_path(self) -> Path:
-        return self._project_root / "ratio_results.xlsx"
+        folder = self._default_output_dir(self.excel_path_edit.text() or None)
+        filename = self._build_suggested_filename()
+        return (folder or Path.cwd()) / filename
+
+    def _default_output_dir(self, excel_root: str | Path | None) -> Path | None:
+        if self._project_root and self._project_root.exists():
+            return resolve_project_subfolder(
+                self._project_root,
+                self._results_folder_hint,
+                self._subfolder_hints,
+                "ratio_results",
+                "4 - Ratio Calculator Results",
+            )
+        if excel_root:
+            fallback = Path(excel_root).parent
+            self._queue_log(
+                f"Using '{fallback}' for results because project root could not be resolved."
+            )
+            return fallback
+        return None
 
     # View API for controller -------------------------------------------------
     def set_conditions(self, conditions: Iterable[str]) -> None:
@@ -155,6 +247,7 @@ class RatioCalculatorWindow(QMainWindow):
             self.cond_b_combo.addItem(cond)
         self.cond_a_combo.blockSignals(False)
         self.cond_b_combo.blockSignals(False)
+        self._update_default_filename(force=False)
 
     def set_rois(self, rois: Iterable[str]) -> None:
         self.roi_combo.blockSignals(True)
@@ -175,7 +268,8 @@ class RatioCalculatorWindow(QMainWindow):
             self.cond_a_combo,
             self.cond_b_combo,
             self.roi_combo,
-            self.output_edit,
+            self.output_dir_edit,
+            self.output_filename_edit,
             self.output_browse_btn,
             self.compute_btn,
         ):
@@ -205,25 +299,32 @@ class RatioCalculatorWindow(QMainWindow):
         if not directory:
             return
         self.excel_path_edit.setText(directory)
-        self.output_edit.setText(str(Path(directory) / "ratio_results.xlsx"))
+        default_output_dir = self._default_output_dir(Path(directory))
+        if default_output_dir:
+            self.output_dir_edit.setText(str(default_output_dir))
+        self._update_default_filename(force=False)
         self.excel_root_changed.emit(Path(directory))
 
-    def _select_output_file(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(
+    def _select_output_dir(self) -> None:
+        path = QFileDialog.getExistingDirectory(
             self,
-            "Save output Excel",
-            str(self._default_output_path()),
-            "Excel Files (*.xlsx)",
+            "Select output folder",
+            str(self._default_output_dir(self.excel_path_edit.text() or None) or self._project_root),
+            options=QFileDialog.ShowDirsOnly,
         )
         if not path:
             return
-        self.output_edit.setText(path)
+        self.output_dir_edit.setText(path)
 
     def _on_compute(self) -> None:
         if self._busy:
             self.append_log("A computation is already running.")
             return
-        excel_root = Path(self.excel_path_edit.text())
+        excel_root_text = self.excel_path_edit.text().strip()
+        if not excel_root_text:
+            self.append_log("Please select a valid Excel root folder.")
+            return
+        excel_root = Path(excel_root_text)
         if not excel_root.exists():
             self.append_log("Please select a valid Excel root folder.")
             return
@@ -234,7 +335,7 @@ class RatioCalculatorWindow(QMainWindow):
             return
         roi_name = self.roi_combo.currentText() or None
         threshold = float(self.threshold_spin.value())
-        output_path = Path(self.output_edit.text())
+        output_path = self._resolve_output_path()
         inputs = RatioCalcInputs(
             excel_root=excel_root,
             cond_a=cond_a,
@@ -251,3 +352,41 @@ class RatioCalculatorWindow(QMainWindow):
             self.append_log("Cannot close while computation is running.")
             return
         super().closeEvent(event)
+
+    def _resolve_output_path(self) -> Path:
+        filename = self.output_filename_edit.text().strip() or self._build_suggested_filename()
+        if not filename.lower().endswith(".xlsx"):
+            filename = f"{filename}.xlsx"
+        output_dir_text = self.output_dir_edit.text().strip()
+        output_dir = Path(output_dir_text) if output_dir_text else Path.cwd()
+        if not output_dir_text:
+            self._queue_log(f"No output folder selected; defaulting to '{output_dir}'.")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        return output_dir / filename
+
+    def _build_suggested_filename(self) -> str:
+        cond_a = self.cond_a_combo.currentText() or "condA"
+        cond_b = self.cond_b_combo.currentText() or "condB"
+        base = f"ratio_{cond_a}_vs_{cond_b}"
+        return f"{self._sanitize_filename(base)}.xlsx"
+
+    @staticmethod
+    def _sanitize_filename(text: str) -> str:
+        cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", text)
+        return cleaned.strip("._") or "ratio_results"
+
+    def _on_conditions_changed(self, _: str) -> None:
+        self._update_default_filename(force=False)
+
+    def _update_default_filename(self, force: bool) -> None:
+        if self._filename_user_edited and not force:
+            return
+        suggested = self._build_suggested_filename()
+        self.output_filename_edit.blockSignals(True)
+        self.output_filename_edit.setText(suggested)
+        self.output_filename_edit.blockSignals(False)
+        if force:
+            self._filename_user_edited = False
+
+    def _on_filename_edited(self, _: str) -> None:
+        self._filename_user_edited = True

--- a/tests/test_ratio_calculator_smoke.py
+++ b/tests/test_ratio_calculator_smoke.py
@@ -20,8 +20,12 @@ def _write_participant_file(path: Path, snr_values: list[list[float]], z_values:
         z_df.to_excel(writer, sheet_name="Z Score", index=False)
 
 
-def test_ratio_calculator_smoke(tmp_path, qtbot):
-    excel_root = tmp_path / "excel"
+def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "project.json").write_text("{}")
+
+    excel_root = project_root / "1 - Excel Data Files"
     cond_a_dir = excel_root / "ConditionA"
     cond_b_dir = excel_root / "ConditionB"
     cond_a_dir.mkdir(parents=True)
@@ -32,28 +36,50 @@ def test_ratio_calculator_smoke(tmp_path, qtbot):
         _write_participant_file(cond_a_dir / f"{pid}_A.xlsx", snr_values=[snr_vals] * 3, z_values=[z_vals] * 3)
         _write_participant_file(cond_b_dir / f"{pid}_B.xlsx", snr_values=[[v / 2 for v in snr_vals]] * 3, z_values=[z_vals] * 3)
 
-    view = RatioCalculatorWindow(project_root=excel_root)
+    monkeypatch.chdir(project_root)
+    view = RatioCalculatorWindow()
     qtbot.addWidget(view)
     controller = RatioCalculatorController(view)
-    controller.set_excel_root(excel_root)
 
+    detected_root = Path(view.excel_path_edit.text())
+    assert detected_root == excel_root
+    controller.set_excel_root(detected_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+
+    output_path = view._resolve_output_path()
     inputs = RatioCalcInputs(
         excel_root=excel_root,
-        cond_a="ConditionA",
-        cond_b="ConditionB",
+        cond_a=view.cond_a_combo.currentText(),
+        cond_b=view.cond_b_combo.currentText(),
         roi_name="Occipital Lobe",
         z_threshold=1.64,
-        output_path=tmp_path / "ratio_output.xlsx",
+        output_path=output_path,
     )
 
     result = controller.compute_ratios_sync(inputs)
 
-    assert inputs.output_path.exists()
+    assert output_path.exists()
+    assert output_path.parent == project_root / "4 - Ratio Calculator Results"
     df = result.dataframe
-    assert not df.empty
-    row = df[df["Ratio per ROI"].str.contains("Occipital Lobe")].iloc[0]
-    for pid in participants:
-        assert pid in df.columns
-        assert not pd.isna(row[pid])
-    assert {"N", "Mean", "Median", "Std", "Variance", "CV%", "Min", "Max"}.issubset(df.columns)
-    assert row["N"] == len(participants)
+    assert list(df.columns) == [
+        "Ratio Label",
+        "PID",
+        "SNR_A",
+        "SNR_B",
+        "Ratio",
+        "SigHarmonics_N",
+        "N",
+        "Mean",
+        "Median",
+        "Std",
+        "Variance",
+        "CV%",
+        "Min",
+        "Max",
+    ]
+    roi_rows = df[df["Ratio Label"].str.contains("Occipital Lobe", na=False)]
+    assert not roi_rows.empty
+    participant_rows = roi_rows[roi_rows["PID"] != "SUMMARY"]
+    assert len(participant_rows) >= 1
+    summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]
+    assert summary_row["N"] == len(participants)


### PR DESCRIPTION
## Summary
- align the Ratio Calculator defaults with the project manifest, including Excel root auto-detection and result folder creation with a configurable filename field
- switch the Excel export to a vertical layout that lists participant rows and ROI summary rows while reusing the existing Stats Excel formatting
- extend the smoke test to cover project-root auto-detection, output folder creation, and the new vertical export columns

## Testing
- QT_QPA_PLATFORM=offscreen pytest tests/test_ratio_calculator_smoke.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d69eac6c832c9ddc7021e9b6f958)