### PR TITLE
Allow RM-ANOVA-empty exports to be skipped and surface worker reason text

### DIFF
--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -1096,7 +1096,7 @@ class StatsWindow(QMainWindow):
                         f"  • Skipping export for {label} (no data)",
                         level="warning",
                     )
-                    return False
+                    continue
 
                 result_paths = self.export_results(kind, data_obj, out_dir)
 
@@ -1150,7 +1150,7 @@ class StatsWindow(QMainWindow):
                         f"  • Skipping export for {label} (no data)",
                         level="warning",
                     )
-                    return False
+                    continue
 
                 result_paths = self.export_results(kind, data_obj, out_dir)
 
@@ -1210,6 +1210,19 @@ class StatsWindow(QMainWindow):
     def _apply_rm_anova_results(self, payload: dict, *, update_text: bool = True) -> str:
         self.rm_anova_results_data = payload.get("anova_df_results")
         alpha = getattr(self, "_current_alpha", 0.05)
+        output_text = payload.get("output_text", "")
+
+        if (
+            (self.rm_anova_results_data is None or self.rm_anova_results_data.empty)
+            and isinstance(output_text, str)
+            and output_text.strip()
+        ):
+            section = self._section_label(PipelineId.SINGLE)
+            self.append_log(
+                section,
+                f"  • RM-ANOVA note: {output_text.strip()}",
+                level="warning",
+            )
 
         output_text = build_rm_anova_output(self.rm_anova_results_data, alpha)
         if update_text:

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -210,8 +210,8 @@ def run_rm_anova(progress_cb, message_cb, *, subjects, conditions, subject_data,
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")
     message_cb("Running RM-ANOVA…")
-    _, anova_df_results = analysis_run_rm_anova(all_subject_bca_data, message_cb)
-    return {"anova_df_results": anova_df_results}
+    output_text, anova_df_results = analysis_run_rm_anova(all_subject_bca_data, message_cb)
+    return {"anova_df_results": anova_df_results, "output_text": output_text}
 
 
 def run_between_group_anova(
@@ -571,4 +571,3 @@ def run_between_group_process_task(
         "stdout": stdout_lines,
         "stderr": stderr_output,
     }
-

--- a/tests/test_stats_export_skip_does_not_fail.py
+++ b/tests/test_stats_export_skip_does_not_fail.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_export_skips_rm_anova_none(tmp_path, monkeypatch):
+    from Tools.Stats.PySide6 import stats_main_window
+    from Tools.Stats.PySide6.stats_core import PipelineId
+    from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+    from PySide6.QtWidgets import QApplication
+
+    monkeypatch.setattr(
+        stats_main_window, "apply_rois_to_modules", lambda *_a, **_k: None, raising=False
+    )
+    monkeypatch.setattr(stats_main_window, "set_rois", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr(stats_main_window, "load_rois_from_settings", lambda: {}, raising=False)
+
+    _app = QApplication.instance() or QApplication([])
+    win = StatsWindow(project_dir=str(tmp_path))
+
+    win.rm_anova_results_data = None
+    win.mixed_model_results_data = pd.DataFrame({"value": [1.0]})
+    win.posthoc_results_data = None
+    win._harmonic_results = {PipelineId.SINGLE: None, PipelineId.BETWEEN: None}
+
+    export_calls: list[tuple[str, object, str]] = []
+
+    def fake_export_results(kind, data_obj, out_dir):
+        export_calls.append((kind, data_obj, out_dir))
+        return [Path(out_dir) / f"{kind}.xlsx"]
+
+    monkeypatch.setattr(win, "export_results", fake_export_results)
+    monkeypatch.setattr(win, "_ensure_results_dir", lambda: str(tmp_path))
+
+    log_calls: list[tuple[str, str, str]] = []
+
+    def fake_append_log(section, message, level="info"):
+        log_calls.append((section, message, level))
+
+    monkeypatch.setattr(win, "append_log", fake_append_log)
+
+    result = win._export_single_pipeline()
+
+    assert result is True
+    assert any(
+        "Skipping export for RM-ANOVA (no data)" in message for _section, message, _level in log_calls
+    )
+    assert any(kind == "lmm" for kind, _data, _out_dir in export_calls)


### PR DESCRIPTION
### Motivation
- A regression caused end-of-pipeline export to treat `None` results from legacy RM-ANOVA as a hard failure, producing misleading “Export failed” messages when the RM-ANOVA legitimately had no output after NaN filtering or empty tables.  
- The RM-ANOVA worker previously discarded the human-readable reason returned by the legacy analyzer, so users could not see why no ANOVA table was produced.  
- The goal is to keep pipeline order and stats behavior unchanged while ensuring a skipped RM-ANOVA does not fail the whole export and its reason string is logged for the user.

### Description
- In `src/Tools/Stats/PySide6/stats_workers.py` updated `run_rm_anova()` to preserve and return the legacy message as `output_text` in the worker payload (`return {

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fed56c40832c813a71c52842ad64)