### PR TITLE
Add regression pytest for Ratio Calculator worker (smoke test + fixtures)

### DIFF
--- a/tests/_ratio_calc_fixtures.py
+++ b/tests/_ratio_calc_fixtures.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+
+def _sheet_frame(
+    electrodes: Sequence[str],
+    freqs: Sequence[str],
+    values: Sequence[Sequence[float | int | None]],
+) -> pd.DataFrame:
+    data: dict[str, list[float | int | None]] = {"Electrode": list(electrodes)}
+    for idx, freq in enumerate(freqs):
+        data[freq] = [row[idx] for row in values]
+    return pd.DataFrame(data)
+
+
+def write_ratio_workbook(
+    path: Path,
+    electrodes: Iterable[str],
+    freqs: Iterable[str],
+    z_values: Sequence[Sequence[float | int | None]],
+    snr_values: Sequence[Sequence[float | int | None]],
+    bca_values: Sequence[Sequence[float | int | None]],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    electrodes_list = list(electrodes)
+    freqs_list = list(freqs)
+    with pd.ExcelWriter(path) as writer:
+        _sheet_frame(electrodes_list, freqs_list, z_values).to_excel(
+            writer,
+            sheet_name="Z Score",
+            index=False,
+        )
+        _sheet_frame(electrodes_list, freqs_list, snr_values).to_excel(
+            writer,
+            sheet_name="SNR",
+            index=False,
+        )
+        _sheet_frame(electrodes_list, freqs_list, bca_values).to_excel(
+            writer,
+            sheet_name="BCA (uV)",
+            index=False,
+        )

--- a/tests/test_ratio_calc_worker_smoke.py
+++ b/tests/test_ratio_calc_worker_smoke.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from Tools.Ratio_Calculator.PySide6.model import RatioCalcInputs
+from Tools.Ratio_Calculator.PySide6.worker import compute_ratios
+from Tools.Stats.roi_resolver import ROI
+
+from tests._ratio_calc_fixtures import write_ratio_workbook
+
+
+def test_compute_ratios_smoke(monkeypatch, tmp_path: Path) -> None:
+    electrodes = ["F3", "F4"]
+    freqs = ["1.2000_Hz", "2.4000_Hz"]
+    roi = ROI(name="Frontal", channels=electrodes)
+    participants = [f"P{idx:02d}" for idx in range(1, 7)]
+    conditions = ["condA", "condB"]
+    subject_data: dict[str, dict[str, str]] = {}
+
+    for idx, pid in enumerate(participants, start=1):
+        cond_files: dict[str, str] = {}
+        for cond in conditions:
+            file_path = tmp_path / f"{pid}_{cond}.xlsx"
+            base = float(idx)
+            z_values = [[5.0, 5.0], [5.0, 5.0]]
+            snr_values = [[base, base + 1], [base + 2, base + 3]]
+            if pid == "P06" and cond == "condB":
+                bca_values = [[0.0, 0.0], [0.0, 0.0]]
+            else:
+                bca_values = [[base + 1, base + 2], [base + 3, base + 4]]
+            write_ratio_workbook(file_path, electrodes, freqs, z_values, snr_values, bca_values)
+            cond_files[cond] = str(file_path)
+        subject_data[pid] = cond_files
+
+    def fake_scan_folder(_root: str):
+        return participants, conditions, subject_data
+
+    monkeypatch.setattr(
+        "Tools.Ratio_Calculator.PySide6.worker.scan_folder_simple",
+        fake_scan_folder,
+    )
+
+    inputs = RatioCalcInputs(
+        excel_root=tmp_path,
+        cond_a="condA",
+        cond_b="condB",
+        roi_name=None,
+        z_threshold=1.0,
+        output_path=tmp_path / "ratio_output.xlsx",
+        significance_mode="group",
+        rois=[roi],
+        metric="bca",
+        outlier_enabled=False,
+        outlier_method="mad",
+        outlier_threshold=3.5,
+        outlier_action="exclude",
+        bca_negative_mode="strict",
+        min_significant_harmonics=1,
+        denominator_floor_enabled=False,
+        denominator_floor_mode="absolute",
+        denominator_floor_quantile=0.1,
+        denominator_floor_scope="global",
+        denominator_floor_reference="summary_b",
+        denominator_floor_absolute=None,
+        summary_metric="ratio",
+        outlier_metric="summary",
+        require_denom_sig=False,
+    )
+
+    result = compute_ratios(inputs)
+    df = result.dataframe
+
+    ratio_label = f"{inputs.cond_a} vs {inputs.cond_b} - {roi.name}"
+    roi_rows = df[df["Ratio Label"] == ratio_label]
+    assert "SUMMARY" in roi_rows["PID"].values
+
+    summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]
+    detail_rows = roi_rows[roi_rows["PID"].isin(participants)].copy()
+    included_rows = detail_rows[detail_rows["IncludedInSummary"]]
+    summary_metric = pd.to_numeric(included_rows["Ratio"], errors="coerce")
+    expected_variance = float(summary_metric.var(ddof=1))
+    assert summary_row["Variance"] == pytest.approx(expected_variance)
+
+    def _is_base_valid(row: pd.Series) -> bool:
+        summary_a = row["SummaryA"]
+        summary_b = row["SummaryB"]
+        return (
+            pd.notna(summary_a)
+            and pd.notna(summary_b)
+            and summary_b != 0
+        )
+
+    base_valid_by_pid = {row["PID"]: _is_base_valid(row) for _, row in detail_rows.iterrows()}
+    included_by_pid = dict(zip(detail_rows["PID"], detail_rows["IncludedInSummary"]))
+    assert included_by_pid == base_valid_by_pid


