### PR TITLE
Add log-ratio summaries and stability rules to Ratio Calculator

### DIFF
--- a/src/Tools/Ratio_Calculator/PySide6/model.py
+++ b/src/Tools/Ratio_Calculator/PySide6/model.py
@@ -25,6 +25,16 @@ class RatioCalcInputs:
     outlier_threshold: float
     outlier_action: str
     bca_negative_mode: str
+    min_significant_harmonics: int
+    denominator_floor_enabled: bool
+    denominator_floor_mode: str
+    denominator_floor_quantile: float
+    denominator_floor_scope: str
+    denominator_floor_reference: str
+    denominator_floor_absolute: float | None
+    summary_metric: str
+    outlier_metric: str
+    require_denom_sig: bool
 
 
 @dataclass

--- a/src/Tools/Ratio_Calculator/PySide6/worker.py
+++ b/src/Tools/Ratio_Calculator/PySide6/worker.py
@@ -34,15 +34,28 @@ class RatioRow:
     summary_a: float | None
     summary_b: float | None
     ratio: float | None
+    log_ratio: float | None
+    ratio_percent: float | None
     sig_count: int
     metric_used: str
     skip_reason: str | None = None
-    include_in_summary: bool = True
+    include_in_summary: bool = False
+    base_valid: bool = False
     outlier_flag: bool = False
     outlier_method: str | None = None
     outlier_score: float | None = None
+    excluded_as_outlier: bool = False
     snr_a: float | None = None
     snr_b: float | None = None
+    denom_floor: float | None = None
+
+
+@dataclass
+class RoiComputation:
+    rows: list[RatioRow]
+    sig_harmonics_group: int
+    n_detected: int
+    skip_reason: str | None = None
 
 
 @dataclass
@@ -53,6 +66,7 @@ class RatioCalcSummaryCounts:
     skipped_missing: int = 0
     skipped_nonpositive_bca: int = 0
     outliers_flagged_per_roi: dict[str, int] = field(default_factory=dict)
+    floor_excluded_per_roi: dict[str, int] = field(default_factory=dict)
 
 
 class RatioCalcWorker(QObject):
@@ -119,6 +133,7 @@ def compute_ratios(
             inputs.cond_b,
             inputs.significance_mode,
             inputs.outlier_action,
+            inputs.summary_metric,
         )
         return RatioCalcResult(empty_df, {}, None, warnings, asdict(summary_counts), inputs.output_path, inputs.output_path.parent)
 
@@ -137,6 +152,7 @@ def compute_ratios(
             inputs.cond_b,
             inputs.significance_mode,
             inputs.outlier_action,
+            inputs.summary_metric,
         )
         return RatioCalcResult(empty_df, {}, None, warnings, asdict(summary_counts), inputs.output_path, inputs.output_path.parent)
 
