### PR TITLE
Correct low/high-pass preprocessing wiring and validation

### DIFF
--- a/src/Main_App/PySide6_App/Backend/preprocess.py
+++ b/src/Main_App/PySide6_App/Backend/preprocess.py
@@ -158,8 +158,8 @@ def perform_preprocessing(
 
     # Runtime parameters (defaults are managed by Settings UI; fall back only if absent)
     downsample_rate = params.get("downsample_rate")
-    low_pass = params.get("low_pass")          # legacy mapping: low_pass -> l_freq
-    high_pass = params.get("high_pass")        # legacy mapping: high_pass -> h_freq
+    low_pass = params.get("low_pass")          # low-pass -> h_freq
+    high_pass = params.get("high_pass")        # high-pass -> l_freq
     reject_thresh = params.get("reject_thresh")
     ref1 = params.get("ref_channel1") or "EXG1"
     ref2 = params.get("ref_channel2") or "EXG2"
@@ -403,9 +403,9 @@ def perform_preprocessing(
             )
 
         # 5) FILTER at (possibly reduced) Fs
-        # LEGACY MAPPING: low_pass -> l_freq, high_pass -> h_freq (intentionally inverted names)
-        l_freq = low_pass if (low_pass and low_pass > 0) else None
-        h_freq = high_pass
+        # Mapping: high_pass -> l_freq (HPF), low_pass -> h_freq (LPF)
+        l_freq = high_pass if (high_pass and high_pass > 0) else None
+        h_freq = low_pass
         if l_freq or h_freq:
             try:
                 low_trans_bw, high_trans_bw, filter_len_points = 0.1, 0.1, 8449

--- a/src/Main_App/PySide6_App/Backend/project.py
+++ b/src/Main_App/PySide6_App/Backend/project.py
@@ -115,9 +115,13 @@ class Project:
 
         # Preprocessing dict
         pp = manifest.get("preprocessing", {})
-        self.preprocessing: Dict[str, Any] = normalize_preprocessing_settings(
-            pp if isinstance(pp, Mapping) else {}
-        )
+        try:
+            self.preprocessing: Dict[str, Any] = normalize_preprocessing_settings(
+                pp if isinstance(pp, Mapping) else {}
+            )
+        except ValueError as exc:
+            print(f"[PROJECT] Invalid preprocessing settings in manifest; using defaults: {exc}")
+            self.preprocessing = normalize_preprocessing_settings({})
         manifest["preprocessing"] = {
             key: self.preprocessing[key] for key in PREPROCESSING_CANONICAL_KEYS
         }

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -1146,7 +1146,11 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
         return True
 
     def _build_validated_params(self) -> dict | None:
-        normalized = normalize_preprocessing_settings(self.currentProject.preprocessing)
+        try:
+            normalized = normalize_preprocessing_settings(self.currentProject.preprocessing)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Preprocessing Settings", str(exc))
+            return None
 
         # Event map from UI rows → {label: int_id}
         event_map: dict[str, int] = {}
@@ -1499,7 +1503,11 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
             edit = QLineEdit(str(value) if value is not None else "")
             return _QtEntryAdapter(edit)
 
-        p = normalize_preprocessing_settings(self.currentProject.preprocessing)
+        try:
+            p = normalize_preprocessing_settings(self.currentProject.preprocessing)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Preprocessing Settings", str(exc))
+            p = normalize_preprocessing_settings({})
         self.low_pass_entry = make_entry(p.get("low_pass"))
         self.high_pass_entry = make_entry(p.get("high_pass"))
         self.downsample_entry = make_entry(p.get("downsample"))

--- a/src/Main_App/PySide6_App/utils/audit.py
+++ b/src/Main_App/PySide6_App/utils/audit.py
@@ -147,7 +147,7 @@ def compare_preproc(
             )
 
     # High-pass check
-    target_hp = _to_float(params.get("low_pass"))
+    target_hp = _to_float(params.get("high_pass"))
     if target_hp and target_hp > 0:
         actual_hp = _to_float(after.get("highpass"))
         if actual_hp is None or abs(actual_hp - target_hp) > 0.1:
@@ -156,7 +156,7 @@ def compare_preproc(
             )
 
     # Low-pass check
-    target_lp = _to_float(params.get("high_pass"))
+    target_lp = _to_float(params.get("low_pass"))
     if target_lp and target_lp > 0:
         actual_lp = _to_float(after.get("lowpass"))
         if actual_lp is None or abs(actual_lp - target_lp) > 0.1:

--- a/tests/test_fif_flag_audit.py
+++ b/tests/test_fif_flag_audit.py
@@ -1,6 +1,6 @@
-import numpy as np
 import pytest
 
+np = pytest.importorskip("numpy")
 pytest.importorskip("PySide6")
 mne = pytest.importorskip("mne")
 
@@ -29,8 +29,8 @@ def test_fif_flag_audit_reports_zero(tmp_path):
     params = {
         "downsample": 256,
         "downsample_rate": 256,
-        "low_pass": 0.0,
-        "high_pass": 50.0,
+        "low_pass": 50.0,
+        "high_pass": 0.1,
         "reject_thresh": 0.0,
         "ref_channel1": "EXG1",
         "ref_channel2": "EXG2",

--- a/tests/test_gui_preproc_dialog.py
+++ b/tests/test_gui_preproc_dialog.py
@@ -19,8 +19,8 @@ def _prep_project(root):
     project = Project.load(proj_root)
     project.update_preprocessing(
         {
-            "low_pass": 0.25,
-            "high_pass": 45.0,
+            "low_pass": 45.0,
+            "high_pass": 0.25,
             "downsample": 512,
             "rejection_z": 4.0,
             "epoch_start_s": -0.25,

--- a/tests/test_preproc_audit.py
+++ b/tests/test_preproc_audit.py
@@ -1,6 +1,6 @@
-import numpy as np
 import pytest
 
+np = pytest.importorskip("numpy")
 pytest.importorskip("PySide6")
 mne = pytest.importorskip("mne")
 
@@ -31,8 +31,8 @@ def test_preproc_audit_round_trip():
     params = {
         "downsample": 256,
         "downsample_rate": 256,
-        "low_pass": 0.1,
-        "high_pass": 50.0,
+        "low_pass": 50.0,
+        "high_pass": 0.1,
         "reject_thresh": 3.0,
         "ref_channel1": "EXG1",
         "ref_channel2": "EXG2",

--- a/tests/test_preproc_persistence.py
+++ b/tests/test_preproc_persistence.py
@@ -17,8 +17,8 @@ def test_normalization_and_roundtrip(tmp_path):
         json.dumps(
             {
                 "preprocessing": {
-                    "low_pass": "0.25",
-                    "high_pass": "45",
+                    "low_pass": "45",
+                    "high_pass": "0.25",
                     "downsample_rate": "512",
                     "reject_thresh": "4.2",
                     "epoch_start": "-0.5",
@@ -37,6 +37,8 @@ def test_normalization_and_roundtrip(tmp_path):
     project = Project.load(tmp_path)
     normalized = project.preprocessing
 
+    assert normalized["high_pass"] == 0.25
+    assert normalized["low_pass"] == 45.0
     assert normalized["downsample"] == 512
     assert normalized["rejection_z"] == 4.2
     assert normalized["epoch_start_s"] == -0.5
@@ -50,8 +52,8 @@ def test_normalization_and_roundtrip(tmp_path):
 
     project.update_preprocessing(
         {
-            "low_pass": 0.5,
-            "high_pass": 30,
+            "low_pass": 30,
+            "high_pass": 0.5,
             "downsample": 256,
             "rejection_z": 3.0,
             "epoch_start_s": -1.0,
@@ -73,5 +75,7 @@ def test_normalization_and_roundtrip(tmp_path):
     assert "downsample_rate" not in saved["preprocessing"]
 
     fresh = Project.load(tmp_path)
+    assert fresh.preprocessing["high_pass"] == 0.5
+    assert fresh.preprocessing["low_pass"] == 30.0
     assert fresh.preprocessing["max_chan_idx_keep"] == 64
     assert fresh.preprocessing["save_preprocessed_fif"] is False

--- a/tests/test_preprocessing_settings.py
+++ b/tests/test_preprocessing_settings.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from Main_App.PySide6_App.Backend.preprocessing_settings import normalize_preprocessing_settings
+
+
+def test_defaults_use_expected_bandpass():
+    normalized = normalize_preprocessing_settings({})
+    assert normalized["high_pass"] == 0.1
+    assert normalized["low_pass"] == 50.0
+
+
+def test_inverted_bandpass_raises():
+    with pytest.raises(ValueError):
+        normalize_preprocessing_settings({"low_pass": 0.1, "high_pass": 50.0})

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -18,8 +18,8 @@ def _build_worker_project(root: Path) -> Project:
     project = Project.load(root)
     project.update_preprocessing(
         {
-            "low_pass": 0.2,
-            "high_pass": 50.0,
+            "low_pass": 50.0,
+            "high_pass": 0.2,
             "downsample": 256,
             "rejection_z": 5.0,
             "epoch_start_s": -1.0,


### PR DESCRIPTION
## Summary
- align preprocessing defaults so high-pass maps to the filter lower edge and low-pass to the upper edge, matching UI labels
- surface validation errors for inverted or invalid bandpass entries in the settings dialog and project loading, while keeping processing order unchanged
- refresh persistence/audit paths and add regression coverage for default bandpass values and swapped inputs

## Testing
- python -m pytest tests/test_preprocessing_settings.py tests/test_preproc_persistence.py tests/test_preproc_audit.py tests/test_fif_flag_audit.py tests/test_worker_integration.py tests/test_gui_preproc_dialog.py *(skipped: PySide6/numpy/mne not installed in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c18a67ba8832caae778c7a1393335)