### PR TITLE
Add BCA metric toggle and outlier detection to Ratio Calculator

### DIFF
--- a/src/Tools/Ratio_Calculator/PySide6/README.md
+++ b/src/Tools/Ratio_Calculator/PySide6/README.md
@@ -17,20 +17,41 @@ The Ratio Calculator computes ROI-level SNR ratios between two conditions from a
    - **Per-participant (experimental):**
      - For each participant and ROI, compute mean Z-scores per harmonic across ROI channels (Condition A only).
      - Each participant uses their own significant harmonics set (Z > 1.64).
-2. **Summary SNR (per participant & ROI):** Mean SNR across the significant harmonics for each condition (group shared set or participant-specific set depending on the mode).
-3. **Ratio:** `summary_SNR_A / summary_SNR_B`.
+2. **Summary metric (per participant & ROI):**
+   - **SNR (default metric):** Mean SNR across the significant harmonics for each condition (group shared set or participant-specific set depending on the mode).
+   - **BCA (uV):** Sum of ROI-mean BCA across the significant harmonics for each condition using the `BCA (uV)` sheet and the same frequency columns as SNR.
+3. **Ratio:** `summary_A / summary_B` using the selected metric.
+
+## Metric modes (SNR vs BCA)
+- **Default:** SNR with the existing behavior preserved.
+- **Metric dropdown:** Choose between SNR and BCA without affecting other defaults (significance remains group-level unless changed).
+- **BCA negative handling (Advanced, shown only in BCA mode):**
+  - **Strict (default):** If either condition’s summed BCA ≤ 0, the ratio is skipped (row retained with `SkipReason`).
+  - **Rectify negatives to 0:** Negative ROI-mean BCA values per harmonic are clamped to 0 before summing; ratios are skipped if the denominator remains 0.
+
+## Outlier detection (Advanced, optional)
+- Disabled by default; enabling toggles per-ROI detection on computed ratios (requires ≥5 valid ratios).
+- **Methods:**
+  - **MAD (robust z, default when enabled):** `robust_z = 0.6745 * (x - median) / MAD`; if MAD is 0, robust z-scores are treated as 0.
+  - **IQR:** Flags ratios below `Q1 - k*IQR` or above `Q3 + k*IQR` (k = threshold).
+- **Threshold defaults:** MAD = 3.5; IQR multiplier = 1.5.
+- **Actions:**
+  - **Flag only (default):** Outliers are marked but still included in summary stats.
+  - **Exclude from summary stats:** Outliers remain in participant rows but are omitted from summary aggregates.
 
 ## Output
 - Default output folder: `4 - Ratio Calculator Results` under the active project root (auto-created). You can override the folder
   and filename; `.xlsx` is appended automatically.
 - Single-sheet Excel export formatted via `_auto_format_and_write_excel(...)` in a **vertical layout**:
-  - Columns: Ratio Label, PID, SNR_A, SNR_B, Ratio, SigHarmonics_N, N, Mean, Median, Std, Variance, CV%, Min, Max.
-  - Participant rows list each PID with its ROI summary SNRs and ratio. `SigHarmonics_N` reflects the count of significant harmonics actually used for that participant (group mode uses the shared ROI count).
+  - Columns: Ratio Label, PID, SNR_A, SNR_B, SummaryA, SummaryB, Ratio, MetricUsed, SkipReason, OutlierFlag, OutlierMethod, OutlierScore, SigHarmonics_N, N, Mean, Median, Std, Variance, CV%, Min, Max.
+  - Participant rows list each PID with ROI summaries for the chosen metric (`SummaryA`/`SummaryB`) alongside legacy SNR columns. `SigHarmonics_N` reflects the count of significant harmonics actually used for that participant (group mode uses the shared ROI count).
   - SUMMARY rows appear after each ROI block with per-ROI statistics (blank separator row after each block).
+  - Outliers (if enabled) are flagged per participant, and summary stats optionally exclude them depending on the selected action.
 
 ## Skip rules and warnings
 - Missing condition files for a participant.
 - Missing `SNR` or `Z Score` sheets.
 - ROI without matching channels in a file.
 - No significant harmonics for an ROI (ratios left blank/NaN).
-- Denominator summary SNR equals zero.
+- Denominator summary equals zero.
+- Non-positive summed BCA when using strict negative handling.

--- a/src/Tools/Ratio_Calculator/PySide6/model.py
+++ b/src/Tools/Ratio_Calculator/PySide6/model.py
@@ -19,6 +19,12 @@ class RatioCalcInputs:
     output_path: Path
     significance_mode: str
     rois: list[ROI]
+    metric: str
+    outlier_enabled: bool
+    outlier_method: str
+    outlier_threshold: float
+    outlier_action: str
+    bca_negative_mode: str
 
 
 @dataclass
