### PR TITLE
Route single-file runs through MpRunnerBridge

### DIFF
--- a/tests/test_single_file_process_mode.py
+++ b/tests/test_single_file_process_mode.py
@@ -1,0 +1,95 @@
+import importlib.util
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+if importlib.util.find_spec("PySide6") is None or importlib.util.find_spec("pytestqt") is None:
+    pytest.skip("PySide6 or pytest-qt not available", allow_module_level=True)
+
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtWidgets import QApplication
+
+from Main_App.Legacy_App.processing_utils import ProcessingMixin
+from Main_App.PySide6_App.GUI.main_window import MainWindow
+import Main_App.PySide6_App.workers.mp_runner_bridge as mp_runner_bridge
+
+
+def test_single_file_process_mode_routes_through_mp_runner(qtbot, tmp_path, monkeypatch):
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+
+    QApplication.instance() or QApplication([])
+
+    project_root = tmp_path / "project"
+    input_folder = project_root / "input"
+    input_folder.mkdir(parents=True)
+    excel_subfolder = "1 - Excel Data Files"
+    (project_root / excel_subfolder).mkdir(parents=True)
+
+    preprocessing = {
+        "low_pass": 0.1,
+        "high_pass": 50.0,
+        "downsample": 256,
+        "rejection_z": 5.0,
+        "epoch_start_s": -1.0,
+        "epoch_end_s": 125.0,
+        "ref_chan1": "EXG1",
+        "ref_chan2": "EXG2",
+        "max_chan_idx_keep": 64,
+        "max_bad_chans": 10,
+        "save_preprocessed_fif": False,
+        "stim_channel": "Status",
+    }
+
+    win = MainWindow()
+    qtbot.addWidget(win)
+    win.currentProject = SimpleNamespace(
+        project_root=project_root,
+        input_folder=input_folder,
+        subfolders={"excel": excel_subfolder},
+        preprocessing=preprocessing,
+        options={},
+    )
+
+    win._on_mode_changed("single")
+    win.add_event_row("CondA", "1")
+
+    dummy_path = input_folder / "sample.bdf"
+    dummy_path.touch()
+    win.data_paths = [str(dummy_path)]
+    if hasattr(win, "le_input_file"):
+        win.le_input_file.setText(str(dummy_path))
+
+    def _no_processing_notice():
+        return None
+
+    monkeypatch.setattr(win, "_show_processing_started_notice", _no_processing_notice)
+    monkeypatch.setattr(MainWindow, "_on_processing_finished", lambda self, payload=None: None)
+
+    def _fail_legacy_start(self):
+        raise AssertionError("Legacy start_processing was called unexpectedly.")
+
+    monkeypatch.setattr(ProcessingMixin, "start_processing", _fail_legacy_start)
+
+    class FakeMpRunnerBridge(QObject):
+        progress = Signal(int)
+        error = Signal(str)
+        finished = Signal(object)
+
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            self.start_calls = []
+
+        def start(self, **kwargs):
+            self.start_calls.append(kwargs)
+
+    monkeypatch.setattr(mp_runner_bridge, "MpRunnerBridge", FakeMpRunnerBridge)
+
+    win.start_processing()
+
+    assert isinstance(win._mp, FakeMpRunnerBridge)
+    assert win._mp.start_calls
+    call = win._mp.start_calls[0]
+    assert call["max_workers"] == 1
+    assert call["data_files"] == [Path(dummy_path)]


### PR DESCRIPTION
### Motivation

- Avoid legacy `ProcessingMixin` single-file truthiness / `Epochs.__len__` crashes by routing Single-file UI runs through the multiprocessing runner bridge used for batch/process mode.  
- Preserve existing pipeline ordering and outputs while ensuring Single runs use the same process-based pipeline as Batch.  
- Allow cooperative stop/cancel when an `MpRunnerBridge`-backed run is active regardless of the stored `parallel_mode`.  
- Add a pytest-qt smoke test to lock in the routing behavior and prevent regressions.

### Description

- Updated `MainWindow.start_processing()` in `src/Main_App/PySide6_App/GUI/main_window.py` to detect UI mode via `self.file_mode.get()` and treat Single UI as an `MpRunnerBridge` run by setting `is_mp_run = (self.parallel_mode == "process") or is_single_ui`.  
- For Single UI runs the code now passes `data_files = [Path(self.data_paths[0])]` and forces `max_workers=1` while preserving batch behavior for multi-file runs.  
- Stopped the legacy queue poll timer for mp runs (same as batch), early-returned after launching `MpRunnerBridge` to avoid falling through to the legacy path, and ensured Start/Stop button text remains toggled to `Stop Processing` during runs.  
- Modified `stop_processing()` to allow cancellation when an `MpRunnerBridge` instance is present and active, and added a light reordering so the legacy warning is only shown when `_mp` is `None`.  
- Added `tests/test_single_file_process_mode.py`, a pytest-qt smoke test that stubs a minimal project, monkeypatches `MpRunnerBridge` with a fake that records `start()` calls, and asserts that Single UI runs call `MpRunnerBridge.start()` with `max_workers==1` and a single `data_files` entry.

### Testing

- Ran `python -m pytest -q` for the repository; collection failed due to missing environment dependencies (`PySide6`, `numpy`, `pandas`) so the full test suite could not be executed in this environment.  
- Ran `ruff check .` which surfaced existing repository lint issues (many unrelated pre-existing violations); the lint command failed against the full codebase.  
- Ran `mypy src --strict` which failed due to an existing syntax error in `src/Compiler_Script.py` and did not complete type-checking.  
- The new pytest-qt smoke test `tests/test_single_file_process_mode.py` was added and is designed to pass under a properly provisioned environment (it monkeypatches `MpRunnerBridge` and avoids spawning processes), but could not be validated here because `PySide6` and pytest-qt were not available during collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962561e9654832cb53e0f866b85f3e4)