### PR TITLE
Log explicit preprocessing HPF/LPF/downsample snapshots in main_window, MpRunnerBridge, and process_runner

### DIFF
--- a/src/Main_App/Performance/process_runner.py
+++ b/src/Main_App/Performance/process_runner.py
@@ -239,7 +239,16 @@ def _run_full_pipeline_for_file(
         #    initial EXG ref -> drop EXGs -> channel limit keeping stim ->
         #    downsample -> filter -> kurtosis/interp -> final avg ref)
         logger.info(
-            "preproc_settings_snapshot",
+            "RUNNER_SETTINGS_SNAPSHOT file=%s high_pass=%r low_pass=%r downsample_rate=%r "
+            "reject_thresh=%r ref=(%r,%r) stim=%r",
+            Path(file_path).name if file_path else "UNKNOWN",
+            settings.get("high_pass"),
+            settings.get("low_pass"),
+            settings.get("downsample_rate", settings.get("downsample")),
+            settings.get("reject_thresh"),
+            settings.get("ref_channel1"),
+            settings.get("ref_channel2"),
+            settings.get("stim_channel"),
             extra={
                 "source": "process_runner",
                 "file": file_path.name,

--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -1155,6 +1155,14 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
 
     def _build_validated_params(self) -> dict | None:
         normalized = normalize_preprocessing_settings(self.currentProject.preprocessing)
+        logger.info(
+            "NORMALIZED_PREPROC_SNAPSHOT file_mode=%s normalized.high_pass=%r "
+            "normalized.low_pass=%r normalized.downsample=%r",
+            getattr(self, "file_mode", None).get() if hasattr(self, "file_mode") else "UNKNOWN",
+            normalized.get("high_pass"),
+            normalized.get("low_pass"),
+            normalized.get("downsample"),
+        )
 
         # Event map from UI rows → {label: int_id}
         event_map: dict[str, int] = {}
@@ -1197,6 +1205,17 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
             "save_preprocessed_fif": bool(normalized.get("save_preprocessed_fif", False)),
             "event_id_map": event_map,
         }
+        logger.info(
+            "VALIDATED_PARAMS_SNAPSHOT high_pass=%r low_pass=%r downsample_rate=%r "
+            "reject_thresh=%r ref=(%r,%r) stim=%r",
+            params.get("high_pass"),
+            params.get("low_pass"),
+            params.get("downsample_rate"),
+            params.get("reject_thresh"),
+            params.get("ref_channel1"),
+            params.get("ref_channel2"),
+            params.get("stim_channel"),
+        )
         return params
 
     # ------------------------- settings UI -------------------------- #

--- a/src/Main_App/PySide6_App/workers/mp_runner_bridge.py
+++ b/src/Main_App/PySide6_App/workers/mp_runner_bridge.py
@@ -88,7 +88,16 @@ class MpRunnerBridge(QObject):
 
         for file_path in data_files:
             logger.info(
-                "preproc_settings_snapshot",
+                "BRIDGE_SETTINGS_SNAPSHOT n_files=%d high_pass=%r low_pass=%r "
+                "downsample_rate=%r reject_thresh=%r ref=(%r,%r) stim=%r",
+                len(data_files),
+                settings.get("high_pass"),
+                settings.get("low_pass"),
+                settings.get("downsample_rate", settings.get("downsample")),
+                settings.get("reject_thresh"),
+                settings.get("ref_channel1"),
+                settings.get("ref_channel2"),
+                settings.get("stim_channel"),
                 extra={
                     "source": "mp_runner_bridge",
                     "file": file_path.name,


### PR DESCRIPTION
### Motivation
- Existing `preproc_settings_snapshot` logging relied on `extra=` fields and did not print HPF/LPF/downsample values in the message, making it hard to trace where filter/downsamping values are set or swapped.
- Add explicit, human-readable snapshot logs at the key checkpoints to help locate mismatches between normalized settings, validated params, bridge dispatch, and per-file runner settings.
- Capture both the normalized settings and the validated `params` built by the GUI so any swap in `high_pass`/`low_pass` can be detected earlier in the pipeline.
- Keep changes strictly logging-only with no behavioral, control-flow, or output alterations.

### Description
- In `main_window._build_validated_params` added a `NORMALIZED_PREPROC_SNAPSHOT` `logger.info` immediately after `normalize_preprocessing_settings()` and a `VALIDATED_PARAMS_SNAPSHOT` `logger.info` after `params` are constructed to print `high_pass`, `low_pass`, `downsample_rate`, `reject_thresh`, refs, and `stim_channel`.
- In `MpRunnerBridge` replaced the per-file `preproc_settings_snapshot` logging call with a formatted `BRIDGE_SETTINGS_SNAPSHOT` message that includes `n_files`, `high_pass`, `low_pass`, `downsample_rate`, `reject_thresh`, refs, and `stim_channel`, while preserving the structured `extra=` payload.
- In `process_runner` added a per-file `RUNNER_SETTINGS_SNAPSHOT` `logger.info` immediately before calling `perform_preprocessing()` that prints the file name plus the same preprocessing fields and also preserves `extra=`.
- No functional changes were made; only `logger.info()` statements were added and required imports (e.g., `Path`) are present or unchanged.

### Testing
- Ran `ruff check .` which reported many pre-existing lint violations in the repository; the added logging lines did not introduce any new actionable lints beyond the repo baseline.
- Ran `python -m pytest` which failed during collection due to missing runtime dependencies in the environment (e.g., `PySide6`, `numpy`, `pandas`), so the full test suite could not be exercised here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625e752d50832cbe7bc09fc9844922)