### PR TITLE
Add trimmed ROI summaries and summary dialog to Ratio Calculator

### DIFF
--- a/src/Tools/Ratio_Calculator/PySide6/README.md
+++ b/src/Tools/Ratio_Calculator/PySide6/README.md
@@ -50,10 +50,10 @@ The Ratio Calculator computes ROI-level SNR ratios between two conditions from a
 ## Output
 - Default output folder: `4 - Ratio Calculator Results` under the active project root (auto-created). You can override the folder and filename; `.xlsx` is appended automatically.
 - Single-sheet Excel export formatted via `_auto_format_and_write_excel(...)` in a **vertical layout**:
-  - Columns: Ratio Label, PID, SNR_A, SNR_B, SummaryA, SummaryB, Ratio, LogRatio, RatioPercent, MetricUsed, SkipReason, IncludedInSummary, OutlierFlag, OutlierMethod, OutlierScore, ExcludedAsOutlier, SigHarmonics_N, DenomFloor, N_detected, N_base_valid, N_outliers_excluded, N_floor_excluded, N_used, N, Mean, Median, Std, Variance, CV%, MeanRatio_fromLog, MedianRatio_fromLog, Min, Max, MinRatio, MaxRatio.
-  - Participant rows list each PID with ROI summaries for the chosen metric (`SummaryA`/`SummaryB`) alongside legacy SNR columns and QC flags.
-  - SUMMARY rows appear after each ROI block with per-ROI statistics, QC counts, and interpretability helpers (`MeanRatio_fromLog`, `MedianRatio_fromLog`).
-  - Outliers (if enabled) are flagged per participant; exclusions are tracked separately from skip reasons.
+  - Columns: Ratio Label, PID, **metric-specific Summary columns** (`SNR_A`/`SNR_B` or `BCA_A`/`BCA_B`), SummaryA, SummaryB, Ratio, LogRatio, RatioPercent, MetricUsed, SkipReason, IncludedInSummary, OutlierFlag, OutlierMethod, OutlierScore, ExcludedAsOutlier, SigHarmonics_N, DenomFloor, N_detected, N_base_valid, N_outliers_excluded, N_floor_excluded, N_used, N, N_used_untrimmed, N_used_trimmed, N_trimmed_excluded, Mean, Median, Std, Variance, CV%, MeanRatio_fromLog, MedianRatio_fromLog, Min, Max, MinRatio, MaxRatio, Mean_trim, Median_trim, Std_trim, Variance_trim, gCV%_trim, MeanRatio_fromLog_trim, MedianRatio_fromLog_trim, MinRatio_trim, MaxRatio_trim.
+  - Participant rows list each PID with ROI summaries for the chosen metric (`SummaryA`/`SummaryB`) alongside metric-specific columns and QC flags.
+  - SUMMARY rows appear after each ROI block with per-ROI statistics and QC counts; **SUMMARY_TRIMMED** rows follow immediately and exclude the single highest and lowest LogRatio before recomputing stats.
+  - Outliers (if enabled) are flagged per participant; exclusions are tracked separately from skip reasons and surfaced in the post-run summary dialog.
 
 ## Skip rules and warnings
 - Missing condition files for a participant.

--- a/src/Tools/Ratio_Calculator/PySide6/model.py
+++ b/src/Tools/Ratio_Calculator/PySide6/model.py
@@ -46,3 +46,5 @@ class RatioCalcResult:
     summary_counts: dict[str, object]
     output_path: Path
     output_folder: Path
+    summary_table: list[dict[str, object]] | None = None
+    exclusions: list[dict[str, object]] | None = None

