### PR TITLE
Add Summed BCA DV policy selector (Legacy + Fixed-K) and routing

### DIFF
--- a/src/Tools/Stats/PySide6/dv_policies.py
+++ b/src/Tools/Stats/PySide6/dv_policies.py
@@ -1,0 +1,335 @@
+"""Summed BCA DV policies for the Stats tool."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.Legacy.excel_io import safe_read_excel
+from Tools.Stats.Legacy.stats_analysis import (
+    SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
+    _current_rois_map,
+    _match_freq_column,
+    filter_to_oddball_harmonics,
+    get_included_freqs,
+    prepare_all_subject_summed_bca_data,
+)
+
+LEGACY_POLICY_NAME = "Current (Legacy)"
+FIXED_K_POLICY_NAME = "Fixed-K harmonics"
+
+
+@dataclass(frozen=True)
+class DVPolicySettings:
+    name: str = LEGACY_POLICY_NAME
+    fixed_k: int = 5
+    exclude_harmonic1: bool = True
+    exclude_base_harmonics: bool = True
+
+    def to_metadata(self, *, base_freq: float, selected_conditions: List[str]) -> dict:
+        return {
+            "policy_name": self.name,
+            "fixed_k": int(self.fixed_k),
+            "exclude_harmonic1": bool(self.exclude_harmonic1),
+            "exclude_base_harmonics": bool(self.exclude_base_harmonics),
+            "base_frequency_hz": float(base_freq),
+            "selected_conditions": list(selected_conditions),
+        }
+
+
+def normalize_dv_policy(settings: dict[str, object] | None) -> DVPolicySettings:
+    if not settings:
+        return DVPolicySettings()
+    name = str(settings.get("name", LEGACY_POLICY_NAME))
+    if name not in (LEGACY_POLICY_NAME, FIXED_K_POLICY_NAME):
+        name = LEGACY_POLICY_NAME
+    fixed_k = int(settings.get("fixed_k", 5))
+    if fixed_k < 1:
+        fixed_k = 1
+    return DVPolicySettings(
+        name=name,
+        fixed_k=fixed_k,
+        exclude_harmonic1=bool(settings.get("exclude_harmonic1", True)),
+        exclude_base_harmonics=bool(settings.get("exclude_base_harmonics", True)),
+    )
+
+
+def prepare_summed_bca_data(
+    *,
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    base_freq: float,
+    log_func: Callable[[str], None],
+    rois: Optional[Dict[str, List[str]]] = None,
+    provenance_map: Optional[dict[tuple[str, str, str], dict[str, object]]] = None,
+    dv_policy: dict[str, object] | None = None,
+) -> Optional[Dict[str, Dict[str, Dict[str, float]]]]:
+    settings = normalize_dv_policy(dv_policy)
+    if settings.name == FIXED_K_POLICY_NAME:
+        return _prepare_fixed_k_bca_data(
+            subjects=subjects,
+            conditions=conditions,
+            subject_data=subject_data,
+            base_freq=base_freq,
+            log_func=log_func,
+            rois=rois,
+            provenance_map=provenance_map,
+            settings=settings,
+        )
+    return prepare_all_subject_summed_bca_data(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        log_func=log_func,
+        rois=rois,
+        provenance_map=provenance_map,
+    )
+
+
+def _parse_freqs_from_columns(
+    all_col_names: Iterable[object],
+    log_func: Callable[[str], None],
+) -> List[float]:
+    numeric_freqs: List[float] = []
+    for col_name in all_col_names:
+        if isinstance(col_name, str) and col_name.endswith("_Hz"):
+            try:
+                numeric_freqs.append(float(col_name[:-3]))
+            except ValueError:
+                log_func(f"Could not parse freq from col: {col_name}")
+    if not numeric_freqs:
+        return []
+    return sorted(set(numeric_freqs))
+
+
+def _is_base_multiple(freq_val: float, base_freq: float, tol: float = 1e-6) -> bool:
+    return abs(freq_val / base_freq - round(freq_val / base_freq)) < tol
+
+
+def _determine_fixed_k_freqs(
+    *,
+    columns: Sequence[object],
+    base_freq: float,
+    settings: DVPolicySettings,
+    log_func: Callable[[str], None],
+) -> List[float]:
+    if settings.exclude_base_harmonics:
+        freq_candidates = get_included_freqs(base_freq, columns, log_func)
+    else:
+        freq_candidates = _parse_freqs_from_columns(columns, log_func)
+    if not freq_candidates:
+        return []
+
+    oddball_list = filter_to_oddball_harmonics(
+        freq_candidates,
+        base_freq,
+        every_n=SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
+        tol=1e-3,
+    )
+    if settings.exclude_base_harmonics:
+        oddball_list = [
+            item for item in oddball_list if not _is_base_multiple(item[0], base_freq)
+        ]
+    if settings.exclude_harmonic1:
+        oddball_list = [item for item in oddball_list if item[1] != 1]
+
+    if not oddball_list:
+        return []
+    return [freq for freq, _k in oddball_list[: settings.fixed_k]]
+
+
+def _find_first_bca_columns(
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    log_func: Callable[[str], None],
+) -> Optional[pd.Index]:
+    for pid in subjects:
+        for cond_name in conditions:
+            file_path = subject_data.get(pid, {}).get(cond_name)
+            if not file_path:
+                continue
+            try:
+                df_bca = safe_read_excel(
+                    file_path, sheet_name="BCA (uV)", index_col="Electrode"
+                )
+                return df_bca.columns
+            except Exception as exc:  # noqa: BLE001
+                log_func(f"Failed to read BCA columns from {file_path}: {exc}")
+    return None
+
+
+def _aggregate_bca_sum_fixed_k(
+    file_path: str,
+    roi_name: str,
+    log_func: Callable[[str], None],
+    harmonic_freqs: List[float],
+    rois: Optional[Dict[str, List[str]]] = None,
+    diag_meta: Optional[dict[str, object]] = None,
+) -> float:
+    try:
+        if diag_meta is not None:
+            diag_meta.setdefault("source_file", file_path)
+            diag_meta.setdefault("sheet", "BCA (uV)")
+            diag_meta.setdefault("row_label", None)
+            diag_meta.setdefault("col_label", None)
+            diag_meta.setdefault("raw_cell", None)
+
+        df_bca = safe_read_excel(file_path, sheet_name="BCA (uV)", index_col="Electrode")
+        df_bca.index = df_bca.index.astype(str).str.upper().str.strip()
+
+        if rois is not None:
+            roi_map = rois
+        else:
+            roi_map = _current_rois_map()
+
+        roi_channels = [str(ch).strip().upper() for ch in roi_map.get(roi_name, [])]
+        if not roi_channels:
+            log_func(f"ROI {roi_name} not defined.")
+            return np.nan
+
+        roi_chans = [ch for ch in roi_channels if ch in df_bca.index]
+        if not roi_chans:
+            log_func(f"No overlapping BCA data for ROI {roi_name} in {file_path}.")
+            return np.nan
+        if diag_meta is not None:
+            diag_meta["row_label"] = roi_chans
+
+        df_bca_roi = df_bca.loc[roi_chans].dropna(how="all")
+        if df_bca_roi.empty:
+            log_func(f"No data for ROI {roi_name} in {file_path}.")
+            return np.nan
+
+        cols_to_sum: List[str] = []
+        for freq_val in harmonic_freqs:
+            col_bca = _match_freq_column(df_bca_roi.columns, freq_val)
+            if col_bca:
+                cols_to_sum.append(col_bca)
+
+        if not cols_to_sum:
+            log_func(
+                f"No fixed-k harmonics found for ROI {roi_name} in {file_path}."
+            )
+            if diag_meta is not None:
+                diag_meta["col_label"] = []
+            return np.nan
+
+        if diag_meta is not None:
+            diag_meta["col_label"] = cols_to_sum
+            diag_meta["raw_cell"] = df_bca_roi[cols_to_sum].to_dict(orient="index")
+
+        bca_block = (
+            df_bca_roi[cols_to_sum]
+            .apply(pd.to_numeric, errors="coerce")
+            .replace([np.inf, -np.inf], np.nan)
+        )
+        bca_vals = bca_block.sum(axis=1, min_count=1)
+
+        bca_vals = pd.to_numeric(bca_vals, errors="coerce").replace(
+            [np.inf, -np.inf], np.nan
+        )
+        if not bca_vals.notna().any():
+            log_func(
+                f"Warning: All-NaN BCA values after summation for ROI {roi_name} "
+                f"({file_path})."
+            )
+            return np.nan
+
+        out = float(bca_vals.mean(skipna=True))
+        return out if np.isfinite(out) else np.nan
+
+    except Exception as exc:  # noqa: BLE001
+        log_func(f"Error aggregating fixed-k BCA for {file_path}, ROI {roi_name}: {exc}")
+        return np.nan
+
+
+def _prepare_fixed_k_bca_data(
+    *,
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    base_freq: float,
+    log_func: Callable[[str], None],
+    rois: Optional[Dict[str, List[str]]] = None,
+    provenance_map: Optional[dict[tuple[str, str, str], dict[str, object]]] = None,
+    settings: DVPolicySettings,
+) -> Optional[Dict[str, Dict[str, Dict[str, float]]]]:
+    if not subjects or not subject_data:
+        log_func("No subject data. Scan folder first.")
+        return None
+
+    rois_map = rois if rois is not None else _current_rois_map()
+    if not rois_map:
+        log_func("No ROIs defined or available.")
+        return None
+
+    columns = _find_first_bca_columns(subjects, conditions, subject_data, log_func)
+    if columns is None:
+        log_func("Unable to read any BCA columns to build fixed-k harmonics.")
+        return None
+
+    harmonic_freqs = _determine_fixed_k_freqs(
+        columns=columns, base_freq=base_freq, settings=settings, log_func=log_func
+    )
+    if not harmonic_freqs:
+        raise RuntimeError(
+            "Fixed-K harmonics selection produced an empty list. "
+            "Adjust exclusions or verify the data files."
+        )
+
+    log_func(
+        "Fixed-K harmonics selected: "
+        + ", ".join(f"{freq:g} Hz" for freq in harmonic_freqs)
+    )
+
+    all_subject_data: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for pid in subjects:
+        all_subject_data[pid] = {}
+        for cond_name in conditions:
+            file_path = subject_data.get(pid, {}).get(cond_name)
+            all_subject_data[pid].setdefault(cond_name, {})
+            for roi_name in rois_map.keys():
+                sum_val = np.nan
+                diag_meta: Optional[dict[str, object]] = None
+                if provenance_map is not None:
+                    diag_meta = {}
+                if file_path and Path(file_path).exists():
+                    sum_val = _aggregate_bca_sum_fixed_k(
+                        file_path,
+                        roi_name,
+                        log_func,
+                        harmonic_freqs,
+                        rois=rois_map,
+                        diag_meta=diag_meta,
+                    )
+                else:
+                    log_func(f"Missing file for {pid} {cond_name}: {file_path}")
+                all_subject_data[pid][cond_name][roi_name] = sum_val
+                if provenance_map is not None:
+                    provenance = {
+                        "source_file": file_path,
+                        "sheet": "BCA (uV)",
+                        "row_label": None,
+                        "col_label": None,
+                        "raw_cell": None,
+                    }
+                    if diag_meta:
+                        provenance.update(diag_meta)
+                    provenance_map[(pid, cond_name, roi_name)] = provenance
+
+    total = 0
+    finite = 0
+    for pid, conds in all_subject_data.items():
+        for _cond, rois_dict in conds.items():
+            for _roi, val in rois_dict.items():
+                total += 1
+                if val is not None and np.isfinite(val):
+                    finite += 1
+    log_func(f"[DEBUG] Summed BCA finite cells: {finite}/{total}")
+    log_func("Summed BCA data prep complete.")
+    return all_subject_data

--- a/src/Tools/Stats/PySide6/stats_controller.py
+++ b/src/Tools/Stats/PySide6/stats_controller.py
@@ -704,6 +704,7 @@ class StatsController:
             "roi_map": anova_kwargs.get("rois", {}),
             "base_freq": anova_kwargs.get("base_freq", 6.0),
             "alpha": mixed_kwargs.get("alpha", 0.05),
+            "dv_policy": anova_kwargs.get("dv_policy", {}),
             "harmonic_options": {
                 "metric": harmonic_kwargs.get("selected_metric", "Z Score"),
                 "mean_value_threshold": harmonic_kwargs.get("mean_value_threshold", 0.0),

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -35,11 +35,11 @@ from Tools.Stats.Legacy.mixed_effects_model import run_mixed_effects_model
 from Tools.Stats.Legacy.mixed_group_anova import run_mixed_group_anova
 from Tools.Stats.Legacy.posthoc_tests import run_interaction_posthocs
 from Tools.Stats.Legacy.stats_analysis import (
-    prepare_all_subject_summed_bca_data,
     run_harmonic_check as run_harmonic_check_new,
     run_rm_anova as analysis_run_rm_anova,
     set_rois,
 )
+from Tools.Stats.PySide6.dv_policies import prepare_summed_bca_data
 
 logger = logging.getLogger("Tools.Stats")
 RM_ANOVA_DIAG = os.getenv("FPVS_RM_ANOVA_DIAG", "0").strip() == "1"
@@ -255,18 +255,21 @@ def run_rm_anova(
     subject_data,
     base_freq,
     rois,
+    dv_policy: dict | None = None,
     results_dir: str | None = None,
 ):
     set_rois(rois)
     message_cb("Preparing data for Summed BCA RM-ANOVA…")
     provenance_map = {} if RM_ANOVA_DIAG else None
-    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+    all_subject_bca_data = prepare_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
         subject_data=subject_data,
         base_freq=base_freq,
         log_func=message_cb,
+        rois=rois,
         provenance_map=provenance_map,
+        dv_policy=dv_policy,
     )
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")
@@ -294,15 +297,18 @@ def run_between_group_anova(
     base_freq,
     rois,
     subject_groups: dict[str, str | None] | None = None,
+    dv_policy: dict | None = None,
 ):
     set_rois(rois)
     message_cb("Preparing data for Between-Group RM-ANOVA…")
-    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+    all_subject_bca_data = prepare_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
         subject_data=subject_data,
         base_freq=base_freq,
         log_func=message_cb,
+        rois=rois,
+        dv_policy=dv_policy,
     )
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")
@@ -343,16 +349,19 @@ def run_lmm(
     rois,
     subject_groups: dict[str, str | None] | None = None,
     include_group: bool = False,
+    dv_policy: dict | None = None,
 ):
     set_rois(rois)
     prep_label = "Mixed Effects Model" if not include_group else "Between-Group Mixed Model"
     message_cb(f"Preparing data for {prep_label}…")
-    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+    all_subject_bca_data = prepare_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
         subject_data=subject_data,
         base_freq=base_freq,
         log_func=message_cb,
+        rois=rois,
+        dv_policy=dv_policy,
     )
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")
@@ -432,16 +441,19 @@ def run_posthoc(
     alpha,
     rois,
     subject_groups: dict[str, str | None] | None = None,
+    dv_policy: dict | None = None,
     **kwargs,
 ):
     set_rois(rois)
     message_cb("Preparing data for Interaction Post-hoc tests…")
-    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+    all_subject_bca_data = prepare_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
         subject_data=subject_data,
         base_freq=base_freq,
         log_func=message_cb,
+        rois=rois,
+        dv_policy=dv_policy,
     )
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")
@@ -474,16 +486,19 @@ def run_group_contrasts(
     alpha,
     rois,
     subject_groups: dict[str, str | None] | None = None,
+    dv_policy: dict | None = None,
 ):
     set_rois(rois)
     _ = alpha
     message_cb("Preparing data for Between-Group Contrasts…")
-    all_subject_bca_data = prepare_all_subject_summed_bca_data(
+    all_subject_bca_data = prepare_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
         subject_data=subject_data,
         base_freq=base_freq,
         log_func=message_cb,
+        rois=rois,
+        dv_policy=dv_policy,
     )
     if not all_subject_bca_data:
         raise RuntimeError("Data preparation failed (empty).")

--- a/tests/test_stats_dv_policy.py
+++ b/tests/test_stats_dv_policy.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+from Tools.Stats.PySide6.dv_policies import (  # noqa: E402
+    FIXED_K_POLICY_NAME,
+    LEGACY_POLICY_NAME,
+)
+from Tools.Stats.PySide6.stats_core import PipelineId, StepId  # noqa: E402
+from Tools.Stats.PySide6.stats_controller import (  # noqa: E402
+    BETWEEN_PIPELINE_STEPS,
+    SINGLE_PIPELINE_STEPS,
+)
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow  # noqa: E402
+
+
+def _setup_window_state(window: StatsWindow) -> None:
+    window.subjects = ["S1", "S2"]
+    window.conditions = ["CondA", "CondB"]
+    window.subject_data = {"S1": {"CondA": "a.xlsx", "CondB": "b.xlsx"}}
+    window.rois = {"ROI1": ["Fz"]}
+
+
+@pytest.mark.qt
+def test_stats_dv_policy_defaults(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+
+    assert window.dv_policy_combo.currentText() == LEGACY_POLICY_NAME
+    assert window.get_dv_policy_snapshot()["name"] == LEGACY_POLICY_NAME
+
+
+@pytest.mark.qt
+def test_stats_dv_policy_fixed_k_snapshot_and_kwargs(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+    _setup_window_state(window)
+
+    window.dv_policy_combo.setCurrentText(FIXED_K_POLICY_NAME)
+    window.fixed_k_spinbox.setValue(7)
+
+    snapshot = window.get_dv_policy_snapshot()
+    assert snapshot["name"] == FIXED_K_POLICY_NAME
+    assert snapshot["fixed_k"] == 7
+
+    kwargs, _handler = window.get_step_config(PipelineId.SINGLE, StepId.RM_ANOVA)
+    assert kwargs["dv_policy"]["name"] == FIXED_K_POLICY_NAME
+    assert kwargs["dv_policy"]["fixed_k"] == 7
+
+
+@pytest.mark.qt
+def test_stats_dv_policy_does_not_change_step_queue(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+    _setup_window_state(window)
+
+    legacy_steps = window._controller._build_steps(PipelineId.SINGLE, SINGLE_PIPELINE_STEPS)
+    legacy_ids = [step.id for step in legacy_steps]
+
+    window.dv_policy_combo.setCurrentText(FIXED_K_POLICY_NAME)
+    window.fixed_k_spinbox.setValue(9)
+
+    fixed_steps = window._controller._build_steps(PipelineId.SINGLE, SINGLE_PIPELINE_STEPS)
+    fixed_ids = [step.id for step in fixed_steps]
+
+    assert legacy_ids == fixed_ids
+    for legacy_step, fixed_step in zip(legacy_steps, fixed_steps):
+        if "dv_policy" in legacy_step.kwargs:
+            assert legacy_step.kwargs["dv_policy"]["name"] == LEGACY_POLICY_NAME
+            assert fixed_step.kwargs["dv_policy"]["name"] == FIXED_K_POLICY_NAME
+
+    window.dv_policy_combo.setCurrentText(LEGACY_POLICY_NAME)
+    between_legacy = window._controller._build_steps(PipelineId.BETWEEN, BETWEEN_PIPELINE_STEPS)
+    window.dv_policy_combo.setCurrentText(FIXED_K_POLICY_NAME)
+    between_fixed = window._controller._build_steps(PipelineId.BETWEEN, BETWEEN_PIPELINE_STEPS)
+    assert [step.id for step in between_legacy] == [step.id for step in between_fixed]

--- a/tests/test_stats_group_contrasts_validation.py
+++ b/tests/test_stats_group_contrasts_validation.py
@@ -59,7 +59,7 @@ def test_validate_group_contrasts_happy_path(valid_df):
 def test_run_group_contrasts_blocks_invalid_data(monkeypatch):
     called = False
 
-    def fake_prepare_all_subject_summed_bca_data(**kwargs):  # noqa: ARG001
+    def fake_prepare_summed_bca_data(**kwargs):  # noqa: ARG001
         return {
             "s1": {"c1": {"r1": float("inf")}},
             "s2": {"c1": {"r1": 2.0}},
@@ -71,8 +71,8 @@ def test_run_group_contrasts_blocks_invalid_data(monkeypatch):
         raise AssertionError("Legacy compute_group_contrasts should not be called")
 
     monkeypatch.setattr(
-        "Tools.Stats.PySide6.stats_workers.prepare_all_subject_summed_bca_data",
-        fake_prepare_all_subject_summed_bca_data,
+        "Tools.Stats.PySide6.stats_workers.prepare_summed_bca_data",
+        fake_prepare_summed_bca_data,
     )
     monkeypatch.setattr(
         "Tools.Stats.PySide6.stats_workers.compute_group_contrasts",

--- a/tests/test_stats_multigroup_smoke.py
+++ b/tests/test_stats_multigroup_smoke.py
@@ -25,8 +25,7 @@ def stats_smoke_env(monkeypatch):
     dummy_df = pd.DataFrame({"Effect": ["group"], "Pr > F": [0.5]})
 
     monkeypatch.setattr(
-        stats_mod,
-        "prepare_all_subject_summed_bca_data",
+        "Tools.Stats.PySide6.stats_workers.prepare_summed_bca_data",
         lambda *a, **k: store["payload"],
         raising=False,
     )


### PR DESCRIPTION
### Motivation
- Provide a configurable DV policy layer so the primary dependent variable (Summed BCA) can be computed either with the existing legacy selection or with a deterministic Fixed-K harmonics rule. 
- Keep downstream analyses unchanged while allowing users to choose the DV selection method from the Stats UI for the current session. 
- Record DV policy and settings in exports so runs are auditable.

### Description
- Added a new module `src/Tools/Stats/PySide6/dv_policies.py` that exposes `prepare_summed_bca_data` and implements `Legacy` (delegates to existing `prepare_all_subject_summed_bca_data`) and `Fixed-K` DV policies with deterministic harmonic selection, exclusions, and guardrails. 
- Introduced a “Summed BCA definition” section in the Stats UI (`src/Tools/Stats/PySide6/stats_main_window.py`) with a single-select policy dropdown (`"Current (Legacy)"` default, `"Fixed-K harmonics"`), Fixed-K controls (`K` spinbox, exclude harmonic 1, exclude base-rate harmonics) and a read-only base frequency display; policies are stored in window state for the session. 
- Routed the DV policy through the pipeline: Stats workers now call `prepare_summed_bca_data` instead of the legacy helper; `dv_policy` is threaded through `get_step_config` kwargs, `StatsController` job specs, and the between-groups CLI (`src/Tools/Stats/Legacy/between_groups_cli.py`) so all analysis steps use the selected policy. 
- Added minimal DV metadata export (`dv_metadata.json`) alongside existing exports containing `policy_name`, `fixed_k`, exclusions, `base_frequency_hz`, and `selected_conditions`. 
- Tests: added `tests/test_stats_dv_policy.py` (pytest-qt) to validate UI presence/defaults, Fixed-K snapshot/kwargs, and that changing DV policy does not reorder/alter pipeline steps; updated a couple of existing tests/mocks to use the new `prepare_summed_bca_data` entrypoint.

### Testing
- Added automated pytest-qt tests in `tests/test_stats_dv_policy.py` that exercise the UI selector default, changing to Fixed-K and snapshotting kwargs, and step-queue invariance; these tests were added to the test suite. 
- Attempted to run the project's recommended verification commands (`.venv/Scripts/python -m pytest -q`, `.venv/Scripts/ruff check .`, `.venv/Scripts/mypy src --strict`) but they could not complete because the repository environment `.venv` is not present in this run environment; no test failures were observed in repository static inspection. 
- Performed code-level verification that `QAction` import remains from `PySide6.QtGui` and that no legacy black-box modules under `Legacy` (other than adding an entrypoint usage) were modified in their internal logic. 
- Manual/interactive UI checks were not performed in this environment; CI should run the full pytest suite and linters to validate runtime behavior and catch any environment-specific issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752dad0410832cb9e519e2bbaffab2)