### PR TITLE
Add RM-ANOVA diagnostics with invalid-cell classification and provenance

### DIFF
--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -970,6 +970,8 @@ class StatsWindow(QMainWindow):
                     base_freq=self._current_base_freq,
                     rois=self.rois,
                 )
+                if os.getenv("FPVS_RM_ANOVA_DIAG", "0").strip() == "1":
+                    kwargs["results_dir"] = self._ensure_results_dir()
                 def handler(payload):
                     self._apply_rm_anova_results(payload, update_text=False)
 

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -246,15 +246,27 @@ def _diag_subject_data_structure(subject_data, subjects, conditions, rois, messa
             )
 
 
-def run_rm_anova(progress_cb, message_cb, *, subjects, conditions, subject_data, base_freq, rois):
+def run_rm_anova(
+    progress_cb,
+    message_cb,
+    *,
+    subjects,
+    conditions,
+    subject_data,
+    base_freq,
+    rois,
+    results_dir: str | None = None,
+):
     set_rois(rois)
     message_cb("Preparing data for Summed BCA RM-ANOVA…")
+    provenance_map = {} if RM_ANOVA_DIAG else None
     all_subject_bca_data = prepare_all_subject_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
         subject_data=subject_data,
         base_freq=base_freq,
         log_func=message_cb,
+        provenance_map=provenance_map,
     )
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")
@@ -266,6 +278,8 @@ def run_rm_anova(progress_cb, message_cb, *, subjects, conditions, subject_data,
         subjects=list(subjects) if subjects else None,
         conditions=list(conditions) if conditions else None,
         rois=sorted(rois.keys()) if isinstance(rois, dict) else None,
+        provenance_map=provenance_map,
+        results_dir=results_dir,
     )
     return {"anova_df_results": anova_df_results, "output_text": output_text}
 


### PR DESCRIPTION
### Motivation
- Make RM-ANOVA diagnostics actionable by classifying WHY cells were excluded (NaN/None/inf/non-numeric/etc.) and linking each invalid cell back to its source so upstream ingestion issues can be fixed.
- Keep all analysis unchanged and ensure diagnostics run only when explicitly requested via `FPVS_RM_ANOVA_DIAG=1`.

### Description
- Added `classify_invalid(value) -> (is_valid, reason, coerced_value)` in `src/Tools/Stats/Legacy/repeated_m_anova.py` to categorize invalid cells; reasons include: `none`, `nan`, `inf`, `non_numeric_str`, `empty_str`, `conversion_error`, `other_invalid` (and returns a safe coerced float for reporting only).
- Augmented RM-ANOVA diagnostics in `src/Tools/Stats/Legacy/stats_analysis.py` to build an `invalid_df` with raw value/type, reason, coerced preview, and provenance fields (`source_file`, `sheet`, `row_label`, `col_label`, `raw_cell`), and to log counts by reason and top examples.
- Implemented provenance collection during file/ROI aggregation: `aggregate_bca_sum` now accepts optional `diag_meta` and `prepare_all_subject_summed_bca_data` can populate a `provenance_map` keyed by `(subject, condition, roi)` without changing computed values.
- Emit debug CSV artifacts when diagnostics are enabled, written to the stats results directory: `RM_ANOVA_DEBUG_invalid_cells.csv`, `RM_ANOVA_DEBUG_value_matrix.csv`, and `RM_ANOVA_DEBUG_reason_summary.csv` (paths logged); diagnostics are gated by `FPVS_RM_ANOVA_DIAG` and a `results_dir` passed from the PySide6 layer.
- Threading/worker wiring: `stats_workers.run_rm_anova` now creates & passes a `provenance_map` when diagnostics are active and accepts an optional `results_dir`; `stats_main_window.get_step_config` attaches `results_dir` to the RM-ANOVA kwargs only when `FPVS_RM_ANOVA_DIAG=1`.
- No changes to filtering rules, numeric coercion used only for reporting, and RM-ANOVA computation path (`df_valid`, `run_repeated_measures_anova`) is unchanged.

### Testing
- Searched for gating to confirm diagnostics are guarded by `FPVS_RM_ANOVA_DIAG` using `rg` (`FPVS_RM_ANOVA_DIAG` occurrences present in `repeated_m_anova.py`, `stats_workers.py`, and `stats_main_window.py`). (success)
- Ran `ruff check src tests`; this failed due to pre-existing lint issues in unrelated modules (`SourceLocalization` and tests) and is unrelated to the diagnostics changes. (failed — unrelated lint errors)
- Ran `python -m pytest`; collection failed because required runtime packages / GUI bindings are not available in this environment (`PySide6`, `numpy`, `pandas` errors reported), so pipeline-level diagnostics could not be executed and no CSV artifacts were produced. (failed — missing dependencies)
- Attempted to run the app with diagnostics on (`FPVS_RM_ANOVA_DIAG=1 python src/main.py`); this exited early due to missing `PySide6` so no RM-ANOVA run or debug files were created. (failed — missing PySide6)

Notes: I could not produce the requested excerpt of `RM_ANOVA_DEBUG_invalid_cells.csv` because the environment lacks GUI and data dependencies to run the pipeline end-to-end; however, the changes are self-contained to the Stats tool, fully gated by `FPVS_RM_ANOVA_DIAG`, and do not alter analysis computations or exported payload keys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e2984454832c938f6e121ea8e8bb)