### PR TITLE
Add per-participant significance mode and settings-based ROI selection to Ratio Calculator

### DIFF
--- a/src/Tools/Ratio_Calculator/PySide6/README.md
+++ b/src/Tools/Ratio_Calculator/PySide6/README.md
@@ -6,15 +6,18 @@ The Ratio Calculator computes ROI-level SNR ratios between two conditions from a
 - **Excel root folder:** Defaults to the Stats tool's project folder at `1 - Excel Data Files` (auto-detected via the project's
   `project.json`); one subfolder per condition containing participant `.xlsx` files.
 - **Conditions:** Discovered via `scan_folder_simple` using `EXCEL_PID_REGEX` for participant IDs.
-- **ROIs:** Loaded from `resolve_active_rois()`; channel membership follows Stats ROI settings.
+- **ROIs:** Loaded only from ROI pairs defined in **Settings**; channel membership follows the saved Stats ROI settings. Defaults (Frontal/Parietal/Central/Occipital) are not added automatically.
 - **Sheets used:** `SNR` and `Z Score` with an `Electrode` column plus frequency columns named `{freq:.4f}_Hz`.
 
 ## Computation
-1. **Significant harmonics (group level, per ROI):**
-   - For each participant with both conditions, compute ROI-mean Z-scores per harmonic by averaging rows where `Electrode` matches the ROI channels (case-insensitive).
-   - Take the group mean across participants for each harmonic.
-   - Harmonics with mean Z > 1.64 (default threshold) are considered significant.
-2. **Summary SNR (per participant & ROI):** Mean SNR across the significant harmonics for each condition.
+1. **Significance mode (Advanced → Significance mode):**
+   - **Group-level (default/recommended):**
+     - For each ROI, compute mean Z-scores per harmonic across participants (Condition A only).
+     - Harmonics with mean Z > 1.64 (default threshold) are significant for all participants in that ROI.
+   - **Per-participant (experimental):**
+     - For each participant and ROI, compute mean Z-scores per harmonic across ROI channels (Condition A only).
+     - Each participant uses their own significant harmonics set (Z > 1.64).
+2. **Summary SNR (per participant & ROI):** Mean SNR across the significant harmonics for each condition (group shared set or participant-specific set depending on the mode).
 3. **Ratio:** `summary_SNR_A / summary_SNR_B`.
 
 ## Output
@@ -22,7 +25,7 @@ The Ratio Calculator computes ROI-level SNR ratios between two conditions from a
   and filename; `.xlsx` is appended automatically.
 - Single-sheet Excel export formatted via `_auto_format_and_write_excel(...)` in a **vertical layout**:
   - Columns: Ratio Label, PID, SNR_A, SNR_B, Ratio, SigHarmonics_N, N, Mean, Median, Std, Variance, CV%, Min, Max.
-  - Participant rows list each PID with its ROI summary SNRs and ratio.
+  - Participant rows list each PID with its ROI summary SNRs and ratio. `SigHarmonics_N` reflects the count of significant harmonics actually used for that participant (group mode uses the shared ROI count).
   - SUMMARY rows appear after each ROI block with per-ROI statistics (blank separator row after each block).
 
 ## Skip rules and warnings
@@ -31,6 +34,3 @@ The Ratio Calculator computes ROI-level SNR ratios between two conditions from a
 - ROI without matching channels in a file.
 - No significant harmonics for an ROI (ratios left blank/NaN).
 - Denominator summary SNR equals zero.
-
-## Future work
-- Individual-level harmonic significance selection is a planned enhancement.

--- a/src/Tools/Ratio_Calculator/PySide6/controller.py
+++ b/src/Tools/Ratio_Calculator/PySide6/controller.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import logging
 import time
+from dataclasses import replace
 from pathlib import Path
 
-from PySide6.QtCore import QObject, QThread
+from PySide6.QtCore import QObject, QThread, QUrl
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtWidgets import QMessageBox
 
+from Main_App import SettingsManager
 from Main_App.PySide6_App.utils.op_guard import OpGuard
 from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs, RatioCalcResult
 from Tools.Ratio_Calculator.PySide6.worker import RatioCalcWorker, compute_ratios
 from Tools.Stats.PySide6.stats_data_loader import ScanError, scan_folder_simple
-from Tools.Stats.roi_resolver import resolve_active_rois
+from Tools.Stats.roi_resolver import ROI
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +26,7 @@ class RatioCalculatorController(QObject):
         self._guard = OpGuard()
         self._thread: QThread | None = None
         self._worker: RatioCalcWorker | None = None
+        self._rois: list[ROI] = []
 
     def set_excel_root(self, path: Path) -> None:
         try:
@@ -37,20 +42,24 @@ class RatioCalculatorController(QObject):
         if hasattr(self.view, "set_conditions"):
             self.view.set_conditions(conds)
         try:
