### PR TITLE
Add Group Mean‑Z (Union within ROI) DV policy with preview and export

### DIFF
--- a/src/Tools/Stats/PySide6/dv_policies.py
+++ b/src/Tools/Stats/PySide6/dv_policies.py
@@ -17,9 +17,21 @@ from Tools.Stats.Legacy.stats_analysis import (
     get_included_freqs,
     prepare_all_subject_summed_bca_data,
 )
+from Tools.Stats.PySide6.group_harmonics import (
+    GroupMeanZSummary,
+    build_group_mean_z_summary,
+    compute_union_harmonics_by_roi,
+)
 
 LEGACY_POLICY_NAME = "Current (Legacy)"
 FIXED_K_POLICY_NAME = "Fixed-K harmonics"
+GROUP_MEAN_Z_POLICY_NAME = (
+    "Group Mean-Z (Union within ROI across selected conditions)"
+)
+
+EMPTY_LIST_FALLBACK_FIXED_K = "Fallback to Fixed-K"
+EMPTY_LIST_SET_ZERO = "Set DV=0"
+EMPTY_LIST_ERROR = "Error"
 
 
 @dataclass(frozen=True)
@@ -28,6 +40,8 @@ class DVPolicySettings:
     fixed_k: int = 5
     exclude_harmonic1: bool = True
     exclude_base_harmonics: bool = True
+    z_threshold: float = 1.64
+    empty_list_policy: str = EMPTY_LIST_FALLBACK_FIXED_K
 
     def to_metadata(self, *, base_freq: float, selected_conditions: List[str]) -> dict:
         return {
@@ -35,6 +49,8 @@ class DVPolicySettings:
             "fixed_k": int(self.fixed_k),
             "exclude_harmonic1": bool(self.exclude_harmonic1),
             "exclude_base_harmonics": bool(self.exclude_base_harmonics),
+            "z_threshold": float(self.z_threshold),
+            "empty_list_policy": str(self.empty_list_policy),
             "base_frequency_hz": float(base_freq),
             "selected_conditions": list(selected_conditions),
         }
@@ -44,16 +60,32 @@ def normalize_dv_policy(settings: dict[str, object] | None) -> DVPolicySettings:
     if not settings:
         return DVPolicySettings()
     name = str(settings.get("name", LEGACY_POLICY_NAME))
-    if name not in (LEGACY_POLICY_NAME, FIXED_K_POLICY_NAME):
+    if name not in (
+        LEGACY_POLICY_NAME,
+        FIXED_K_POLICY_NAME,
+        GROUP_MEAN_Z_POLICY_NAME,
+    ):
         name = LEGACY_POLICY_NAME
     fixed_k = int(settings.get("fixed_k", 5))
     if fixed_k < 1:
         fixed_k = 1
+    empty_list_policy = str(
+        settings.get("empty_list_policy", EMPTY_LIST_FALLBACK_FIXED_K)
+    )
+    if empty_list_policy not in (
+        EMPTY_LIST_FALLBACK_FIXED_K,
+        EMPTY_LIST_SET_ZERO,
+        EMPTY_LIST_ERROR,
+    ):
+        empty_list_policy = EMPTY_LIST_FALLBACK_FIXED_K
+    z_threshold = float(settings.get("z_threshold", 1.64))
     return DVPolicySettings(
         name=name,
         fixed_k=fixed_k,
         exclude_harmonic1=bool(settings.get("exclude_harmonic1", True)),
         exclude_base_harmonics=bool(settings.get("exclude_base_harmonics", True)),
+        z_threshold=z_threshold,
+        empty_list_policy=empty_list_policy,
     )
 
 
@@ -67,9 +99,28 @@ def prepare_summed_bca_data(
     rois: Optional[Dict[str, List[str]]] = None,
     provenance_map: Optional[dict[tuple[str, str, str], dict[str, object]]] = None,
     dv_policy: dict[str, object] | None = None,
+    dv_metadata: Optional[dict[str, object]] = None,
 ) -> Optional[Dict[str, Dict[str, Dict[str, float]]]]:
     settings = normalize_dv_policy(dv_policy)