--- a/src/Tools/Ratio_Calculator/PySide6/summary_dialog.py
+++ b/src/Tools/Ratio_Calculator/PySide6/summary_dialog.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from PySide6.QtCore import Qt, QUrl
+from PySide6.QtGui import QDesktopServices, QGuiApplication
+from PySide6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+
+class RatioSummaryDialog(QDialog):
+    def __init__(
+        self,
+        summary_table: list[dict[str, object]] | None,
+        exclusions: list[dict[str, object]] | None,
+        results_folder: Path | None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Ratio Summary Report")
+        self._summary_table = summary_table or []
+        self._exclusions = exclusions or []
+        self._results_folder = Path(results_folder) if results_folder else None
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("ROI summary"))
+
+        self.summary_widget = QTableWidget(self)
+        layout.addWidget(self.summary_widget)
+        self._populate_table(
+            self.summary_widget,
+            self._summary_table,
+            [
+                "ROI",
+                "SigHarmonics_N",
+                "N_detected",
+                "N_base_valid",
+                "N_outliers_excluded",
+                "N_floor_excluded",
+                "N_used_untrimmed",
+                "Mean_log",
+                "Median_log",
+                "Std_log",
+                "Variance_log",
+                "gCV%",
+                "MeanRatio_fromLog",
+                "MedianRatio_fromLog",
+                "MinRatio",
+                "MaxRatio",
+                "N_used_trimmed",
+                "N_trimmed_excluded",
+                "Mean_log_trim",
+                "Median_log_trim",
+                "Std_log_trim",
+                "Variance_log_trim",
+                "gCV%_trim",
+                "MeanRatio_fromLog_trim",
+                "MedianRatio_fromLog_trim",
+                "MinRatio_trim",
+                "MaxRatio_trim",
+            ],
+        )
+
+        layout.addWidget(QLabel("Excluded participants"))
+        self.exclusions_widget = QTableWidget(self)
+        layout.addWidget(self.exclusions_widget)
+        self._populate_table(self.exclusions_widget, self._exclusions, ["ROI", "PID", "Reason"])
+
+        btn_row = QHBoxLayout()
+        self.copy_btn = QPushButton("Copy", self)
+        self.copy_btn.clicked.connect(self._copy_to_clipboard)
+        btn_row.addWidget(self.copy_btn)
+
+        self.save_btn = QPushButton("Save…", self)
+        self.save_btn.clicked.connect(self._save_summary)
+        btn_row.addWidget(self.save_btn)
+
+        self.open_btn = QPushButton("Open folder", self)
+        self.open_btn.clicked.connect(self._open_results_folder)
+        btn_row.addWidget(self.open_btn)
+
+        btn_row.addStretch(1)
+        close_btn = QPushButton("Close", self)
+        close_btn.clicked.connect(self.close)
+        btn_row.addWidget(close_btn)
+
+        layout.addLayout(btn_row)
+
+        self.resize(900, 600)
+
+    def _populate_table(self, table: QTableWidget, data: list[dict[str, object]], columns: list[str]) -> None:
+        if not data:
+            table.setRowCount(0)
+            table.setColumnCount(len(columns))
+            table.setHorizontalHeaderLabels(columns)
+            return
+        frame = pd.DataFrame(data)
+        available_cols = [col for col in columns if col in frame.columns]
+        remaining = [col for col in frame.columns if col not in available_cols]
+        all_columns = available_cols + remaining
+        table.setColumnCount(len(all_columns))
+        table.setHorizontalHeaderLabels(all_columns)
+        table.setRowCount(len(frame))
+        for row_idx, (_, series) in enumerate(frame[all_columns].iterrows()):
+            for col_idx, value in enumerate(series):
+                table.setItem(row_idx, col_idx, QTableWidgetItem(self._format_value(value)))
+        table.resizeColumnsToContents()
+
+    @staticmethod
+    def _format_value(value: object) -> str:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return ""
+        if isinstance(value, float):
+            return f"{value:.4f}"
+        return str(value)
+
+    def _copy_to_clipboard(self) -> None:
+        clipboard = QGuiApplication.clipboard()
+        parts: list[str] = []
+        if self._summary_table:
+            summary_df = pd.DataFrame(self._summary_table)
+            parts.append(summary_df.to_csv(index=False))
+        if self._exclusions:
+            exclusions_df = pd.DataFrame(self._exclusions)
+            parts.append("Exclusions\n" + exclusions_df.to_csv(index=False))
+        clipboard.setText("\n".join(parts) if parts else "")
+
+    def _save_summary(self) -> None:
+        default_dir = str(self._results_folder) if self._results_folder else ""
+        default_name = "ratio_summary_report.csv"
+        initial_path = str(Path(default_dir) / default_name) if default_dir else default_name
+        path_str, selected_filter = QFileDialog.getSaveFileName(
+            self,
+            "Save summary",
+            initial_path,
+            "CSV Files (*.csv);;Text Files (*.txt)",
+        )
+        if not path_str:
+            return
+        target = Path(path_str)
+        if not target.suffix:
+            target = target.with_suffix(".csv")
+        try:
+            self._write_summary_file(target, selected_filter)
+        except Exception as exc:  # noqa: BLE001
+            QMessageBox.warning(self, "Save failed", f"Could not save summary: {exc}")
+
+    def _write_summary_file(self, path: Path, selected_filter: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        summary_df = pd.DataFrame(self._summary_table)
+        exclusion_df = pd.DataFrame(self._exclusions)
+        if selected_filter.startswith("Text") or path.suffix.lower() == ".txt":
+            content = ""
+            if not summary_df.empty:
+                content += summary_df.to_string(index=False)
+            if not exclusion_df.empty:
+                content += "\n\nExclusions\n" + exclusion_df.to_string(index=False)
+            path.write_text(content, encoding="utf-8")
+            return
+
+        with path.open("w", encoding="utf-8") as handle:
+            if not summary_df.empty:
+                summary_df.to_csv(handle, index=False)
+            if not exclusion_df.empty:
+                handle.write("\nExclusions\n")
+                exclusion_df.to_csv(handle, index=False)
+
+    def _open_results_folder(self) -> None:
+        if not self._results_folder:
+            QMessageBox.information(self, "Results folder", "Results folder not available.")
+            return
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(self._results_folder)))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package marker for reliable intra-test imports.

--- a/tests/test_ratio_calculator_smoke.py
+++ b/tests/test_ratio_calculator_smoke.py
@@ -120,7 +120,7 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
     assert output_path.exists()
     assert output_path.parent == project_root / "4 - Ratio Calculator Results"
     df = result.dataframe