@@ -27,5 +33,6 @@ class RatioCalcResult:
     significant_freqs_by_roi: dict[str, list[float]]
     significant_freqs_by_roi_by_pid: Optional[dict[str, dict[str, list[float]]]]
     warnings: list[str]
+    summary_counts: dict[str, object]
     output_path: Path
     output_folder: Path

--- a/tests/test_ratio_calculator_smoke.py
+++ b/tests/test_ratio_calculator_smoke.py
@@ -12,7 +12,12 @@ from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs
 from Tools.Ratio_Calculator.PySide6.view import RatioCalculatorWindow
 
 
-def _write_participant_file(path: Path, snr_values: list[list[float]], z_values: list[list[float]]) -> None:
+def _write_participant_file(
+    path: Path,
+    snr_values: list[list[float]],
+    z_values: list[list[float]],
+    bca_values: list[list[float]] | None = None,
+) -> None:
     electrodes = ["O1", "O2", "Oz"]
     freqs = ["1.2000_Hz", "2.4000_Hz"]
     snr_df = pd.DataFrame({"Electrode": electrodes})
@@ -23,6 +28,32 @@ def _write_participant_file(path: Path, snr_values: list[list[float]], z_values:
     with pd.ExcelWriter(path) as writer:
         snr_df.to_excel(writer, sheet_name="SNR", index=False)
         z_df.to_excel(writer, sheet_name="Z Score", index=False)
+        if bca_values:
+            bca_df = pd.DataFrame({"Electrode": electrodes})
+            for idx, freq in enumerate(freqs):
+                bca_df[freq] = [row[idx] for row in bca_values]
+            bca_df.to_excel(writer, sheet_name="BCA (uV)", index=False)
+
+
+def _make_inputs(view, controller, excel_root: Path, roi_name: str, **overrides):
+    params = {
+        "excel_root": excel_root,
+        "cond_a": view.cond_a_combo.currentText(),
+        "cond_b": view.cond_b_combo.currentText(),
+        "roi_name": roi_name,
+        "z_threshold": float(view.threshold_spin.value()),
+        "output_path": view._resolve_output_path(),
+        "significance_mode": view.significance_combo.currentData(),
+        "rois": controller._rois,
+        "metric": view.metric_combo.currentData(),
+        "outlier_enabled": view.outlier_checkbox.isChecked(),
+        "outlier_method": view.outlier_method_combo.currentData(),
+        "outlier_threshold": float(view.outlier_threshold_spin.value()),
+        "outlier_action": view.outlier_action_combo.currentData(),
+        "bca_negative_mode": view.bca_handling_combo.currentData(),
+    }
+    params.update(overrides)
+    return RatioCalcInputs(**params)
 
 
 def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
@@ -68,16 +99,7 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
     view.significance_combo.setCurrentIndex(view.significance_combo.findData("individual"))
 
     output_path = view._resolve_output_path()
-    inputs = RatioCalcInputs(
-        excel_root=excel_root,
-        cond_a=view.cond_a_combo.currentText(),
-        cond_b=view.cond_b_combo.currentText(),
-        roi_name="Bilateral OT",
-        z_threshold=1.64,
-        output_path=output_path,
-        significance_mode=view.significance_combo.currentData(),
-        rois=controller._rois,
-    )
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT", output_path=output_path)
 
     result = controller.compute_ratios_sync(inputs)
 
@@ -89,7 +111,14 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
         "PID",
         "SNR_A",
         "SNR_B",
+        "SummaryA",
+        "SummaryB",
         "Ratio",
+        "MetricUsed",
+        "SkipReason",
+        "OutlierFlag",
+        "OutlierMethod",
+        "OutlierScore",
         "SigHarmonics_N",
         "N",
         "Mean",
@@ -107,6 +136,8 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
     assert (participant_rows["SigHarmonics_N"] > 0).any()
     summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]
     assert summary_row["N"] == len(participants)
+    assert (participant_rows["MetricUsed"] == "SNR").all()
+    assert (participant_rows["OutlierFlag"] == False).all()  # noqa: E712
 
     monkeypatch.setattr(QMessageBox, "question", lambda *_, **__: QMessageBox.Yes)
     opened = []
@@ -118,3 +149,140 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
     monkeypatch.setattr(QDesktopServices, "openUrl", _fake_open)
     controller._on_finished(result)
     assert opened