@@ -153,21 +169,24 @@ def compute_ratios(
     _emit(progress_cb, 50)
 
     participants_seq = list(participants_map.values())
-    ratios = _compute_ratio_table(
+    ratio_data = _compute_ratio_table(
         participants_seq, rois, sig_freqs, sig_freqs_by_pid, inputs, log_warning, summary_counts
     )
-    _apply_outlier_detection(ratios, inputs, log_warning, summary_counts)
-    summary_counts.participants_used_per_roi = _participants_used(ratios, inputs.outlier_action)
+    _apply_outlier_detection(ratio_data, inputs, log_warning, summary_counts)
+    floor_map = _compute_denominator_floors(ratio_data, inputs, log_warning)
+    _apply_denominator_floor(ratio_data, floor_map, summary_counts)
+    summary_counts.participants_used_per_roi = _participants_used(ratio_data, inputs.summary_metric)
     _emit(progress_cb, 85)
 
     df = _build_output_frame(
-        ratios,
+        ratio_data,
         selected_roi_names,
         sig_freqs,
         inputs.cond_a,
         inputs.cond_b,
         inputs.significance_mode,
         inputs.outlier_action,
+        inputs.summary_metric,
     )
     _emit(progress_cb, 90)
     _write_excel(df, inputs.output_path, log_info)
@@ -179,6 +198,7 @@ def compute_ratios(
     log_info(f"Skipped missing data: {summary_counts.skipped_missing}")
     log_info(f"Skipped non-positive BCA: {summary_counts.skipped_nonpositive_bca}")
     log_info(f"Outliers flagged per ROI: {summary_counts.outliers_flagged_per_roi}")
+    log_info(f"Denominator floor exclusions per ROI: {summary_counts.floor_excluded_per_roi}")
 
     return RatioCalcResult(
         df,
@@ -305,20 +325,49 @@ def _compute_ratio_table(
     inputs: RatioCalcInputs,
     log_warning: LogCallback,
     summary_counts: RatioCalcSummaryCounts,
-) -> dict[str, list[RatioRow]]:
-    ratios: dict[str, list[RatioRow]] = {roi.name: [] for roi in rois}
+) -> dict[str, RoiComputation]:
     metric_label = "BCA" if inputs.metric == "bca" else "SNR"
-    for part in participants:
+    ratio_data: dict[str, RoiComputation] = {}
+    min_k = max(1, min(50, inputs.min_significant_harmonics))
+    participants_list = list(participants)
+    metrics_cache: dict[str, tuple[dict[str, pd.Series], dict[str, pd.Series]]] = {}
+    for part in participants_list:
         metric_a = _load_metric_data(part.cond_a_file, rois, log_warning, part.pid, inputs.metric)
         metric_b = _load_metric_data(part.cond_b_file, rois, log_warning, part.pid, inputs.metric)
-
-        for roi in rois:
-            if inputs.significance_mode == "individual" and individual_sig_freqs is not None:
-                freqs = individual_sig_freqs.get(roi.name, {}).get(part.pid, [])
-            else:
-                freqs = sig_freqs.get(roi.name, [])
-            if not freqs:
-                log_warning(f"No significant harmonics for ROI {roi.name}; skipping ratios.")
+        metrics_cache[part.pid] = (metric_a, metric_b)
+    for roi in rois:
+        shared_freqs = sig_freqs.get(roi.name, [])
+        roi_rows: list[RatioRow] = []
+        skip_reason = None
+        if inputs.significance_mode != "individual" and len(shared_freqs) < min_k:
+            skip_reason = "insufficient_sig_harmonics"
+            log_warning(f"ROI {roi.name} has only {len(shared_freqs)} significant harmonics (< {min_k}); skipping ratios.")
+        for part in participants_list:
+            metric_a, metric_b = metrics_cache.get(part.pid, ({}, {}))
+            freqs = (
+                individual_sig_freqs.get(roi.name, {}).get(part.pid, [])
+                if inputs.significance_mode == "individual" and individual_sig_freqs is not None
+                else shared_freqs
+            )
+            sig_count = len(freqs)
+            if skip_reason or sig_count < min_k:
+                roi_rows.append(
+                    RatioRow(
+                        pid=part.pid,
+                        summary_a=None,
+                        summary_b=None,
+                        ratio=None,
+                        log_ratio=None,
+                        ratio_percent=None,
+                        sig_count=sig_count,
+                        metric_used=metric_label,
+                        skip_reason=skip_reason or "insufficient_sig_harmonics",
+                        include_in_summary=False,
+                        base_valid=False,
+                        snr_a=None,
+                        snr_b=None,
+                    )
+                )
                 continue
 
             summary_a = _summary_for_roi(metric_a.get(roi.name), freqs, inputs.metric, inputs.bca_negative_mode)
@@ -326,46 +375,66 @@ def _compute_ratio_table(
 
             if summary_a is None or summary_b is None:
                 summary_counts.skipped_missing += 1
-                log_warning(f"Missing ROI data for participant {part.pid} in ROI {roi.name}; skipping participant.")
+                roi_rows.append(
+                    RatioRow(
+                        pid=part.pid,
+                        summary_a=summary_a,
+                        summary_b=summary_b,
+                        ratio=None,
+                        log_ratio=None,
+                        ratio_percent=None,
+                        sig_count=sig_count,
+                        metric_used=metric_label,
+                        skip_reason="missing_data",
+                        include_in_summary=False,
+                        base_valid=False,
+                        snr_a=summary_a,
+                        snr_b=summary_b,
+                    )
+                )
                 continue
 
-            skip_reason: str | None = None
-            include_in_summary = True
-
-            if inputs.metric == "bca" and inputs.bca_negative_mode == "strict":
-                if summary_a <= 0 or summary_b <= 0:
-                    skip_reason = "Non-positive BCA sum"
-                    include_in_summary = False
-                    summary_counts.skipped_nonpositive_bca += 1
-                    log_warning(f"Non-positive BCA sum for participant {part.pid} ROI {roi.name}; skipping ratio.")
-                    if summary_b == 0:
-                        summary_counts.skipped_denominator_zero += 1
-
-            if skip_reason is None and summary_b == 0:
+            base_reason: str | None = None
+            if inputs.metric == "bca" and inputs.bca_negative_mode == "strict" and (summary_a <= 0 or summary_b <= 0):
+                base_reason = "nonpositive_bca_sum"
+                summary_counts.skipped_nonpositive_bca += 1
+                if summary_b == 0:
+                    summary_counts.skipped_denominator_zero += 1
+            if base_reason is None and summary_b == 0:
+                base_reason = "denominator_zero"
                 summary_counts.skipped_denominator_zero += 1
-                log_warning(f"Denominator {metric_label} is zero for participant {part.pid} ROI {roi.name}; skipping participant.")
-                if inputs.metric == "bca":
-                    skip_reason = "Denominator zero"
-                    include_in_summary = False
-                else:
-                    continue
 
-            ratio_value = None if skip_reason else summary_a / summary_b
-            ratios.setdefault(roi.name, []).append(
+            ratio_value = None if base_reason else summary_a / summary_b
+            log_ratio = float(np.log(ratio_value)) if ratio_value is not None and ratio_value > 0 and summary_a > 0 and summary_b > 0 else None
+            ratio_percent = float((np.exp(log_ratio) - 1) * 100) if log_ratio is not None else None
+
+            summary_metric_value = _summary_metric_value(ratio_value, log_ratio, inputs.summary_metric)
+            base_valid = base_reason is None and summary_metric_value is not None and np.isfinite(summary_metric_value)
+
+            roi_rows.append(
                 RatioRow(
                     pid=part.pid,
                     summary_a=summary_a,
                     summary_b=summary_b,
                     ratio=ratio_value,
-                    sig_count=len(freqs),
+                    log_ratio=log_ratio,
+                    ratio_percent=ratio_percent,
+                    sig_count=sig_count,
                     metric_used=metric_label,
-                    skip_reason=skip_reason,
-                    include_in_summary=include_in_summary,
+                    skip_reason=base_reason or None,
+                    include_in_summary=base_valid,
+                    base_valid=base_valid,
                     snr_a=summary_a,
                     snr_b=summary_b,
                 )
             )
-    return ratios
+        ratio_data[roi.name] = RoiComputation(
+            rows=roi_rows,
+            sig_harmonics_group=len(shared_freqs),
+            n_detected=len(participants_list),
+            skip_reason=skip_reason,
+        )
+    return ratio_data
 
 
 def _load_metric_data(
@@ -419,20 +488,40 @@ def _summary_for_roi(series: pd.Series | None, freqs: list[float], metric: str, 
     return float(np.nanmean(arr))
 
 
+def _summary_metric_value(ratio_value: float | None, log_ratio: float | None, summary_metric: str) -> float | None:
+    if summary_metric == "ratio":
+        return ratio_value if ratio_value is not None and np.isfinite(ratio_value) else None
+    return log_ratio if log_ratio is not None and np.isfinite(log_ratio) else None
+
+
+def _outlier_metric_value(row: RatioRow, metric: str) -> float | None:
+    if metric == "ratio":
+        return row.ratio if row.ratio is not None and np.isfinite(row.ratio) else None
+    if metric == "logratio":
+        return row.log_ratio if row.log_ratio is not None and np.isfinite(row.log_ratio) else None
+    return None
+
+
 def _apply_outlier_detection(
-    ratios: dict[str, list[RatioRow]],
+    ratio_data: dict[str, RoiComputation],
     inputs: RatioCalcInputs,
     log_warning: LogCallback,
     summary_counts: RatioCalcSummaryCounts,
 ) -> None:
     if not inputs.outlier_enabled:
         return
-    for roi_name, rows in ratios.items():
-        valid_indices = [idx for idx, row in enumerate(rows) if row.ratio is not None and np.isfinite(row.ratio)]
+    for roi_name, comp in ratio_data.items():
+        rows = comp.rows
+        metric_name = inputs.outlier_metric if inputs.outlier_metric != "summary" else inputs.summary_metric
+        valid_indices = [
+            idx
+            for idx, row in enumerate(rows)
+            if row.base_valid and _outlier_metric_value(row, metric_name) is not None
+        ]
         if len(valid_indices) < 5:
-            log_warning(f"Outlier detection skipped for ROI {roi_name}: fewer than 5 valid ratios.")
+            log_warning(f"Outlier detection skipped for ROI {roi_name}: fewer than 5 valid rows.")
             continue
-        values = np.array([rows[idx].ratio for idx in valid_indices], dtype=float)
+        values = np.array([_outlier_metric_value(rows[idx], metric_name) for idx in valid_indices], dtype=float)
         if inputs.outlier_method == "mad":
             median = float(np.nanmedian(values))
             mad = float(np.nanmedian(np.abs(values - median)))
@@ -444,61 +533,110 @@ def _apply_outlier_detection(
             flags = np.abs(scores) > inputs.outlier_threshold
             method_label = "MAD (robust z)"
             for idx, score, flag in zip(valid_indices, scores, flags):
-                rows[idx].outlier_method = method_label
-                rows[idx].outlier_score = float(score)
-                rows[idx].outlier_flag = bool(flag)
+                row = rows[idx]
+                row.outlier_method = method_label
+                row.outlier_score = float(score)
+                row.outlier_flag = bool(flag)
                 if flag:
                     summary_counts.outliers_flagged_per_roi[roi_name] = (
                         summary_counts.outliers_flagged_per_roi.get(roi_name, 0) + 1
                     )
                     if inputs.outlier_action == "exclude":
-                        rows[idx].include_in_summary = False
-        else:
-            q1 = float(np.nanpercentile(values, 25))
-            q3 = float(np.nanpercentile(values, 75))
-            iqr = q3 - q1
-            lower = q1 - inputs.outlier_threshold * iqr
-            upper = q3 + inputs.outlier_threshold * iqr
-            method_label = "IQR"
-            for idx, val in zip(valid_indices, values):
-                score = np.nan
-                flag = False
-                if val < lower:
-                    score = val - lower
-                    flag = True
-                elif val > upper:
-                    score = val - upper
-                    flag = True
-                rows[idx].outlier_method = method_label
-                rows[idx].outlier_score = float(score) if score == score else np.nan
-                rows[idx].outlier_flag = flag
-                if flag:
-                    summary_counts.outliers_flagged_per_roi[roi_name] = (
-                        summary_counts.outliers_flagged_per_roi.get(roi_name, 0) + 1
-                    )
-                    if inputs.outlier_action == "exclude":
-                        rows[idx].include_in_summary = False
+                        row.include_in_summary = False
+                        row.excluded_as_outlier = True
 
 
-def _participants_used(ratios: dict[str, list[RatioRow]], outlier_action: str) -> dict[str, int]:
+def _compute_denominator_floors(
+    ratio_data: dict[str, RoiComputation],
+    inputs: RatioCalcInputs,
+    log_warning: LogCallback,
+) -> dict[str, float]:
+    if not inputs.denominator_floor_enabled:
+        return {}
+    floor_map: dict[str, float] = {}
+    if inputs.denominator_floor_mode == "absolute":
+        if inputs.denominator_floor_absolute is None:
+            return {}
+        value = float(inputs.denominator_floor_absolute)
+        for roi_name in ratio_data:
+            floor_map[roi_name] = value
+        return floor_map
+
+    def _eligible_summary_b(comp: RoiComputation) -> list[float]:
+        return [
+            float(row.summary_b)
+            for row in comp.rows
+            if row.include_in_summary and row.summary_b is not None and np.isfinite(row.summary_b)
+        ]
+
+    quantile = min(max(inputs.denominator_floor_quantile, 0.01), 0.25)
+    if inputs.denominator_floor_scope == "global":
+        values: list[float] = []
+        for comp in ratio_data.values():
+            values.extend(_eligible_summary_b(comp))
+        if not values:
+            log_warning("Denominator floor (global) skipped: no eligible SummaryB values.")
+            return {}
+        floor_value = float(np.nanquantile(np.array(values, dtype=float), quantile))
+        for roi_name in ratio_data:
+            floor_map[roi_name] = floor_value
+        return floor_map
+
+    for roi_name, comp in ratio_data.items():
+        values = _eligible_summary_b(comp)
+        if not values:
+            log_warning(f"Denominator floor skipped for ROI {roi_name}: no eligible SummaryB values.")
+            continue
+        floor_map[roi_name] = float(np.nanquantile(np.array(values, dtype=float), quantile))
+    return floor_map
+
+
+def _apply_denominator_floor(
+    ratio_data: dict[str, RoiComputation],
+    floor_map: dict[str, float],
+    summary_counts: RatioCalcSummaryCounts,
+) -> None:
+    if not floor_map:
+        return
+    for roi_name, comp in ratio_data.items():
+        floor_value = floor_map.get(roi_name)
+        if floor_value is None:
+            continue
+        for row in comp.rows:
+            row.denom_floor = floor_value
+            if not row.include_in_summary:
+                continue
+            if row.summary_b is None or not np.isfinite(row.summary_b):
+                continue
+            if row.summary_b < floor_value:
+                row.skip_reason = "denom_below_floor"
+                row.include_in_summary = False
+                row.ratio = None
+                row.log_ratio = None
+                row.ratio_percent = None
+                summary_counts.floor_excluded_per_roi[roi_name] = (
+                    summary_counts.floor_excluded_per_roi.get(roi_name, 0) + 1
+                )
+
+
+def _participants_used(ratios: dict[str, RoiComputation], summary_metric: str) -> dict[str, int]:
     usage: dict[str, int] = {}
-    for roi_name, rows in ratios.items():
+    for roi_name, comp in ratios.items():
         usage[roi_name] = sum(
-            1
-            for row in rows
-            if row.ratio is not None and (row.include_in_summary or outlier_action != "exclude")
+            1 for row in comp.rows if row.include_in_summary and _summary_metric_value(row.ratio, row.log_ratio, summary_metric) is not None
         )
     return usage
 
 
 def _build_output_frame(
-    ratios: dict[str, list[RatioRow]],
+    ratios: dict[str, RoiComputation],
     roi_filter: list[str],
     sig_freqs: dict[str, list[float]],
     cond_a: str,
     cond_b: str,
     significance_mode: str,
     outlier_action: str,
+    summary_metric: str,
 ) -> pd.DataFrame:
     rows: list[dict[str, float | str | int | None]] = []
     roi_names = roi_filter if roi_filter else list(ratios.keys()) or list(sig_freqs.keys())
@@ -506,7 +644,39 @@ def _build_output_frame(
     for roi in roi_names:
         label = f"{cond_a} vs {cond_b} - {roi}"
         sig_count_group = len(sig_freqs.get(roi, []))
-        roi_ratios = ratios.get(roi, []) if sig_count_group or significance_mode == "individual" else []
+        roi_comp = ratios.get(roi, RoiComputation(rows=[], sig_harmonics_group=sig_count_group, n_detected=0))
+        roi_ratios = roi_comp.rows if sig_count_group or significance_mode == "individual" else []
+
+        n_base_valid = sum(1 for entry in roi_ratios if entry.base_valid)
+        n_outlier_excluded = sum(1 for entry in roi_ratios if entry.excluded_as_outlier)
+        n_floor_excluded = sum(
+            1 for entry in roi_ratios if entry.base_valid and not entry.include_in_summary and (entry.skip_reason or "") == "denom_below_floor"
+        )
+        n_used = sum(
+            1 for entry in roi_ratios if entry.include_in_summary and _summary_metric_value(entry.ratio, entry.log_ratio, summary_metric) is not None
+        )
+
+        summary_metric_values = [
+            _summary_metric_value(entry.ratio, entry.log_ratio, summary_metric)
+            for entry in roi_ratios
+            if entry.include_in_summary
+        ]
+        summary_metric_series = pd.Series([v for v in summary_metric_values if v is not None and np.isfinite(v)])
+        n = int(summary_metric_series.count()) if not summary_metric_series.empty else 0
+        mean = float(summary_metric_series.mean()) if n else np.nan
+        median = float(summary_metric_series.median()) if n else np.nan
+        std = float(summary_metric_series.std()) if n else np.nan
+        variance = float(summary_metric_series.var()) if n else np.nan
+        if mean is not None and not np.isnan(mean) and mean != 0:
+            cv = float((std / mean) * 100) if std is not None else np.nan
+        else:
+            cv = np.nan
+        min_val = float(summary_metric_series.min()) if n else np.nan
+        max_val = float(summary_metric_series.max()) if n else np.nan
+
+        ratio_used_series = pd.Series([entry.ratio for entry in roi_ratios if entry.include_in_summary and entry.ratio is not None])
+        min_ratio = float(ratio_used_series.min()) if not ratio_used_series.empty else np.nan
+        max_ratio = float(ratio_used_series.max()) if not ratio_used_series.empty else np.nan
 
         for entry in roi_ratios:
             rows.append(
@@ -518,42 +688,42 @@ def _build_output_frame(
                     "SummaryA": entry.summary_a,
                     "SummaryB": entry.summary_b,
                     "Ratio": entry.ratio,
+                    "LogRatio": entry.log_ratio,
+                    "RatioPercent": entry.ratio_percent,
                     "MetricUsed": entry.metric_used,
                     "SkipReason": entry.skip_reason or "",
+                    "IncludedInSummary": bool(entry.include_in_summary),
                     "OutlierFlag": bool(entry.outlier_flag),
                     "OutlierMethod": entry.outlier_method or "",
                     "OutlierScore": entry.outlier_score,
+                    "ExcludedAsOutlier": bool(entry.excluded_as_outlier),
                     "SigHarmonics_N": entry.sig_count,
+                    "DenomFloor": entry.denom_floor,
+                    "N_detected": None,
+                    "N_base_valid": None,
+                    "N_outliers_excluded": None,
+                    "N_floor_excluded": None,
+                    "N_used": None,
                     "N": None,
                     "Mean": None,
                     "Median": None,
                     "Std": None,
                     "Variance": None,
                     "CV%": None,
+                    "MeanRatio_fromLog": None,
+                    "MedianRatio_fromLog": None,
                     "Min": None,
                     "Max": None,
+                    "MinRatio": None,
+                    "MaxRatio": None,
                 }
             )
 
-        ratio_values = [
-            entry.ratio
-            for entry in roi_ratios
-            if entry.ratio is not None and (entry.include_in_summary or outlier_action != "exclude")
-        ]
-        ratio_series = pd.Series(ratio_values)
-        n = int(ratio_series.count()) if not ratio_series.empty else 0
-        mean = float(ratio_series.mean()) if n else np.nan
-        median = float(ratio_series.median()) if n else np.nan
-        std = float(ratio_series.std()) if n else np.nan
-        variance = float(ratio_series.var()) if n else np.nan
-        if mean is not None and not np.isnan(mean) and mean != 0:
-            cv = float((std / mean) * 100) if std is not None else np.nan
-        else:
-            cv = np.nan
-        min_val = float(ratio_series.min()) if n else np.nan
-        max_val = float(ratio_series.max()) if n else np.nan
-
         sig_count_summary = sig_count_group or max((entry.sig_count for entry in roi_ratios), default=0)
+
+        mean_ratio_from_log = float(np.exp(summary_metric_series.mean())) if summary_metric == "logratio" and n else np.nan
+        median_ratio_from_log = float(np.exp(summary_metric_series.median())) if summary_metric == "logratio" and n else np.nan
+        skip_for_summary = roi_comp.skip_reason or ""
 
         rows.append(
             {
@@ -564,20 +734,34 @@ def _build_output_frame(
                 "SummaryA": None,
                 "SummaryB": None,
                 "Ratio": None,
+                "LogRatio": None,
+                "RatioPercent": None,
                 "MetricUsed": None,
-                "SkipReason": "",
+                "SkipReason": skip_for_summary,
+                "IncludedInSummary": None,
                 "OutlierFlag": None,
                 "OutlierMethod": None,
                 "OutlierScore": None,
+                "ExcludedAsOutlier": None,
                 "SigHarmonics_N": sig_count_summary,
+                "DenomFloor": roi_ratios[0].denom_floor if roi_ratios else None,
+                "N_detected": roi_comp.n_detected,
+                "N_base_valid": n_base_valid,
+                "N_outliers_excluded": n_outlier_excluded,
+                "N_floor_excluded": n_floor_excluded,
+                "N_used": n_used,
                 "N": n,
                 "Mean": mean,
                 "Median": median,
                 "Std": std,
                 "Variance": variance,
                 "CV%": cv if np.isfinite(cv) else np.nan,
+                "MeanRatio_fromLog": mean_ratio_from_log if np.isfinite(mean_ratio_from_log) else np.nan,
+                "MedianRatio_fromLog": median_ratio_from_log if np.isfinite(median_ratio_from_log) else np.nan,
                 "Min": min_val,
                 "Max": max_val,
+                "MinRatio": min_ratio,
+                "MaxRatio": max_ratio,
             }
         )
         rows.append({})
@@ -590,20 +774,34 @@ def _build_output_frame(
         "SummaryA",
         "SummaryB",
         "Ratio",
+        "LogRatio",
+        "RatioPercent",
         "MetricUsed",
         "SkipReason",
+        "IncludedInSummary",
         "OutlierFlag",
         "OutlierMethod",
         "OutlierScore",
+        "ExcludedAsOutlier",
         "SigHarmonics_N",
+        "DenomFloor",
+        "N_detected",
+        "N_base_valid",
+        "N_outliers_excluded",
+        "N_floor_excluded",
+        "N_used",
         "N",
         "Mean",
         "Median",
         "Std",
         "Variance",
         "CV%",
+        "MeanRatio_fromLog",
+        "MedianRatio_fromLog",
         "Min",
         "Max",
+        "MinRatio",
+        "MaxRatio",
     ]
     return pd.DataFrame(rows, columns=columns)
 

--- a/tests/test_ratio_calculator_rules.py
+++ b/tests/test_ratio_calculator_rules.py
@@ -1,0 +1,196 @@
+import os
+from math import isclose
+from pathlib import Path
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from tests.test_ratio_calculator_smoke import _make_inputs, _write_participant_file
+
+from Tools.Ratio_Calculator.PySide6.controller import RatioCalculatorController
+from Tools.Ratio_Calculator.PySide6.view import RatioCalculatorWindow
+
+
+def _setup_tool(tmp_path, qtbot, monkeypatch):
+    class FakeSettingsManager:
+        def get_roi_pairs(self):
+            return [("Bilateral OT", ["O1", "O2"])]
+
+    monkeypatch.setattr("Main_App.SettingsManager", lambda *_, **__: FakeSettingsManager())
+    monkeypatch.setattr(
+        "Tools.Ratio_Calculator.PySide6.controller.SettingsManager",
+        lambda *_, **__: FakeSettingsManager(),
+    )
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "project.json").write_text("{}")
+
+    excel_root = project_root / "1 - Excel Data Files"
+    cond_a_dir = excel_root / "ConditionA"
+    cond_b_dir = excel_root / "ConditionB"
+    cond_a_dir.mkdir(parents=True)
+    cond_b_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(project_root)
+    view = RatioCalculatorWindow()
+    qtbot.addWidget(view)
+    controller = RatioCalculatorController(view)
+    return project_root, excel_root, cond_a_dir, cond_b_dir, view, controller
+
+
+def test_logratio_and_ratio_percent(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    _write_participant_file(
+        cond_a_dir / "P01_A.xlsx",
+        snr_values=[[4.0, 4.0, 4.0]] * 3,
+        z_values=[[3.0, 3.0, 3.0]] * 3,
+    )
+    _write_participant_file(
+        cond_b_dir / "P01_B.xlsx",
+        snr_values=[[2.0, 2.0, 2.0]] * 3,
+        z_values=[[3.0, 3.0, 3.0]] * 3,
+    )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    participant = df[df["PID"] == "P01"].iloc[0]
+    assert isclose(participant["Ratio"], 2.0, rel_tol=1e-6)
+    assert isclose(participant["LogRatio"], np.log(2.0), rel_tol=1e-6)
+    assert isclose(participant["RatioPercent"], 100.0, rel_tol=1e-6)
+
+
+def test_summary_stats_on_logratio(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    ratios = {"P01": 2.0, "P02": 4.0}
+    for pid, ratio in ratios.items():
+        cond_a_vals = [2.0 * ratio] * 3
+        cond_b_vals = [2.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    summary_row = df[df["PID"] == "SUMMARY"].iloc[0]
+    expected_logs = [np.log(r) for r in ratios.values()]
+    assert isclose(summary_row["Mean"], float(np.mean(expected_logs)), rel_tol=1e-6)
+    assert isclose(summary_row["MeanRatio_fromLog"], float(np.exp(np.mean(expected_logs))), rel_tol=1e-6)
+
+
+def test_minimum_harmonics_rule(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    _write_participant_file(
+        cond_a_dir / "P01_A.xlsx",
+        snr_values=[[4.0, 4.0]] * 3,
+        z_values=[[3.0, 3.0]] * 3,
+    )
+    _write_participant_file(
+        cond_b_dir / "P01_B.xlsx",
+        snr_values=[[2.0, 2.0]] * 3,
+        z_values=[[3.0, 3.0]] * 3,
+    )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    summary_row = df[df["PID"] == "SUMMARY"].iloc[0]
+    assert summary_row["N_used"] == 0
+    assert summary_row["SkipReason"] == "insufficient_sig_harmonics"
+
+
+def test_denominator_floor_quantile(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    values = {"P01": [4.0, 4.0, 4.0], "P02": [4.0, 4.0, 4.0]}
+    summary_b_values = {"P01": [1.0, 1.0, 1.0], "P02": [4.0, 4.0, 4.0]}
+    for pid in values:
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[values[pid]] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[summary_b_values[pid]] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    view.denom_floor_checkbox.setChecked(True)
+    view.denom_floor_quantile_spin.setValue(0.25)
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    p01_row = df[df["PID"] == "P01"].iloc[0]
+    summary_row = df[df["PID"] == "SUMMARY"].iloc[0]
+    assert p01_row["SkipReason"] == "denom_below_floor"
+    assert p01_row["IncludedInSummary"] is False
+    assert p01_row["DenomFloor"] > 1.0
+    assert summary_row["N_floor_excluded"] == 1
+    assert summary_row["N_used"] == 1
+
+
+def test_outlier_exclusion_counts(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    ratios = {"P01": 1.0, "P02": 1.1, "P03": 1.2, "P04": 1.05, "P05": 5.0}
+    for pid, ratio in ratios.items():
+        cond_a_vals = [2.0 * ratio] * 3
+        cond_b_vals = [2.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    view.outlier_checkbox.setChecked(True)
+    view.outlier_action_combo.setCurrentIndex(view.outlier_action_combo.findData("exclude"))
+    inputs = _make_inputs(
+        view,
+        controller,
+        excel_root,
+        "Bilateral OT",
+        outlier_enabled=True,
+        outlier_action="exclude",
+    )
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    p05_row = df[df["PID"] == "P05"].iloc[0]
+    summary_row = df[df["PID"] == "SUMMARY"].iloc[0]
+    assert p05_row["OutlierFlag"] is True
+    assert p05_row["ExcludedAsOutlier"] is True
+    assert summary_row["N_outliers_excluded"] == 1
+    assert summary_row["N_used"] == 4


### PR DESCRIPTION
## Summary
- add advanced controls for summary metric selection, minimum harmonics, denominator stability floor, and expanded outlier handling
- compute log-ratio-first summaries with QC counts, ratio percent, and new export columns while keeping raw ratios available
- document the new rules and add pytest coverage for log ratios, harmonics threshold, denominator floors, and outlier exclusion

## Testing
- python -m pytest tests/test_ratio_calculator_smoke.py tests/test_ratio_calculator_rules.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e1b8e570832cb4ecd42558fba9a0)