-    assert list(df.columns) == [
+    expected_columns = [
         "Ratio Label",
         "PID",
         "SNR_A",
@@ -145,6 +145,9 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
         "N_floor_excluded",
         "N_used",
         "N",
+        "N_used_untrimmed",
+        "N_used_trimmed",
+        "N_trimmed_excluded",
         "Mean",
         "Median",
         "Std",
@@ -156,10 +159,20 @@ def test_ratio_calculator_smoke(tmp_path, qtbot, monkeypatch):
         "Max",
         "MinRatio",
         "MaxRatio",
+        "Mean_trim",
+        "Median_trim",
+        "Std_trim",
+        "Variance_trim",
+        "gCV%_trim",
+        "MeanRatio_fromLog_trim",
+        "MedianRatio_fromLog_trim",
+        "MinRatio_trim",
+        "MaxRatio_trim",
     ]
+    assert list(df.columns) == expected_columns
     roi_rows = df[df["Ratio Label"].str.contains("Bilateral OT", na=False)]
     assert not roi_rows.empty
-    participant_rows = roi_rows[roi_rows["PID"] != "SUMMARY"]
+    participant_rows = roi_rows[~roi_rows["PID"].isin(["SUMMARY", "SUMMARY_TRIMMED"])]
     assert len(participant_rows) >= 1
     assert (participant_rows["SigHarmonics_N"] > 0).any()
     summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]

--- a/tests/test_ratio_calculator_summary.py
+++ b/tests/test_ratio_calculator_summary.py
@@ -1,0 +1,136 @@
+import os
+from math import isclose
+import numpy as np
+import pandas as pd
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from tests.test_ratio_calculator_rules import _setup_tool
+from tests.test_ratio_calculator_smoke import _make_inputs, _write_participant_file
+
+
+def test_trimmed_summary_excludes_extremes(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    log_values = np.array([-0.2, 0.0, 0.5, 1.0, 1.5])
+    for idx, log_val in enumerate(log_values, start=1):
+        ratio = float(np.exp(log_val))
+        pid = f"P{idx:02d}"
+        cond_a_vals = [ratio] * 3
+        cond_b_vals = [1.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    trimmed_row = df[(df["PID"] == "SUMMARY_TRIMMED") & df["Ratio Label"].str.contains("Bilateral OT", na=False)].iloc[0]
+    trimmed_expected = np.sort(log_values)[1:-1]
+    assert trimmed_row["N_used_trimmed"] == len(trimmed_expected)
+    assert trimmed_row["N_trimmed_excluded"] == 2
+    assert isclose(float(trimmed_row["Mean"]), float(trimmed_expected.mean()), rel_tol=1e-6)
+    assert isclose(float(trimmed_row["Median"]), float(np.median(trimmed_expected)), rel_tol=1e-6)
+
+
+def test_trimmed_summary_with_small_sample_returns_na(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    for idx in range(2):
+        pid = f"P{idx+1:02d}"
+        cond_a_vals = [1.5] * 3
+        cond_b_vals = [1.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    trimmed_row = df[(df["PID"] == "SUMMARY_TRIMMED") & df["Ratio Label"].str.contains("Bilateral OT", na=False)].iloc[0]
+    assert trimmed_row["N_used_trimmed"] == 0
+    assert trimmed_row["N_trimmed_excluded"] == 0
+    assert pd.isna(trimmed_row["Mean"])
+    assert pd.isna(trimmed_row["MeanRatio_fromLog_trim"])
+
+
+def test_metric_headers_switch_for_bca(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    for pid in ("P01", "P02", "P03"):
+        cond_a_vals = [3.0] * 3
+        cond_b_vals = [1.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+            bca_values=[cond_a_vals] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+            bca_values=[cond_b_vals] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    view.metric_combo.setCurrentIndex(view.metric_combo.findData("bca"))
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    columns = list(result.dataframe.columns)
+    assert "BCA_A" in columns
+    assert "BCA_B" in columns
+    assert "SNR_A" not in columns
+    assert "SNR_B" not in columns
+
+
+def test_summary_dialog_builds_without_crashing(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    for pid in ("P01", "P02", "P03"):
+        cond_a_vals = [2.0] * 3
+        cond_b_vals = [1.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    view.handle_result(result)
+    dialog = view._summary_dialog
+    assert dialog is not None
+    qtbot.addWidget(dialog)
+    qtbot.waitUntil(dialog.isVisible)
+    dialog.close()


### PR DESCRIPTION
## Summary
- compute trimmed ROI summary rows with log-ratio statistics, geometric CV, and metric-aware summary column headers
- add a post-run Ratio Summary Report dialog to review summaries, exclusions, copy to clipboard, and save/open the results folder
- expand tests for trimming rules, metric headers, dialog creation, and update smoke expectations

## Testing
- `LD_LIBRARY_PATH=/tmp/libgl1/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH pytest -q tests/test_ratio_calculator_summary.py tests/test_ratio_calculator_rules.py tests/test_ratio_calculator_smoke.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fdd65ad4832c924fe577264847f8)