### PR TITLE
Debounce legacy preprocessing bandpass warning

### DIFF
--- a/src/Main_App/PySide6_App/Backend/project.py
+++ b/src/Main_App/PySide6_App/Backend/project.py
@@ -132,8 +132,9 @@ class Project:
             print(f"[PROJECT] Invalid preprocessing settings in manifest; using defaults: {exc}")
             self.preprocessing = normalize_preprocessing_settings({})
         else:
-            if _bandpass_notes:
+            if _bandpass_notes and self.project_root not in _LEGACY_BANDPASS_WARNED:
                 print(f"[PROJECT] {_bandpass_notes[0]}")
+                _LEGACY_BANDPASS_WARNED.add(self.project_root)
         manifest["preprocessing"] = {
             key: self.preprocessing[key] for key in PREPROCESSING_CANONICAL_KEYS
         }

--- a/tests/test_project_bandpass_warning.py
+++ b/tests/test_project_bandpass_warning.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from Main_App.PySide6_App.Backend.project import Project, _LEGACY_BANDPASS_WARNED
+
+
+def test_legacy_bandpass_warns_once_per_project(tmp_path, capsys):
+    manifest_path = tmp_path / "project.json"
+    manifest_path.write_text(
+        json.dumps({"preprocessing": {"low_pass": "0.1", "high_pass": "50.0"}}),
+        encoding="utf-8",
+    )
+
+    previous = set(_LEGACY_BANDPASS_WARNED)
+    _LEGACY_BANDPASS_WARNED.clear()
+
+    try:
+        project = Project.load(tmp_path)
+        first = capsys.readouterr().out
+
+        assert project.preprocessing["low_pass"] == 50.0
+        assert project.preprocessing["high_pass"] == 0.1
+        assert "Invalid preprocessing bandpass detected" in first
+
+        Project.load(tmp_path)
+        second = capsys.readouterr().out
+
+        assert "Invalid preprocessing bandpass detected" not in second
+    finally:
+        _LEGACY_BANDPASS_WARNED.clear()
+        _LEGACY_BANDPASS_WARNED.update(previous)


### PR DESCRIPTION
## Summary
- ensure legacy bandpass inversion warnings only emit once per project instance while still normalizing manifests
- add regression test covering legacy bandpass inversion normalization and warn-once behavior

## Testing
- pytest tests/test_project_bandpass_warning.py (skipped: PySide6 not installed in CI environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c2b80fdcc832c8ba7b53873158a2b)