+
+
+def test_ratio_calculator_bca_strict(tmp_path, qtbot, monkeypatch):
+    class FakeSettingsManager:
+        def get_roi_pairs(self):
+            return [("Bilateral OT", ["O1", "O2"])]
+
+    monkeypatch.setattr("Main_App.SettingsManager", lambda *_, **__: FakeSettingsManager())
+    monkeypatch.setattr(
+        "Tools.Ratio_Calculator.PySide6.controller.SettingsManager",
+        lambda *_, **__: FakeSettingsManager(),
+    )
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "project.json").write_text("{}")
+
+    excel_root = project_root / "1 - Excel Data Files"
+    cond_a_dir = excel_root / "ConditionA"
+    cond_b_dir = excel_root / "ConditionB"
+    cond_a_dir.mkdir(parents=True)
+    cond_b_dir.mkdir(parents=True)
+
+    participant_data = {
+        "P01": {"a": [2.0, 2.0], "b": [-1.0, -1.0]},
+        "P02": {"a": [3.0, 3.0], "b": [1.0, 1.0]},
+    }
+    for pid, values in participant_data.items():
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[values["a"]] * 3,
+            z_values=[[3.0, 3.0]] * 3,
+            bca_values=[values["a"]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[values["b"]] * 3,
+            z_values=[[3.0, 3.0]] * 3,
+            bca_values=[values["b"]] * 3,
+        )
+
+    monkeypatch.chdir(project_root)
+    view = RatioCalculatorWindow()
+    qtbot.addWidget(view)
+    controller = RatioCalculatorController(view)
+
+    detected_root = Path(view.excel_path_edit.text())
+    controller.set_excel_root(detected_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    view.metric_combo.setCurrentIndex(view.metric_combo.findData("bca"))
+
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+
+    roi_rows = df[df["Ratio Label"].str.contains("Bilateral OT", na=False)]
+    p01_row = roi_rows[roi_rows["PID"] == "P01"].iloc[0]
+    assert pd.isna(p01_row["Ratio"])
+    assert p01_row["SkipReason"]
+    assert p01_row["MetricUsed"] == "BCA"
+    p02_row = roi_rows[roi_rows["PID"] == "P02"].iloc[0]
+    assert not pd.isna(p02_row["Ratio"])
+    summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]
+    assert summary_row["N"] == 1
+
+
+def test_ratio_calculator_outlier_detection(tmp_path, qtbot, monkeypatch):
+    class FakeSettingsManager:
+        def get_roi_pairs(self):
+            return [("Bilateral OT", ["O1", "O2"])]
+
+    monkeypatch.setattr("Main_App.SettingsManager", lambda *_, **__: FakeSettingsManager())
+    monkeypatch.setattr(
+        "Tools.Ratio_Calculator.PySide6.controller.SettingsManager",
+        lambda *_, **__: FakeSettingsManager(),
+    )
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "project.json").write_text("{}")
+
+    excel_root = project_root / "1 - Excel Data Files"
+    cond_a_dir = excel_root / "ConditionA"
+    cond_b_dir = excel_root / "ConditionB"
+    cond_a_dir.mkdir(parents=True)
+    cond_b_dir.mkdir(parents=True)
+
+    ratios = {"P01": 1.0, "P02": 1.1, "P03": 1.2, "P04": 1.05, "P05": 8.0}
+    base = 2.0
+    for pid, ratio in ratios.items():
+        cond_a_vals = [base * ratio, base * ratio]
+        cond_b_vals = [base, base]
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0]] * 3,
+        )
+
+    monkeypatch.chdir(project_root)
+    view = RatioCalculatorWindow()
+    qtbot.addWidget(view)
+    controller = RatioCalculatorController(view)
+
+    detected_root = Path(view.excel_path_edit.text())
+    controller.set_excel_root(detected_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    view.outlier_checkbox.setChecked(True)
+    view.outlier_threshold_spin.setValue(2.0)
+    view.outlier_action_combo.setCurrentIndex(view.outlier_action_combo.findData("exclude"))
+
+    inputs = _make_inputs(
+        view,
+        controller,
+        excel_root,
+        "Bilateral OT",
+        outlier_enabled=True,
+        outlier_threshold=2.0,
+        outlier_action="exclude",
+    )
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+
+    roi_rows = df[df["Ratio Label"].str.contains("Bilateral OT", na=False)]
+    participant_rows = roi_rows[roi_rows["PID"].isin(ratios.keys())]
+    flagged = participant_rows[participant_rows["PID"] == "P05"].iloc[0]
+    assert bool(flagged["OutlierFlag"]) is True
+    assert flagged["OutlierMethod"] == "MAD (robust z)"
+    summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]
+    assert summary_row["N"] == 4
+    assert summary_row["Mean"] < 2


### PR DESCRIPTION
## Summary
- add UI controls for metric selection, BCA negative-handling options, and optional outlier detection in the Ratio Calculator
- extend worker calculations to support BCA summaries, negative handling, and outlier filtering while expanding export columns and logging
- document the new modes and expand pytest-qt coverage for default, BCA strict, and outlier-detection scenarios

## Testing
- ruff check src/Tools/Ratio_Calculator/PySide6 tests/test_ratio_calculator_smoke.py
- python -m pytest tests/test_ratio_calculator_smoke.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bdfb1970832c946808b77b9e3461)