### PR TITLE
Fix PsychoPy spelling in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 The Fast Periodic Visual Stimulation (FPVS) Toolbox allows you to easily process
 EEG data from FPVS experiments and run statistical analyses on the resulting
-metrics. As of now, FPVS Toolbox only supports the BioSemi data format (.BDF) and FPVS experiments ran with PyschoPy. 
+metrics. As of now, FPVS Toolbox only supports the BioSemi data format (.BDF) and FPVS experiments ran with PsychoPy. 
 
 **This documentation page is a work in progress and is not yet complete.**
 


### PR DESCRIPTION
## Summary
- correct the spelling of PsychoPy in the documentation

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f186bca0832c9a9346f3fa7eba93)