### PR TITLE
Add export-only DV variants (Fixed-K / Group Mean‑Z) with UI, worker wiring, export workbook & tests

### DIFF
--- a/src/Tools/Stats/PySide6/dv_variants.py
+++ b/src/Tools/Stats/PySide6/dv_variants.py
@@ -1,0 +1,211 @@
+"""Helpers for computing and exporting DV variant tables."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+import pandas as pd
+
+from Tools.Stats.PySide6.dv_policies import (
+    FIXED_K_POLICY_NAME,
+    GROUP_MEAN_Z_POLICY_NAME,
+    LEGACY_POLICY_NAME,
+    normalize_dv_policy,
+    prepare_summed_bca_data,
+)
+
+
+DV_POLICY_SHORT_NAMES = {
+    LEGACY_POLICY_NAME: "Legacy",
+    FIXED_K_POLICY_NAME: "FixedK",
+    GROUP_MEAN_Z_POLICY_NAME: "GroupMeanZUnion",
+}
+
+
+@dataclass(frozen=True)
+class DVVariantPayload:
+    primary_name: str
+    primary_df: pd.DataFrame
+    variant_dfs: Dict[str, pd.DataFrame]
+    summary_df: pd.DataFrame
+    errors: List[dict]
+    selected_variants: List[str]
+
+
+def dv_policy_short_name(policy_name: str) -> str:
+    return DV_POLICY_SHORT_NAMES.get(policy_name, policy_name.replace(" ", ""))
+
+
+def build_long_dv_table(
+    all_subject_bca_data: Dict[str, Dict[str, Dict[str, float]]],
+) -> pd.DataFrame:
+    rows: List[dict] = []
+    for pid, cond_data in all_subject_bca_data.items():
+        for cond_name, roi_data in cond_data.items():
+            for roi_name, value in roi_data.items():
+                if not pd.isna(value):
+                    rows.append(
+                        {
+                            "subject": pid,
+                            "condition": cond_name,
+                            "roi": roi_name,
+                            "value": value,
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def build_dv_comparison_summary(
+    dv_tables: Dict[str, pd.DataFrame],
+) -> pd.DataFrame:
+    if not dv_tables:
+        return pd.DataFrame()
+
+    merged: Optional[pd.DataFrame] = None
+    for name, df in dv_tables.items():
+        if df is None or df.empty:
+            continue
+        short = dv_policy_short_name(name)
+        stats = (
+            df.groupby(["condition", "roi"], dropna=False)["value"]
+            .agg(["count", "mean", "std"])
+            .reset_index()
+        )
+        stats = stats.rename(
+            columns={
+                "count": f"N__{short}",
+                "mean": f"mean__{short}",
+                "std": f"sd__{short}",
+            }
+        )
+        if merged is None:
+            merged = stats
+        else:
+            merged = merged.merge(stats, on=["condition", "roi"], how="outer")
+
+    return merged if merged is not None else pd.DataFrame()
+
+
+def compute_dv_variants_payload(
+    *,
+    subjects: List[str],
+    conditions: List[str],
+    subject_data: Dict[str, Dict[str, str]],
+    base_freq: float,
+    rois: Dict[str, List[str]],
+    dv_policy: dict[str, object] | None,
+    variant_policies: List[dict[str, object]],
+    log_func: Callable[[str], None],
+    primary_data: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None,
+) -> Optional[DVVariantPayload]:
+    if not variant_policies:
+        return None
+
+    primary_settings = normalize_dv_policy(dv_policy)
+    primary_name = primary_settings.name
+
+    if primary_data is None:
+        primary_data = prepare_summed_bca_data(
+            subjects=subjects,
+            conditions=conditions,
+            subject_data=subject_data,
+            base_freq=base_freq,
+            log_func=log_func,
+            rois=rois,
+            dv_policy=dv_policy,
+        )
+    if not primary_data:
+        raise RuntimeError("Primary DV data preparation failed (empty).")
+
+    primary_df = build_long_dv_table(primary_data)
+    errors: List[dict] = []
+    variant_dfs: Dict[str, pd.DataFrame] = {}
+    selected_variants: List[str] = []
+
+    for policy in variant_policies:
+        settings = normalize_dv_policy(policy)
+        name = settings.name
+        selected_variants.append(name)
+        if name == primary_name:
+            log_func(
+                f"Skipping DV variant {name} because it matches the primary DV method."
+            )
+            continue
+        try:
+            variant_data = prepare_summed_bca_data(
+                subjects=subjects,
+                conditions=conditions,
+                subject_data=subject_data,
+                base_freq=base_freq,
+                log_func=log_func,
+                rois=rois,
+                dv_policy=policy,
+            )
+            if not variant_data:
+                raise RuntimeError("Data preparation failed (empty).")
+            variant_dfs[name] = build_long_dv_table(variant_data)
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"variant": name, "error": str(exc)})
+
+    all_tables = {primary_name: primary_df, **variant_dfs}
+    summary_df = build_dv_comparison_summary(all_tables)
+
+    return DVVariantPayload(
+        primary_name=primary_name,
+        primary_df=primary_df,
+        variant_dfs=variant_dfs,
+        summary_df=summary_df,
+        errors=errors,
+        selected_variants=selected_variants,
+    )
+
+
+def _sheet_name(prefix: str, policy_name: str) -> str:
+    short = dv_policy_short_name(policy_name)
+    return f"{prefix}{short}"[:31]
+
+
+def export_dv_variants_workbook(
+    *,
+    save_path: Path,
+    primary_name: str,
+    primary_df: pd.DataFrame,
+    variant_dfs: Dict[str, pd.DataFrame],
+    summary_df: pd.DataFrame,
+    errors: List[dict],
+    log_func: Callable[[str], None],
+) -> None:
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with pd.ExcelWriter(save_path, engine="openpyxl") as writer:
+        primary_df.to_excel(
+            writer,
+            sheet_name=_sheet_name("DV__PRIMARY__", primary_name),
+            index=False,
+        )
+
+        for name, df in variant_dfs.items():
+            df.to_excel(
+                writer,
+                sheet_name=_sheet_name("DV__VAR__", name),
+                index=False,
+            )
+
+        if summary_df is not None and not summary_df.empty:
+            summary_df.to_excel(writer, sheet_name="DV Comparison Summary", index=False)
+        else:
+            pd.DataFrame().to_excel(
+                writer, sheet_name="DV Comparison Summary", index=False
+            )
+
+        if errors:
+            pd.DataFrame(errors).to_excel(
+                writer, sheet_name="DV Variant Errors", index=False
+            )
+        else:
+            pd.DataFrame(columns=["variant", "error"]).to_excel(
+                writer, sheet_name="DV Variant Errors", index=False
+            )
+
+    log_func(f"Exported DV variants workbook to {save_path}")

--- a/src/Tools/Stats/PySide6/stats_controller.py
+++ b/src/Tools/Stats/PySide6/stats_controller.py
@@ -705,6 +705,7 @@ class StatsController:
             "base_freq": anova_kwargs.get("base_freq", 6.0),
             "alpha": mixed_kwargs.get("alpha", 0.05),
             "dv_policy": anova_kwargs.get("dv_policy", {}),
+            "dv_variants": anova_kwargs.get("dv_variants", []),
             "harmonic_options": {
                 "metric": harmonic_kwargs.get("selected_metric", "Z Score"),
                 "mean_value_threshold": harmonic_kwargs.get("mean_value_threshold", 0.0),
@@ -913,6 +914,10 @@ class StatsController:
                         message=f"{step.name} completed",
                     ),
                 )
+
+            dv_variants = payload.get("dv_variants") if isinstance(payload, dict) else None
+            if dv_variants:
+                self._view.store_dv_variants_payload(pipeline_id, dv_variants)
 
             state.current_step_index = len(state.steps)
             self._complete_pipeline(pipeline_id)

--- a/tests/test_stats_condition_selection.py
+++ b/tests/test_stats_condition_selection.py
@@ -18,6 +18,7 @@ def test_stats_condition_selection_snapshot_and_block(qtbot, tmp_path, monkeypat
     window._populate_conditions_panel(conditions)
 
     assert window.conditions_group.title() == "Included Conditions"
+    assert window._get_selected_conditions() == conditions
 
     checkboxes = {box.text(): box for box in window.findChildren(QCheckBox)}
     for condition in conditions:

--- a/tests/test_stats_dv_variants.py
+++ b/tests/test_stats_dv_variants.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtWidgets import QCheckBox  # noqa: E402
+
+from Tools.Stats.PySide6.dv_policies import (  # noqa: E402
+    FIXED_K_POLICY_NAME,
+    GROUP_MEAN_Z_POLICY_NAME,
+    LEGACY_POLICY_NAME,
+)
+from Tools.Stats.PySide6.stats_core import PipelineId, StepId  # noqa: E402
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow  # noqa: E402
+
+
+def _setup_window_state(window: StatsWindow) -> None:
+    window.subjects = ["S1", "S2"]
+    window.conditions = ["CondA", "CondB"]
+    window.subject_data = {
+        "S1": {"CondA": "a.xlsx", "CondB": "b.xlsx"},
+        "S2": {"CondA": "c.xlsx", "CondB": "d.xlsx"},
+    }
+    window.rois = {"ROI1": ["Fz"]}
+
+
+@pytest.mark.qt
+def test_stats_dv_variants_ui_defaults(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+
+    checkboxes = {box.text(): box for box in window.findChildren(QCheckBox)}
+    assert checkboxes[FIXED_K_POLICY_NAME].isChecked() is False
+    assert checkboxes[GROUP_MEAN_Z_POLICY_NAME].isChecked() is False
+    assert window.get_dv_variants_snapshot() == []
+
+
+@pytest.mark.qt
+def test_stats_group_mean_option_visibility(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+
+    window.dv_policy_combo.setCurrentText(GROUP_MEAN_Z_POLICY_NAME)
+    assert window.group_mean_controls.isVisible() is True
+
+
+@pytest.mark.qt
+def test_stats_dv_variants_do_not_change_primary_snapshot(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+    _setup_window_state(window)
+
+    window.dv_policy_combo.setCurrentText(LEGACY_POLICY_NAME)
+    baseline = window.get_dv_policy_snapshot()
+
+    window._dv_variant_checkboxes[FIXED_K_POLICY_NAME].setChecked(True)
+    assert window.get_dv_policy_snapshot() == baseline
+    assert window.get_dv_variants_snapshot() == [FIXED_K_POLICY_NAME]
+
+
+@pytest.mark.qt
+def test_stats_dv_variants_do_not_change_primary_kwargs(qtbot):
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+    window.show()
+    _setup_window_state(window)
+
+    window.dv_policy_combo.setCurrentText(LEGACY_POLICY_NAME)
+    kwargs_a, _handler_a = window.get_step_config(PipelineId.SINGLE, StepId.RM_ANOVA)
+
+    window._dv_variant_checkboxes[FIXED_K_POLICY_NAME].setChecked(True)
+    kwargs_b, _handler_b = window.get_step_config(PipelineId.SINGLE, StepId.RM_ANOVA)
+
+    assert kwargs_a["dv_policy"] == kwargs_b["dv_policy"]
+    assert kwargs_a["dv_variants"] != kwargs_b["dv_variants"]
+
+    kwargs_a_filtered = {k: v for k, v in kwargs_a.items() if k != "dv_variants"}
+    kwargs_b_filtered = {k: v for k, v in kwargs_b.items() if k != "dv_variants"}
+    assert kwargs_a_filtered == kwargs_b_filtered

--- a/tests/test_stats_dv_variants_summary.py
+++ b/tests/test_stats_dv_variants_summary.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from Tools.Stats.PySide6.dv_policies import FIXED_K_POLICY_NAME, LEGACY_POLICY_NAME
+from Tools.Stats.PySide6.dv_variants import build_dv_comparison_summary
+
+
+def test_build_dv_comparison_summary():
+    primary = pd.DataFrame(
+        [
+            {"subject": "S1", "condition": "A", "roi": "R1", "value": 1.0},
+            {"subject": "S2", "condition": "A", "roi": "R1", "value": 3.0},
+            {"subject": "S1", "condition": "B", "roi": "R1", "value": 2.0},
+        ]
+    )
+    variant = pd.DataFrame(
+        [
+            {"subject": "S1", "condition": "A", "roi": "R1", "value": 2.0},
+            {"subject": "S2", "condition": "A", "roi": "R1", "value": 4.0},
+            {"subject": "S1", "condition": "B", "roi": "R1", "value": 6.0},
+        ]
+    )
+
+    summary = build_dv_comparison_summary(
+        {LEGACY_POLICY_NAME: primary, FIXED_K_POLICY_NAME: variant}
+    )
+
+    assert {"condition", "roi"}.issubset(summary.columns)
+    assert "N__Legacy" in summary.columns
+    assert "mean__Legacy" in summary.columns
+    assert "sd__Legacy" in summary.columns
+    assert "N__FixedK" in summary.columns
+
+    row_a = summary.loc[(summary["condition"] == "A") & (summary["roi"] == "R1")].iloc[0]
+    assert row_a["N__Legacy"] == 2
+    assert row_a["mean__Legacy"] == 2.0
+    assert row_a["mean__FixedK"] == 3.0


### PR DESCRIPTION
### Motivation
- Provide an option to compute one-or-more alternative DV definitions in the same run for export/inspection while keeping all inferential statistics (RM-ANOVA / MixedLM / post-hocs) driven only by a single chosen Primary DV.
- Preserve backwards compatibility and processing order so enabling variants does not change any downstream inferential results when the Primary DV remains the same.
- Make variant computation non-blocking and robust: run in worker threads, capture errors per-variant and report them without crashing primary analysis.

### Description
- UI: added a new subsection under the existing "Summed BCA definition" panel titled "Also compute DV variants (export only)" with explanatory text and checkboxes for `Fixed-K harmonics` and `Group Mean-Z (Union...)`, defaulting to none checked; the Primary DV selector and Fixed-K / Group Mean-Z controls are unchanged. (Touched: `src/Tools/Stats/PySide6/stats_main_window.py`)
- Worker/controller plumbing: passed a `dv_variants` payload through `get_step_config` → `StatsController` → worker functions and compute variants inside the worker context using a new helper; variant computation reuses the already-prepared Primary DV data when possible and never mutates the Primary DV used by inferential steps. (Touched: `src/Tools/Stats/PySide6/stats_main_window.py`, `src/Tools/Stats/PySide6/stats_controller.py`, `src/Tools/Stats/PySide6/stats_workers.py`)
- New service module: added `src/Tools/Stats/PySide6/dv_variants.py` which implements `compute_dv_variants_payload`, long-format builders, `build_dv_comparison_summary`, and `export_dv_variants_workbook` that writes a workbook with `DV__PRIMARY__<policy>`, `DV__VAR__<policy>`, `DV Comparison Summary` and `DV Variant Errors`. Variant exports are written to `DV Variants.xlsx`. (Added: `src/Tools/Stats/PySide6/dv_variants.py`)
- Performance & caching: added a conservative in-memory cache around `prepare_summed_bca_data` to avoid repeated heavy I/O when safe to reuse prepared DV maps; cache only used when provenance tracing is not requested. (Touched: `src/Tools/Stats/PySide6/dv_policies.py`)
- Export and metadata: pipeline writes variant selection into `dv_metadata.json` under `variant_methods`; the variant payload (primary table, variant tables, comparison summary, errors) is stored and exported after primary exports. Variant failures are logged and recorded in the `DV Variant Errors` sheet but do not stop the primary analysis. (Touched: `src/Tools/Stats/PySide6/stats_main_window.py`, `src/Tools/Stats/PySide6/stats_workers.py`)
- Tests: added Qt tests to assert the UI/selection behavior and invariants plus a pure unit test for the DV comparison summary aggregation. (Added: `tests/test_stats_dv_variants.py`, `tests/test_stats_dv_variants_summary.py`; updated: `tests/test_stats_condition_selection.py`)
- Maintained project rules: QAction import from `PySide6.QtGui` remains present and unused import kept as sentinel; primary inferential logic and black-box legacy code were not modified.

### Testing
- New/updated tests added: `tests/test_stats_dv_variants.py` (Qt UI behavior), `tests/test_stats_dv_variants_summary.py` (unit aggregation), and a small assertion added in `tests/test_stats_condition_selection.py` to assert default selection snapshot.
- Automated test/lint runs attempted in this environment but could not be executed due to missing local virtualenv scripts: the commands attempted were ` .venv/Scripts/python -m pytest -q`, ` .venv/Scripts/ruff check .`, and ` .venv/Scripts/mypy src --strict`, and they failed because `.venv/Scripts/*` executables are not available here (environment limitation). Therefore no CI results are available from this run.
- Behavioral smoke checks performed in code review: verified that the Primary DV path remains unchanged in step kwargs when variants are toggled, verified variant UI checkboxes default to off, and confirmed variant payloads are serialized and saved for export; these checks are backed by the new unit/qt tests added above but the tests were not executed in this environment.
- Summary of automated status: tests added (see list), but execution of `pytest`, `ruff`, and `mypy` was not possible in the current environment (failures are due to missing `.venv/Scripts/*`). Please run the standard CI commands in your project environment or CI to validate style and typing and to run the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975734f8eb0832c89fd18f4825832c1)