### PR TITLE
Use bin-only amplitude for harmonic z-score

### DIFF
--- a/src/Main_App/Legacy_App/post_process.py
+++ b/src/Main_App/Legacy_App/post_process.py
@@ -265,13 +265,7 @@ def post_process(app: Any, condition_labels_present: List[str]) -> None:
                             )
 
                         signal_amplitude = channel_amplitudes[target_bin_index]
-                        peak_val_slice = slice(
-                            max(0, target_bin_index - 1),
-                            min(len(fft_frequencies), target_bin_index + 2),
-                        )
-                        peak_signal_amplitude = np.max(
-                            channel_amplitudes[peak_val_slice]
-                        )
+                        peak_signal_amplitude = signal_amplitude
 
                         snr_val = (
                             signal_amplitude / noise_mean_val


### PR DESCRIPTION
### Motivation
- Switch the harmonic z-score "signal amplitude" definition from peak-of-3 (target bin ±1) to the target bin only to match the requested metric.
- Preserve all existing noise-window definition, adjacent-bin exclusion, min/max trimming, pipeline order, and BCA/SNR computations.
- Reduce the chance of out-of-range neighbor indexing by eliminating neighbor access.
- Keep the variable name `peak_signal_amplitude` unchanged to minimize the diff.

### Description
- Updated `src/Main_App/Legacy_App/post_process.py` to assign `peak_signal_amplitude = signal_amplitude` instead of taking `np.max` over a neighbor slice.
- Retained the shared noise-floor computation and all downstream calculations (`snr`, `z_score`, `bca`) exactly as before.
- Only `src/Main_App/Legacy_App/post_process.py` was modified and the change is a single-line replacement that removes the neighbor-slice logic.
- No other files or legacy modules were altered.

### Testing
- Ran `ruff check .`, which exited non-zero due to preexisting lint issues elsewhere in the repo and not related to this change.
- Ran `python -m pytest -q`, which failed during collection due to missing environment dependencies (`PySide6`, `numpy`, `pandas`) in this environment.
- No unit tests were added or changed, and the modification is limited to the single targeted assignment in the legacy post-processing file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a6436798832cb367a9b58542729a)