### PR TITLE
Compute significant harmonics separately for Condition A and B and expose SigHarmonicsA_N / SigHarmonicsB_N

### DIFF
--- a/tests/test_ratio_calc_worker_smoke.py
+++ b/tests/test_ratio_calc_worker_smoke.py
@@ -96,3 +96,84 @@ def test_compute_ratios_smoke(monkeypatch, tmp_path: Path) -> None:
     base_valid_by_pid = {row["PID"]: _is_base_valid(row) for _, row in detail_rows.iterrows()}
     included_by_pid = dict(zip(detail_rows["PID"], detail_rows["IncludedInSummary"]))
     assert included_by_pid == base_valid_by_pid
+
+
+def test_compute_ratios_condition_specific_sig_harmonics(monkeypatch, tmp_path: Path) -> None:
+    electrodes = ["F3", "F4"]
+    freqs = ["1.2000_Hz", "2.4000_Hz", "3.6000_Hz", "4.8000_Hz"]
+    roi = ROI(name="Frontal", channels=electrodes)
+    participants = ["P01"]
+    conditions = ["condA", "condB"]
+    subject_data: dict[str, dict[str, str]] = {}
+
+    for pid in participants:
+        cond_files: dict[str, str] = {}
+        for cond in conditions:
+            file_path = tmp_path / f"{pid}_{cond}.xlsx"
+            if cond == "condA":
+                z_values = [[5.0, 5.0, 0.0, 0.0], [5.0, 5.0, 0.0, 0.0]]
+                snr_values = [[10.0, 20.0, 30.0, 40.0], [10.0, 20.0, 30.0, 40.0]]
+            else:
+                z_values = [[5.0, 0.0, 5.0, 5.0], [5.0, 0.0, 5.0, 5.0]]
+                snr_values = [[5.0, 15.0, 25.0, 35.0], [5.0, 15.0, 25.0, 35.0]]
+            bca_values = [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
+            write_ratio_workbook(file_path, electrodes, freqs, z_values, snr_values, bca_values)
+            cond_files[cond] = str(file_path)
+        subject_data[pid] = cond_files
+
+    def fake_scan_folder(_root: str):
+        return participants, conditions, subject_data
+
+    monkeypatch.setattr(
+        "Tools.Ratio_Calculator.PySide6.worker.scan_folder_simple",
+        fake_scan_folder,
+    )
+
+    inputs = RatioCalcInputs(
+        excel_root=tmp_path,
+        cond_a="condA",
+        cond_b="condB",
+        roi_name=None,
+        z_threshold=1.0,
+        output_path=tmp_path / "ratio_output.xlsx",
+        significance_mode="group",
+        rois=[roi],
+        metric="snr",
+        outlier_enabled=False,
+        outlier_method="mad",
+        outlier_threshold=3.5,
+        outlier_action="exclude",
+        bca_negative_mode="strict",
+        min_significant_harmonics=2,
+        denominator_floor_enabled=False,
+        denominator_floor_mode="absolute",
+        denominator_floor_quantile=0.1,
+        denominator_floor_scope="global",
+        denominator_floor_reference="summary_b",
+        denominator_floor_absolute=None,
+        summary_metric="ratio",
+        outlier_metric="summary",
+        require_denom_sig=False,
+    )
+
+    result = compute_ratios(inputs)
+    df = result.dataframe
+
+    ratio_label = f"{inputs.cond_a} vs {inputs.cond_b} - {roi.name}"
+    roi_rows = df[df["Ratio Label"] == ratio_label]
+    detail_row = roi_rows[roi_rows["PID"] == participants[0]].iloc[0]
+
+    assert detail_row["SigHarmonicsA_N"] != detail_row["SigHarmonicsB_N"]
+    assert detail_row["SigHarmonicsA_N"] == 2
+    assert detail_row["SigHarmonicsB_N"] == 3
+
+    summary_row = roi_rows[roi_rows["PID"] == "SUMMARY"].iloc[0]
+    assert summary_row["SigHarmonicsA_N"] == 2
+    assert summary_row["SigHarmonicsB_N"] == 3
+
+    expected_summary_a = 15.0
+    expected_summary_b = (5.0 + 25.0 + 35.0) / 3.0
+    assert detail_row["SummaryA"] == pytest.approx(expected_summary_a)
+    assert detail_row["SummaryB"] == pytest.approx(expected_summary_b)
+    assert detail_row["Ratio"] == pytest.approx(expected_summary_a / expected_summary_b)
+    assert detail_row["Ratio"] < 1.0


### PR DESCRIPTION
### Motivation
- Fix a bug where significant harmonics were determined from Condition A Z-scores only and then applied to both conditions.
- Ensure summaries for Condition A and Condition B are computed from their own Z-score–derived harmonic sets.
- Enforce the minimum-significant-harmonics requirement for both conditions so rows/ROIs with insufficient harmonics are skipped.
- Make harmonic counts transparent in the output (both per-participant and SUMMARY rows).

### Description
- Added a parameterized Z-score loader ` _load_roi_z_scores_for_files(..., which)` to read `cond_a_file` or `cond_b_file` (sheet `"Z Score"`) depending on `which`.
- In `compute_ratios()` the code now loads `z_scores_a` and `z_scores_b` and computes `sig_freqs_a` / `sig_freqs_b` in both `group` and `individual` significance modes.
- Refactored `_compute_ratio_table()` to accept per-condition frequency sets and per-participant individual sig-freq maps for A and B. Summaries are computed using `freqs_a` for SummaryA and `freqs_b` for SummaryB. The minimum K (`min_k = max(1, min(50, inputs.min_significant_harmonics))`) is enforced for both conditions.
- Extended the data model and outputs:
  - `RatioRow` now carries `sig_count_a` and `sig_count_b` (and retains `sig_count` which is defined as `min(sig_count_a, sig_count_b)` for participant rows).
  - `RoiComputation` holds `sig_harmonics_group_a` and `sig_harmonics_group_b`.
  - `_result_columns()` now includes `"SigHarmonicsA_N"` and `"SigHarmonicsB_N"`. `SigHarmonics_N` is preserved and populated as `min(A,B)`; SUMMARY rows are populated with A/B counts and SigHarmonics_N = min(A,B).
- Kept public behavior/UI stable where possible; the DataFrame now provides the explicit A/B harmonic counts required for transparency.
- Added a unit test `test_compute_ratios_condition_specific_sig_harmonics` in `tests/test_ratio_calc_worker_smoke.py` that creates synthetic workbooks where A and B select different harmonic sets and asserts different `SigHarmonicsA_N` vs `SigHarmonicsB_N` and matching summary values.

Files changed
- `src/Tools/Ratio_Calculator/PySide6/worker.py` (core logic and output changes)
- `tests/test_ratio_calc_worker_smoke.py` (new test case)

### Testing
- Ran linter: `ruff check .` — FAIL. The repo contains many pre-existing lint violations (unrelated files); ruff output reported multiple E402/F401/E701 etc. The changes do not attempt to fix global linter issues.
- Ran unit tests: `pytest -q` — FAIL during collection in this environment. Test collection failed with `ModuleNotFoundError` for `PySide6`, `numpy`, and `pandas` (these dependencies are required for the test suite and are not present in the execution environment). Example: `ModuleNotFoundError: No module named 'PySide6'` and similar for `numpy`/`pandas`.

Commands run and short outputs
- `ruff check .` — reported many unrelated lint errors across the repository (E402, F401, E701, ...).
- `pytest -q` — collection aborted; errors include missing packages (PySide6/numpy/pandas). Specific summary: "Interrupted: 23 errors during collection" with multiple `ModuleNotFoundError` entries.

If you want, I can:
- Run only the ratio-calculator tests by configuring pytest to select the module (and installing minimal test dependencies), or
- Modify the PR to also ensure `RatioCalcResult` return values/documentation if you prefer the returned `sig_freqs` field to explicitly carry both-condition info (currently `sig_freqs_a` is returned in place of the previous `sig_freqs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694560a46404832c9f875e9dd9dd60a2)