+    if settings.name == GROUP_MEAN_Z_POLICY_NAME:
+        return _prepare_group_mean_z_union_bca_data(
+            subjects=subjects,
+            conditions=conditions,
+            subject_data=subject_data,
+            base_freq=base_freq,
+            log_func=log_func,
+            rois=rois,
+            provenance_map=provenance_map,
+            settings=settings,
+            dv_metadata=dv_metadata,
+        )
     if settings.name == FIXED_K_POLICY_NAME:
+        if dv_metadata is not None:
+            dv_metadata.update(
+                settings.to_metadata(
+                    base_freq=base_freq, selected_conditions=conditions
+                )
+            )
         return _prepare_fixed_k_bca_data(
             subjects=subjects,
             conditions=conditions,
@@ -80,6 +131,8 @@ def prepare_summed_bca_data(
             provenance_map=provenance_map,
             settings=settings,
         )
+    if dv_metadata is not None:
+        dv_metadata.update(settings.to_metadata(base_freq=base_freq, selected_conditions=conditions))
     return prepare_all_subject_summed_bca_data(
         subjects=subjects,
         conditions=conditions,
@@ -164,7 +217,7 @@ def _find_first_bca_columns(
     return None
 
 
-def _aggregate_bca_sum_fixed_k(
+def _aggregate_bca_sum_harmonics(
     file_path: str,
     roi_name: str,
     log_func: Callable[[str], None],
@@ -212,9 +265,7 @@ def _aggregate_bca_sum_fixed_k(
                 cols_to_sum.append(col_bca)
 
         if not cols_to_sum:
-            log_func(
-                f"No fixed-k harmonics found for ROI {roi_name} in {file_path}."
-            )
+            log_func(f"No harmonics found for ROI {roi_name} in {file_path}.")
             if diag_meta is not None:
                 diag_meta["col_label"] = []
             return np.nan
@@ -299,7 +350,7 @@ def _prepare_fixed_k_bca_data(
                 if provenance_map is not None:
                     diag_meta = {}
                 if file_path and Path(file_path).exists():
-                    sum_val = _aggregate_bca_sum_fixed_k(
+                    sum_val = _aggregate_bca_sum_harmonics(
                         file_path,
                         roi_name,
                         log_func,
@@ -321,6 +372,216 @@ def _prepare_fixed_k_bca_data(
                     if diag_meta:
                         provenance.update(diag_meta)
                     provenance_map[(pid, cond_name, roi_name)] = provenance
+
+    total = 0
+    finite = 0
+    for pid, conds in all_subject_data.items():
+        for _cond, rois_dict in conds.items():
+            for _roi, val in rois_dict.items():
+                total += 1
+                if val is not None and np.isfinite(val):
+                    finite += 1
+    log_func(f"[DEBUG] Summed BCA finite cells: {finite}/{total}")
+    log_func("Summed BCA data prep complete.")
+    return all_subject_data
+
+
+def apply_empty_union_policy(
+    union_harmonics: dict[str, list[float]],
+    *,
+    policy: str,
+    fallback_freqs: list[float],
+) -> tuple[dict[str, list[float]], dict[str, dict[str, object]]]:
+    final_map: dict[str, list[float]] = {}
+    info: dict[str, dict[str, object]] = {}
+    for roi, freqs in union_harmonics.items():
+        if freqs:
+            final_map[roi] = list(freqs)
+            info[roi] = {"policy": policy, "fallback_used": False}
+            continue
+        if policy == EMPTY_LIST_FALLBACK_FIXED_K:
+            final_map[roi] = list(fallback_freqs)
+            info[roi] = {
+                "policy": policy,
+                "fallback_used": True,
+                "fallback_harmonics": list(fallback_freqs),
+            }
+        elif policy == EMPTY_LIST_SET_ZERO:
+            final_map[roi] = []
+            info[roi] = {"policy": policy, "fallback_used": False}
+        elif policy == EMPTY_LIST_ERROR:
+            final_map[roi] = []
+            info[roi] = {"policy": policy, "fallback_used": False}
+        else:
+            final_map[roi] = list(freqs)
+            info[roi] = {"policy": policy, "fallback_used": False}
+    return final_map, info
+
+
+def build_group_mean_z_preview_payload(
+    *,
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    base_freq: float,
+    rois: Dict[str, List[str]],
+    log_func: Callable[[str], None],
+    dv_policy: dict[str, object] | None = None,
+) -> dict[str, object]:
+    settings = normalize_dv_policy(dv_policy)
+    if settings.name != GROUP_MEAN_Z_POLICY_NAME:
+        raise RuntimeError("Group Mean-Z preview requires the Group Mean-Z policy.")
+
+    summary = build_group_mean_z_summary(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        rois=rois,
+        z_threshold=settings.z_threshold,
+        log_func=log_func,
+    )
+    union_map = compute_union_harmonics_by_roi(
+        summary.mean_z_table, conditions=conditions, z_threshold=settings.z_threshold
+    )
+    for roi_name in rois.keys():
+        union_map.setdefault(roi_name, [])
+    fallback_freqs = _determine_fixed_k_freqs(
+        columns=summary.columns,
+        base_freq=base_freq,
+        settings=settings,
+        log_func=log_func,
+    )
+    final_union_map, fallback_info = apply_empty_union_policy(
+        union_map, policy=settings.empty_list_policy, fallback_freqs=fallback_freqs
+    )
+
+    if settings.empty_list_policy == EMPTY_LIST_ERROR:
+        empty_rois = [roi for roi, freqs in union_map.items() if not freqs]
+        if empty_rois:
+            missing = ", ".join(sorted(empty_rois))
+            raise RuntimeError(
+                "Group Mean-Z union harmonics empty for ROI(s): "
+                f"{missing}. Adjust threshold or policy."
+            )
+
+    return {
+        "union_harmonics_by_roi": final_union_map,
+        "fallback_info_by_roi": fallback_info,
+        "mean_z_table": summary.mean_z_table,
+        "harmonic_domain": summary.harmonic_freqs,
+    }
+
+
+def _prepare_group_mean_z_union_bca_data(
+    *,
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    base_freq: float,
+    log_func: Callable[[str], None],
+    rois: Optional[Dict[str, List[str]]] = None,
+    provenance_map: Optional[dict[tuple[str, str, str], dict[str, object]]] = None,
+    settings: DVPolicySettings,
+    dv_metadata: Optional[dict[str, object]] = None,
+) -> Optional[Dict[str, Dict[str, Dict[str, float]]]]:
+    if not subjects or not subject_data:
+        log_func("No subject data. Scan folder first.")
+        return None
+
+    rois_map = rois if rois is not None else _current_rois_map()
+    if not rois_map:
+        log_func("No ROIs defined or available.")
+        return None
+
+    summary: GroupMeanZSummary = build_group_mean_z_summary(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=base_freq,
+        rois=rois_map,
+        z_threshold=settings.z_threshold,
+        log_func=log_func,
+    )
+    union_map = compute_union_harmonics_by_roi(
+        summary.mean_z_table, conditions=conditions, z_threshold=settings.z_threshold
+    )
+    for roi_name in rois_map.keys():
+        union_map.setdefault(roi_name, [])
+
+    fallback_freqs = _determine_fixed_k_freqs(
+        columns=summary.columns,
+        base_freq=base_freq,
+        settings=settings,
+        log_func=log_func,
+    )
+
+    final_union_map, fallback_info = apply_empty_union_policy(
+        union_map, policy=settings.empty_list_policy, fallback_freqs=fallback_freqs
+    )
+
+    if settings.empty_list_policy == EMPTY_LIST_ERROR:
+        empty_rois = [roi for roi, freqs in union_map.items() if not freqs]
+        if empty_rois:
+            missing = ", ".join(sorted(empty_rois))
+            raise RuntimeError(
+                "Group Mean-Z union harmonics empty for ROI(s): "
+                f"{missing}. Adjust threshold or policy."
+            )
+
+    all_subject_data: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for pid in subjects:
+        all_subject_data[pid] = {}
+        for cond_name in conditions:
+            file_path = subject_data.get(pid, {}).get(cond_name)
+            all_subject_data[pid].setdefault(cond_name, {})
+            for roi_name in rois_map.keys():
+                sum_val = np.nan
+                diag_meta: Optional[dict[str, object]] = None
+                if provenance_map is not None:
+                    diag_meta = {}
+                harmonics = final_union_map.get(roi_name, [])
+                if not harmonics and settings.empty_list_policy == EMPTY_LIST_SET_ZERO:
+                    sum_val = 0.0
+                elif file_path and Path(file_path).exists():
+                    sum_val = _aggregate_bca_sum_harmonics(
+                        file_path,
+                        roi_name,
+                        log_func,
+                        harmonics,
+                        rois=rois_map,
+                        diag_meta=diag_meta,
+                    )
+                else:
+                    log_func(f"Missing file for {pid} {cond_name}: {file_path}")
+                all_subject_data[pid][cond_name][roi_name] = sum_val
+                if provenance_map is not None:
+                    provenance = {
+                        "source_file": file_path,
+                        "sheet": "BCA (uV)",
+                        "row_label": None,
+                        "col_label": None,
+                        "raw_cell": None,
+                    }
+                    if diag_meta:
+                        provenance.update(diag_meta)
+                    provenance_map[(pid, cond_name, roi_name)] = provenance
+
+    if dv_metadata is not None:
+        dv_metadata.update(
+            settings.to_metadata(
+                base_freq=base_freq,
+                selected_conditions=conditions,
+            )
+        )
+        dv_metadata["group_mean_z"] = {
+            "z_threshold": float(settings.z_threshold),
+            "empty_list_policy": settings.empty_list_policy,
+            "harmonic_domain": list(summary.harmonic_freqs),
+            "union_harmonics_by_roi": final_union_map,
+            "fallback_info_by_roi": fallback_info,
+            "mean_z_table": summary.mean_z_table,
+        }
 
     total = 0
     finite = 0

--- a/src/Tools/Stats/PySide6/group_harmonics.py
+++ b/src/Tools/Stats/PySide6/group_harmonics.py
@@ -1,0 +1,174 @@
+"""Helpers for Group Mean-Z harmonic union selection."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.Legacy.excel_io import safe_read_excel
+from Tools.Stats.Legacy.stats_analysis import (
+    SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
+    SUMMED_BCA_Z_SHEET_NAME,
+    _match_freq_column,
+    filter_to_oddball_harmonics,
+    get_included_freqs,
+)
+
+
+@dataclass(frozen=True)
+class GroupMeanZSummary:
+    harmonic_freqs: List[float]
+    mean_z_table: pd.DataFrame
+    columns: pd.Index
+
+
+def _find_first_z_columns(
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    log_func: Callable[[str], None],
+) -> pd.Index:
+    for pid in subjects:
+        for cond_name in conditions:
+            file_path = subject_data.get(pid, {}).get(cond_name)
+            if not file_path:
+                continue
+            try:
+                df_z = safe_read_excel(
+                    file_path, sheet_name=SUMMED_BCA_Z_SHEET_NAME, index_col="Electrode"
+                )
+                return df_z.columns
+            except Exception as exc:  # noqa: BLE001
+                log_func(f"Failed to read Z columns from {file_path}: {exc}")
+    return pd.Index([])
+
+
+def _build_harmonic_domain(
+    columns: Iterable[object],
+    base_freq: float,
+    log_func: Callable[[str], None],
+) -> List[float]:
+    freq_candidates = get_included_freqs(base_freq, columns, log_func)
+    if not freq_candidates:
+        return []
+    oddball_list = filter_to_oddball_harmonics(
+        freq_candidates,
+        base_freq,
+        every_n=SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
+        tol=1e-3,
+    )
+    return [freq for freq, _k in oddball_list]
+
+
+def compute_union_harmonics_by_roi(
+    mean_z_table: pd.DataFrame,
+    *,
+    conditions: Sequence[str],
+    z_threshold: float,
+) -> dict[str, list[float]]:
+    union_map: dict[str, list[float]] = {}
+    if mean_z_table.empty:
+        return union_map
+
+    filtered = mean_z_table[mean_z_table["condition"].isin(conditions)]
+    grouped = filtered.groupby("roi")
+    for roi_name, roi_df in grouped:
+        sig_df = roi_df[roi_df["mean_z"] > z_threshold]
+        harmonics = sorted(sig_df["harmonic_hz"].unique().tolist())
+        union_map[str(roi_name)] = harmonics
+    return union_map
+
+
+def build_group_mean_z_summary(
+    *,
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    base_freq: float,
+    rois: Dict[str, List[str]],
+    z_threshold: float,
+    log_func: Callable[[str], None],
+) -> GroupMeanZSummary:
+    columns = _find_first_z_columns(subjects, conditions, subject_data, log_func)
+    harmonic_freqs = _build_harmonic_domain(columns, base_freq, log_func)
+    if not harmonic_freqs:
+        raise RuntimeError(
+            "Group Mean-Z harmonics selection produced an empty list. "
+            "Verify Z-score sheets and base frequency."
+        )
+
+    roi_map = rois
+    mean_values: dict[tuple[str, str, float], list[float]] = {}
+
+    for pid in subjects:
+        for cond_name in conditions:
+            file_path = subject_data.get(pid, {}).get(cond_name)
+            if not file_path:
+                log_func(f"Missing file for {pid} {cond_name}: {file_path}")
+                continue
+            if not Path(file_path).exists():
+                log_func(f"Missing file for {pid} {cond_name}: {file_path}")
+                continue
+            try:
+                df_z = safe_read_excel(
+                    file_path, sheet_name=SUMMED_BCA_Z_SHEET_NAME, index_col="Electrode"
+                )
+            except Exception as exc:  # noqa: BLE001
+                log_func(f"Failed to read Z sheet from {file_path}: {exc}")
+                continue
+
+            df_z.index = df_z.index.astype(str).str.upper().str.strip()
+            col_map = {freq: _match_freq_column(df_z.columns, freq) for freq in harmonic_freqs}
+
+            for roi_name, roi_channels in roi_map.items():
+                roi_chans = [
+                    str(ch).strip().upper()
+                    for ch in (roi_channels or [])
+                    if str(ch).strip().upper() in df_z.index
+                ]
+                if not roi_chans:
+                    log_func(f"No overlapping Z data for ROI {roi_name} in {file_path}.")
+                    continue
+                df_roi = df_z.loc[roi_chans].dropna(how="all")
+                if df_roi.empty:
+                    log_func(f"No Z data for ROI {roi_name} in {file_path}.")
+                    continue
+
+                for freq_val in harmonic_freqs:
+                    col_z = col_map.get(freq_val)
+                    if not col_z:
+                        continue
+                    series = pd.to_numeric(df_roi[col_z], errors="coerce").replace(
+                        [np.inf, -np.inf], np.nan
+                    )
+                    mean_val = float(series.mean(skipna=True))
+                    if not np.isfinite(mean_val):
+                        continue
+                    key = (cond_name, roi_name, float(freq_val))
+                    mean_values.setdefault(key, []).append(mean_val)
+
+    rows = []
+    for (cond_name, roi_name, freq_val), values in mean_values.items():
+        mean_val = float(np.nanmean(values)) if values else np.nan
+        rows.append(
+            {
+                "condition": cond_name,
+                "roi": roi_name,
+                "harmonic_hz": float(freq_val),
+                "mean_z": mean_val,
+                "significant": bool(mean_val > z_threshold),
+            }
+        )
+
+    mean_z_table = pd.DataFrame(rows)
+    if not mean_z_table.empty:
+        mean_z_table = mean_z_table.sort_values(["roi", "condition", "harmonic_hz"])
+
+    return GroupMeanZSummary(
+        harmonic_freqs=harmonic_freqs,
+        mean_z_table=mean_z_table,
+        columns=columns,
+    )

--- a/tests/test_group_mean_z_union_logic.py
+++ b/tests/test_group_mean_z_union_logic.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from Tools.Stats.PySide6.dv_policies import (
+    EMPTY_LIST_FALLBACK_FIXED_K,
+    apply_empty_union_policy,
+)
+from Tools.Stats.PySide6.group_harmonics import compute_union_harmonics_by_roi
+
+
+def test_group_mean_z_union_logic_and_fallback():
+    mean_z_table = pd.DataFrame(
+        [
+            {"condition": "CondA", "roi": "ROI1", "harmonic_hz": 1.2, "mean_z": 2.0},
+            {"condition": "CondA", "roi": "ROI1", "harmonic_hz": 2.4, "mean_z": 1.0},
+            {"condition": "CondB", "roi": "ROI1", "harmonic_hz": 2.4, "mean_z": 2.1},
+            {"condition": "CondA", "roi": "ROI2", "harmonic_hz": 1.2, "mean_z": 0.5},
+            {"condition": "CondB", "roi": "ROI2", "harmonic_hz": 3.6, "mean_z": 0.2},
+        ]
+    )
+
+    union_map = compute_union_harmonics_by_roi(
+        mean_z_table,
+        conditions=["CondA", "CondB"],
+        z_threshold=1.5,
+    )
+
+    assert union_map["ROI1"] == [1.2, 2.4]
+    assert union_map["ROI2"] == []
+
+    final_map, fallback_info = apply_empty_union_policy(
+        union_map,
+        policy=EMPTY_LIST_FALLBACK_FIXED_K,
+        fallback_freqs=[1.2, 2.4, 3.6],
+    )
+
+    assert final_map["ROI2"] == [1.2, 2.4, 3.6]
+    assert fallback_info["ROI2"]["fallback_used"] is True

--- a/tests/test_stats_dv_policy.py
+++ b/tests/test_stats_dv_policy.py
@@ -4,7 +4,9 @@ import pytest
 
 pytest.importorskip("PySide6")
 from Tools.Stats.PySide6.dv_policies import (  # noqa: E402
+    EMPTY_LIST_FALLBACK_FIXED_K,
     FIXED_K_POLICY_NAME,
+    GROUP_MEAN_Z_POLICY_NAME,
     LEGACY_POLICY_NAME,
 )
 from Tools.Stats.PySide6.stats_core import PipelineId, StepId  # noqa: E402
@@ -49,6 +51,20 @@ def test_stats_dv_policy_fixed_k_snapshot_and_kwargs(qtbot):
     kwargs, _handler = window.get_step_config(PipelineId.SINGLE, StepId.RM_ANOVA)
     assert kwargs["dv_policy"]["name"] == FIXED_K_POLICY_NAME
     assert kwargs["dv_policy"]["fixed_k"] == 7
+
+
+@pytest.mark.qt
+def test_stats_dv_policy_group_mean_z_defaults(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+
+    window.dv_policy_combo.setCurrentText(GROUP_MEAN_Z_POLICY_NAME)
+    snapshot = window.get_dv_policy_snapshot()
+
+    assert snapshot["name"] == GROUP_MEAN_Z_POLICY_NAME
+    assert snapshot["z_threshold"] == pytest.approx(1.64)
+    assert snapshot["empty_list_policy"] == EMPTY_LIST_FALLBACK_FIXED_K
 
 
 @pytest.mark.qt

--- a/tests/test_stats_group_mean_preview.py
+++ b/tests/test_stats_group_mean_preview.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtCore import Qt  # noqa: E402
+
+from Tools.Stats.PySide6.dv_policies import (  # noqa: E402
+    EMPTY_LIST_FALLBACK_FIXED_K,
+    GROUP_MEAN_Z_POLICY_NAME,
+)
+from Tools.Stats.PySide6.stats_workers import StatsWorker  # noqa: E402
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow  # noqa: E402
+
+
+@pytest.mark.qt
+def test_group_mean_preview_updates_table(qtbot, tmp_path, monkeypatch):
+    window = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(window)
+    window.show()
+
+    window.subjects = ["S1"]
+    window.conditions = ["CondA", "CondB"]
+    window.subject_data = {"S1": {"CondA": "a.xlsx", "CondB": "b.xlsx"}}
+    window.rois = {"ROI1": ["Fz"]}
+
+    monkeypatch.setattr(window, "refresh_rois", lambda: None)
+    monkeypatch.setattr(window, "_get_analysis_settings", lambda: (6.0, 0.05))
+
+    window.dv_policy_combo.setCurrentText(GROUP_MEAN_Z_POLICY_NAME)
+    window.group_mean_empty_policy_combo.setCurrentText(EMPTY_LIST_FALLBACK_FIXED_K)
+
+    def fast_run(self):  # pragma: no cover - executed in Qt thread pool
+        payload = {
+            "union_harmonics_by_roi": {"ROI1": [1.2, 2.4]},
+            "fallback_info_by_roi": {"ROI1": {"policy": EMPTY_LIST_FALLBACK_FIXED_K, "fallback_used": False}},
+        }
+        self.signals.finished.emit(payload)
+
+    monkeypatch.setattr(StatsWorker, "run", fast_run, raising=False)
+
+    qtbot.mouseClick(window.group_mean_preview_btn, Qt.LeftButton)
+    qtbot.waitUntil(lambda: window.group_mean_preview_table.rowCount() == 1, timeout=2000)
+
+    assert window.group_mean_preview_table.item(0, 0).text() == "ROI1"
+    assert "1.2" in window.group_mean_preview_table.item(0, 1).text()


### PR DESCRIPTION
### Motivation
- Implement the new primary DV method "Group Mean-Z (Union within ROI across selected conditions)" which selects harmonics by group-mean Z and applies the UNION across user-selected conditions per ROI for summed BCA computation.
- Preserve existing downstream statistics pipelines (RM-ANOVA / LMM / post-hocs) and file formats while adding metadata and a DV definition export for reproducibility.
- Provide a non-blocking preview flow so users can inspect final harmonic sets per ROI before running full analyses.

### Description
- Added a new DV policy constant `GROUP_MEAN_Z_POLICY_NAME`, settings (`z_threshold`, `empty_list_policy`) and empty-union policies (`Fallback to Fixed-K`, `Set DV=0`, `Error`) in `src/Tools/Stats/PySide6/dv_policies.py` and wired policy normalization/metadata.
- Implemented the Group Mean-Z harmonic selection and summary builder in new helper module `src/Tools/Stats/PySide6/group_harmonics.py` which reads Z-score sheets, computes ROI-mean Z by subject×condition×ROI×harmonic and produces the mean-Z table used to form unions.
- Implemented union logic, empty-union handling (fallback to Fixed-K, zeroing DV, or abort), summed-BCA aggregation using the union per ROI, and DV metadata capture and export in `src/Tools/Stats/PySide6/dv_policies.py` and integrated it into the existing `prepare_summed_bca_data` pipeline.
- UI: added the option to the DV selector and the Group Mean-Z controls (Z threshold spinbox, empty-union policy dropdown, explanatory label), a read-only preview table and a non-blocking `Preview harmonic sets` action to `src/Tools/Stats/PySide6/stats_main_window.py`, with preview computation run in a worker via `StatsWorker` and preview handler plumbing.
- Worker/service changes: extended worker APIs to accept/return `dv_metadata`, added `run_group_mean_z_preview` helper in `src/Tools/Stats/PySide6/stats_workers.py`, and ensured metadata is propagated back to the view for export.
- Exports: added a DV Definition / Harmonic Sets workbook export (summary + per‑ROI unions + mean-Z table) to the Stats results folder from `StatsWindow._write_dv_metadata` when Group Mean-Z metadata is present.
- Tests: added focused tests for the new functionality: `tests/test_group_mean_z_union_logic.py` (unit: union + fallback logic), `tests/test_stats_group_mean_preview.py` (qt: preview wiring populates preview table via worker), and extended `tests/test_stats_dv_policy.py` to check defaults for the new DV option.

### Testing
- `python -m pytest -q` was executed; collection failed for many tests in this environment due to missing runtime dependencies (notably `numpy`, `pandas`, and `PySide6`) and therefore the full test-suite did not complete (42 errors, 24 skipped during collection). The new unit tests are lightweight and designed to run without EEG data using small DataFrames and mocked workers, but they could not be validated in the current runner because of environment constraints.
- `ruff check .` was run and reported existing repository-wide lint issues unrelated to these changes (pre-existing failures discovered during the run), so repo-wide lint is not clean in this environment.
- `mypy src --strict` was run and aborted due to an unrelated syntax error in `src/Compiler_Script.py` in this environment, so strict typing could not be completed end-to-end.

Note: the new code is confined to the Stats PySide6 path and new helper module; no black-box Legacy modules were modified. Worker-based preview and DV computation run on QRunnable/QThreadPool and preserve downstream dataframe schema so RM-ANOVA/LMM/post-hoc steps receive the same long-format input as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756e66f3c4832cb98109198b334ff4)