-            rois = resolve_active_rois()
-            roi_names = ["All ROIs", *[r.name for r in rois]]
+            rois = self._load_settings_rois()
+            self._rois = rois
             if hasattr(self.view, "set_rois"):
-                self.view.set_rois(roi_names)
+                self.view.set_rois(rois)
+            if not rois and hasattr(self.view, "append_log"):
+                self.view.append_log("No ROIs defined in Settings. Please add ROI pairs in Settings to proceed.")
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to load ROIs: %s", exc)
             if hasattr(self.view, "append_log"):
                 self.view.append_log(f"Failed to load ROIs: {exc}")
         if hasattr(self.view, "append_log"):
-            self.view.append_log(
-                f"Detected {len(subjects)} participant(s) and {len(conds)} condition(s)."
-            )
+            self.view.append_log(f"Detected {len(subjects)} participant(s) and {len(conds)} condition(s).")
 
     def compute_ratios(self, inputs: RatioCalcInputs) -> None:
+        if not self._rois:
+            if hasattr(self.view, "append_log"):
+                self.view.append_log("No ROIs available. Define ROIs in Settings before computing ratios.")
+            return
         if not self._guard.start():
             if hasattr(self.view, "append_log"):
                 self.view.append_log("Computation already in progress.")
@@ -61,7 +70,7 @@ class RatioCalculatorController(QObject):
         if hasattr(self.view, "set_progress"):
             self.view.set_progress(0)
 
-        worker = RatioCalcWorker(inputs)
+        worker = RatioCalcWorker(self._prepare_inputs(inputs))
         thread = QThread()
         worker.moveToThread(thread)
         worker.progress.connect(getattr(self.view, "set_progress"))
@@ -78,7 +87,7 @@ class RatioCalculatorController(QObject):
         thread.start()
 
     def compute_ratios_sync(self, inputs: RatioCalcInputs) -> RatioCalcResult:
-        return compute_ratios(inputs)
+        return compute_ratios(self._prepare_inputs(inputs))
 
     def _on_thread_done(self, started_at: float) -> None:
         elapsed_ms = (time.perf_counter() - started_at) * 1000
@@ -94,3 +103,36 @@ class RatioCalculatorController(QObject):
                 self.view.status_message(warning)
         if hasattr(self.view, "handle_result"):
             self.view.handle_result(result)
+        if result.output_path.exists():
+            self._prompt_open_results(result.output_path)
+
+    def _prepare_inputs(self, inputs: RatioCalcInputs) -> RatioCalcInputs:
+        return replace(inputs, rois=self._rois)
+
+    def _load_settings_rois(self) -> list[ROI]:
+        mgr = SettingsManager()
+        get_roi_pairs = getattr(mgr, "get_roi_pairs", None)
+        pairs = get_roi_pairs() if callable(get_roi_pairs) else []
+        if isinstance(pairs, dict):
+            pairs = list(pairs.items())
+        rois: list[ROI] = []
+        for name, electrodes in pairs:
+            if not name or not electrodes:
+                continue
+            channels = [str(ch).upper() for ch in electrodes if str(ch).strip()]
+            if channels:
+                rois.append(ROI(name=str(name), channels=channels))
+        return rois
+
+    def _prompt_open_results(self, output_path: Path) -> None:
+        parent = self.view if isinstance(self.view, QObject) else None
+        reply = QMessageBox.question(
+            parent,
+            "Ratio Calculator",
+            "Ratio calculations complete. View results?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes,
+        )
+        if reply == QMessageBox.Yes:
+            folder = output_path.parent
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(folder)))

--- a/src/Tools/Ratio_Calculator/PySide6/model.py
+++ b/src/Tools/Ratio_Calculator/PySide6/model.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import pandas as pd
 
+from Tools.Stats.roi_resolver import ROI
+
 
 @dataclass(frozen=True)
 class RatioCalcInputs:
@@ -15,11 +17,15 @@ class RatioCalcInputs:
     roi_name: Optional[str]
     z_threshold: float
     output_path: Path
+    significance_mode: str
+    rois: list[ROI]
 
 
 @dataclass
 class RatioCalcResult:
     dataframe: pd.DataFrame
     significant_freqs_by_roi: dict[str, list[float]]
+    significant_freqs_by_roi_by_pid: Optional[dict[str, dict[str, list[float]]]]
     warnings: list[str]
     output_path: Path
+    output_folder: Path


### PR DESCRIPTION
## Summary
- Load Ratio Calculator ROIs strictly from Settings, disable computing when none are defined, and prompt to open the results folder after successful runs.
- Add a configurable significance mode (group-level vs per-participant), propagate selections through the worker, and reflect per-row significant harmonic counts in exports.
- Update documentation and smoke tests to cover the new options and settings-only ROI population.

## Testing
- python -m pytest tests/test_ratio_calculator_smoke.py
- python -m ruff check (fails on existing issues outside this change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941dc746d5c832c9060bc891129ac75)