### PR DESCRIPTION
### Motivation
- Provide an automated regression smoke test for the Ratio Calculator core so future math/summary changes are validated.
- Keep production code unchanged; tests must avoid real folder scanning and run off the worker's `compute_ratios()` API.
- Ensure the test data includes required sheets and columns so the core summary/variance logic is exercised (≥6 participants, multi-electrode ROI).

### Description
- Added test fixture helper `tests/_ratio_calc_fixtures.py` with `write_ratio_workbook()` to generate minimal Excel workbooks containing sheets `"Z Score"`, `"SNR"`, and `"BCA (uV)"` and frequency columns like `"1.2000_Hz"`.
- Added smoke test `tests/test_ratio_calc_worker_smoke.py` that:
  - Creates 6 participant workbooks for two conditions (`condA`/`condB`) and one ROI with 2 electrodes.
  - Monkeypatches `Tools.Ratio_Calculator.PySide6.worker.scan_folder_simple` to return the synthetic `participants`, `conditions`, and `subject_data` mapping to avoid real folder scanning.
  - Calls `compute_ratios()` with a `RatioCalcInputs` instance and asserts: presence of a `"SUMMARY"` row, the reported `Variance` equals `pandas.Series.var(ddof=1)` over included rows, and `IncludedInSummary` matches base-valid rules (no missing values and denominator != 0).
- Files added:
  - `tests/_ratio_calc_fixtures.py`
  - `tests/test_ratio_calc_worker_smoke.py`

### Testing
- `pytest -q` (full test suite): FAIL — collection aborted due to missing runtime deps in CI environment (`ModuleNotFoundError: No module named 'PySide6' / 'numpy' / 'pandas'`).
- `pytest -q tests/test_ratio_calc_worker_smoke.py`: FAIL — collection failed here due to missing `pandas` in the environment (the test itself depends on `pandas`).
- `ruff check .`: FAIL — repository contains existing lint issues unrelated to these new tests; see project lint output for details. `ruff` run limited to the two new files: `ruff check tests/test_ratio_calc_worker_smoke.py tests/_ratio_calc_fixtures.py` => PASS.
- Byte-compile checks: `python -m compileall` for the new tests and the Ratio_Calculator/Stats modules succeeded (sanity compile passed).

If you want me to: (a) vendor minimal test-only requirements into the test environment or (b) adjust test imports to avoid `pandas`/`numpy` (not recommended because the code under test depends on them), I can prepare that change. The two new test files are committed and ready; running the smoke test in an environment with `pandas`, `numpy`, and `PySide6` available should produce a passing test for the assertions described.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455e9058cc832ca08a136227239f5d)