### PR TITLE
Add trimmed 95% CI columns and improve Ratio Calculator Excel formatting

### DIFF
--- a/tests/test_ratio_calculator_summary.py
+++ b/tests/test_ratio_calculator_summary.py
@@ -2,6 +2,7 @@ import os
 from math import isclose
 import numpy as np
 import pandas as pd
+from scipy import stats
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -72,6 +73,56 @@ def test_trimmed_summary_with_small_sample_returns_na(tmp_path, qtbot, monkeypat
     assert trimmed_row["N_trimmed_excluded"] == 0
     assert pd.isna(trimmed_row["Mean"])
     assert pd.isna(trimmed_row["MeanRatio_fromLog_trim"])
+
+
+def test_trimmed_ci_columns_populated(tmp_path, qtbot, monkeypatch):
+    project_root, excel_root, cond_a_dir, cond_b_dir, view, controller = _setup_tool(tmp_path, qtbot, monkeypatch)
+
+    log_values = np.array([-0.3, 0.1, 0.4, 0.8, 1.2])
+    for idx, log_val in enumerate(log_values, start=1):
+        ratio = float(np.exp(log_val))
+        pid = f"P{idx:02d}"
+        cond_a_vals = [ratio] * 3
+        cond_b_vals = [1.0] * 3
+        _write_participant_file(
+            cond_a_dir / f"{pid}_A.xlsx",
+            snr_values=[cond_a_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+        _write_participant_file(
+            cond_b_dir / f"{pid}_B.xlsx",
+            snr_values=[cond_b_vals] * 3,
+            z_values=[[3.0, 3.0, 3.0]] * 3,
+        )
+
+    controller.set_excel_root(excel_root)
+    view.cond_b_combo.setCurrentText("ConditionB")
+    view.roi_combo.setCurrentText("Bilateral OT")
+    inputs = _make_inputs(view, controller, excel_root, "Bilateral OT")
+    result = controller.compute_ratios_sync(inputs)
+    df = result.dataframe
+    assert "Mean_CI_low_trim" in df.columns
+    assert "Mean_CI_high_trim" in df.columns
+    assert "GMR_CI_low_trim" in df.columns
+    assert "GMR_CI_high_trim" in df.columns
+
+    trimmed_row = df[(df["PID"] == "SUMMARY_TRIMMED") & df["Ratio Label"].str.contains("Bilateral OT", na=False)].iloc[0]
+    summary_row = df[(df["PID"] == "SUMMARY") & df["Ratio Label"].str.contains("Bilateral OT", na=False)].iloc[0]
+    trimmed_vals = np.sort(log_values)[1:-1]
+    tcrit = stats.t.ppf(0.975, df=len(trimmed_vals) - 1)
+    mean = float(trimmed_vals.mean())
+    std = float(trimmed_vals.std(ddof=1))
+    se = std / np.sqrt(len(trimmed_vals))
+    expected_low = mean - tcrit * se
+    expected_high = mean + tcrit * se
+    assert isclose(float(trimmed_row["Mean_CI_low_trim"]), expected_low, rel_tol=1e-6)
+    assert isclose(float(trimmed_row["Mean_CI_high_trim"]), expected_high, rel_tol=1e-6)
+    assert isclose(float(trimmed_row["GMR_CI_low_trim"]), float(np.exp(expected_low)), rel_tol=1e-6)
+    assert isclose(float(trimmed_row["GMR_CI_high_trim"]), float(np.exp(expected_high)), rel_tol=1e-6)
+    assert pd.isna(summary_row["Mean_CI_low_trim"])
+    assert pd.isna(summary_row["Mean_CI_high_trim"])
+    assert pd.isna(summary_row["GMR_CI_low_trim"])
+    assert pd.isna(summary_row["GMR_CI_high_trim"])
 
 
 def test_metric_headers_switch_for_bca(tmp_path, qtbot, monkeypatch):


### PR DESCRIPTION
### Motivation
- Provide trimmed 95% confidence intervals for the trimmed log-ratio summary so the exported Ratio Calculator Excel contains CI for the trimmed mean (computed after removing min/max log-ratios).
- Improve readability of the Ratio Calculator worksheet (freeze header, enable filtering, nicer number formats and visual styling for summary rows) without changing any existing numeric computations or inclusion rules.

### Description
- Added four new export columns: `Mean_CI_low_trim`, `Mean_CI_high_trim`, `GMR_CI_low_trim`, `GMR_CI_high_trim`. They are populated only on `PID == "SUMMARY_TRIMMED"` rows; all other rows remain blank/NaN.
- Implemented trimmed CI computation in `Ratio Calculator` via a new helper ` _compute_trimmed_logratio_ci(log_ratio_series, log_func=None)` which:
  - uses the same included participants (the already filtered `log_ratio_series`), returns NaN if there are fewer than 3 finite values,
  - trims the sorted log-ratios by removing min and max, computes sample SD and SE, and forms a two-sided 95% t-interval using `scipy.stats.t.ppf` when available,
  - falls back deterministically to a normal approximation (`1.96`) if SciPy is not available and logs that fallback once.
- Added Excel-only formatting scoped to the Ratio Calculator sheet via `_apply_ratio_calculator_formatting(...)` called after `_auto_format_and_write_excel`. Formatting includes:
  - freeze panes (top row + first 2 identifier columns), auto-filter on header row,
  - column-specific number formats (ratio/logratio: 3 dp, percent: 1 dp, integers 0 dp), auto column widths with padding,
  - conditional styling for `SUMMARY` and `SUMMARY_TRIMMED` rows (bold + distinct fill) applied with conditional formats so values themselves are unchanged.
- Kept all existing summary computations and inclusion/exclusion/outlier logic intact. Updated the DataFrame schema (`_result_columns`) and the place where the trimmed summary row is assembled to include the new columns.
- Files changed: `src/Tools/Ratio_Calculator/PySide6/worker.py` and test `tests/test_ratio_calculator_summary.py` (adds `test_trimmed_ci_columns_populated`).

### Testing
- Ran project linter/formatter checks: `ruff` on the modified files — passed.
- Added `tests/test_ratio_calculator_summary.py::test_trimmed_ci_columns_populated` to validate the four new columns exist and that trimmed CIs match the t-interval computed from trimmed log-ratios.
- Attempted to run `pytest tests/test_ratio_calculator_summary.py` in CI/dev environment but test collection failed due to the environment missing required packages (`ModuleNotFoundError: No module named 'numpy'`). This is an environment dependency issue; the added test itself is deterministic and expects `numpy`/`scipy` to be available. 
- Notes on runtime behavior and edge cases:
  - If SciPy is not importable, the trimmed CI helper logs a one-time message and uses `1.96` for the interval to remain deterministic.
  - For `len(log_ratios) < 3` (or trimmed size < 2) the helper returns NaN, matching the requested edge-case behavior.

If you want, I can (a) add a small unit test for `_compute_trimmed_logratio_ci(...)` that runs without the full Ratio Calculator infrastructure, or (b) adjust the test run configuration to ensure `numpy`/`scipy` are installed in the test environment so the new test can execute in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69456e8d5e6c832cb71c5214e1085036)