### PR TITLE
Fix project scan lifecycle and add cancellation support

### DIFF
--- a/tests/test_open_existing_project_dialog.py
+++ b/tests/test_open_existing_project_dialog.py
@@ -4,14 +4,22 @@ from pathlib import Path
 
 import pytest
 
-if importlib.util.find_spec("PySide6") is None or importlib.util.find_spec("pytestqt") is None:
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+if not _module_available("PySide6") or not _module_available("pytestqt"):
     pytest.skip("PySide6 or pytest-qt not available", allow_module_level=True)
 
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication  # noqa: E402
 
-import Main_App.PySide6_App.Backend.project_manager as project_manager
-import Main_App.PySide6_App.config.projects_root as projects_root
-from Main_App.PySide6_App.utils import settings as settings_mod
+import Main_App.PySide6_App.Backend.project_manager as project_manager  # noqa: E402
+import Main_App.PySide6_App.config.projects_root as projects_root  # noqa: E402
+from Main_App.PySide6_App.utils import settings as settings_mod  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_project_scan_job.py
+++ b/tests/test_project_scan_job.py
@@ -1,0 +1,59 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+if not _module_available("PySide6"):
+    pytest.skip("PySide6 not available", allow_module_level=True)
+
+from PySide6.QtCore import QCoreApplication  # noqa: E402
+
+from Main_App.PySide6_App.Backend import project_manager  # noqa: E402
+
+
+def _write_project(root: Path, name: str) -> None:
+    project_root = root / name
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "project.json").write_text("{}", encoding="utf-8")
+
+
+def test_project_scan_job_emits_finished(tmp_path: Path) -> None:
+    QCoreApplication.instance() or QCoreApplication([])
+    _write_project(tmp_path, "Project 1")
+    _write_project(tmp_path, "Project 2")
+
+    job = project_manager._ProjectScanJob(tmp_path)
+    finished_payload: list[list] = []
+    errors: list[str] = []
+
+    job.signals.finished.connect(lambda payload: finished_payload.append(payload))
+    job.signals.error.connect(lambda message: errors.append(message))
+
+    job.run()
+
+    assert not errors
+    assert finished_payload
+    assert len(finished_payload[0]) == 2
+
+
+def test_project_scan_job_emits_cancel_error(tmp_path: Path) -> None:
+    QCoreApplication.instance() or QCoreApplication([])
+    _write_project(tmp_path, "Project 1")
+
+    job = project_manager._ProjectScanJob(tmp_path)
+    errors: list[str] = []
+
+    job.signals.error.connect(lambda message: errors.append(message))
+
+    job.request_cancel()
+    job.run()
+
+    assert errors == [project_manager.CANCEL_SCAN_MESSAGE]


### PR DESCRIPTION
### Motivation
- The project enumeration QRunnable could be destroyed before its signals reached the UI, causing an infinite "Scanning Projects…" dialog and stuck guard state.
- The progress dialog was not cancellable which produced a poor UX when scans needed to be aborted.
- Need to guarantee cleanup happens exactly once on every exit path (error, finished, cancel) without changing processing order or touching black-box areas.
- Add a lightweight test to exercise the scan job lifecycle.

### Description
- Keep `_ProjectScanJob` alive and prevent premature deletion by calling `job.setAutoDelete(False)` and storing the job in `self._active_scan_job` until cleanup clears it, and change `finished` signal to `Signal(object)` to avoid meta-type issues across threads (`src/Main_App/PySide6_App/Backend/project_manager.py`).
- Add cancellation support on the worker with `request_cancel()` and an internal `_cancel_requested` flag that causes the job to emit a cancel error and stop early, and wire `progress.canceled` to `job.request_cancel` in the UI.
- Make the progress dialog closable/cancellable by creating `QProgressDialog("Scanning projects...", "Cancel", 0, 100, parent)`, keeping it non-auto-closing, and using a single idempotent `finalize_guard()` to close the dialog and end the `_open_project_guard` on all exit paths.
- Add `logger.info` calls for scan start, scan finished (with count), and scan error/cancel to prove slots execute, and add a pure-Python unit test exercising the scan job lifecycle `tests/test_project_scan_job.py`, plus harden test imports in `tests/test_open_existing_project_dialog.py`.

### Testing
- Ran `ruff check src/Main_App/PySide6_App/Backend/project_manager.py tests/test_project_scan_job.py tests/test_open_existing_project_dialog.py` and it passed.
- Ran `python -m pytest tests/test_project_scan_job.py tests/test_open_existing_project_dialog.py` in the environment; both tests were skipped because `PySide6`/`pytest-qt` are not available in the runner.
- Added `tests/test_project_scan_job.py` which exercises `job.run()` and verifies `finished` emits and cancel emits the cancel message; this test is executed when `PySide6` is available.
- No changes introduced that load full `Project.load` during enumeration; enumeration remains metadata-only (`read_project_metadata` usage preserved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696133858c78832c8dc7716b3383bf87)