### PR TITLE
Lazy-load legacy Average Preprocessing UI to avoid CustomTkinter import on startup

### DIFF
--- a/src/Tools/Average_Preprocessing/__init__.py
+++ b/src/Tools/Average_Preprocessing/__init__.py
@@ -2,17 +2,90 @@
 
 from __future__ import annotations
 
-import os
+import logging
+from typing import TYPE_CHECKING, Callable, TypeVar
 
-if os.getenv("FPVS_TEST_MODE") or os.getenv("PYTEST_CURRENT_TEST"):
-    AdvancedAnalysisWindow = None
-    run_advanced_averaging_processing = None
-    __all__ = []
-else:
+logger = logging.getLogger(__name__)
+
+LEGACY_AVERAGE_PREPROCESSING_UI_ERROR_MESSAGE = (
+    "Legacy Average Preprocessing UI requires CustomTkinter/Tkinter and is not available in this build."
+)
+
+_T = TypeVar("_T")
+
+if TYPE_CHECKING:
     from Tools.Average_Preprocessing.Legacy.advanced_analysis import AdvancedAnalysisWindow
-    from Tools.Average_Preprocessing.Legacy.advanced_analysis_core import run_advanced_averaging_processing
+    from Tools.Average_Preprocessing.Legacy.advanced_analysis_core import (
+        run_advanced_averaging_processing,
+    )
 
-    __all__ = [
-        "AdvancedAnalysisWindow",
-        "run_advanced_averaging_processing",
-    ]
+
+def _log_tkinter_diagnostics() -> None:
+    try:
+        import tkinter as tk
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning(
+            "Failed to import tkinter for legacy Average Preprocessing diagnostics: %s",
+            exc,
+        )
+        return
+
+    logger.info(
+        "Legacy Average Preprocessing tkinter diagnostics: tkinter=%s has_canvas=%s",
+        getattr(tk, "__file__", "unknown"),
+        hasattr(tk, "Canvas"),
+    )
+
+
+def _import_legacy(symbol_name: str, importer: Callable[[], _T]) -> _T:
+    try:
+        return importer()
+    except Exception as exc:
+        logger.error("Failed to import legacy Average Preprocessing %s.", symbol_name, exc_info=exc)
+        raise RuntimeError(LEGACY_AVERAGE_PREPROCESSING_UI_ERROR_MESSAGE) from exc
+
+
+def get_legacy_advanced_analysis_window() -> "type[AdvancedAnalysisWindow]":
+    """Lazy-load the legacy AdvancedAnalysisWindow UI class."""
+    _log_tkinter_diagnostics()
+
+    def _importer() -> "type[AdvancedAnalysisWindow]":
+        from Tools.Average_Preprocessing.Legacy.advanced_analysis import AdvancedAnalysisWindow
+
+        return AdvancedAnalysisWindow
+
+    return _import_legacy("AdvancedAnalysisWindow", _importer)
+
+
+def get_legacy_advanced_averaging_processing() -> "run_advanced_averaging_processing":
+    """Lazy-load the legacy advanced averaging processing function."""
+
+    def _importer() -> "run_advanced_averaging_processing":
+        from Tools.Average_Preprocessing.Legacy.advanced_analysis_core import (
+            run_advanced_averaging_processing,
+        )
+
+        return run_advanced_averaging_processing
+
+    return _import_legacy("run_advanced_averaging_processing", _importer)
+
+
+def __getattr__(name: str):
+    if name == "AdvancedAnalysisWindow":
+        value = get_legacy_advanced_analysis_window()
+        globals()[name] = value
+        return value
+    if name == "run_advanced_averaging_processing":
+        value = get_legacy_advanced_averaging_processing()
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "AdvancedAnalysisWindow",
+    "LEGACY_AVERAGE_PREPROCESSING_UI_ERROR_MESSAGE",
+    "get_legacy_advanced_analysis_window",
+    "get_legacy_advanced_averaging_processing",
+    "run_advanced_averaging_processing",
+]

--- a/src/fpvs_app.py
+++ b/src/fpvs_app.py
@@ -60,7 +60,10 @@ from Main_App import post_process as _external_post_process
 
 
 # Advanced averaging UI and core function
-from Tools.Average_Preprocessing import AdvancedAnalysisWindow
+from Tools.Average_Preprocessing import (
+    LEGACY_AVERAGE_PREPROCESSING_UI_ERROR_MESSAGE,
+    get_legacy_advanced_analysis_window,
+)
 
 # Statistics toolbox
 import Tools.Stats as stats
@@ -229,8 +232,13 @@ class FPVSApp(ctk.CTk, LoggingMixin, EventMapMixin, FileSelectionMixin,
         """Opens the Advanced Preprocessing Epoch Averaging window."""
         self.log("Opening Advanced Analysis (Preprocessing Epoch Averaging) tool...")
         self.debug("Advanced analysis window requested")
-        # AdvancedAnalysisWindow is imported from Tools.Average_Preprocessing
-        adv_win = AdvancedAnalysisWindow(master=self)
+        try:
+            advanced_window = get_legacy_advanced_analysis_window()
+        except RuntimeError:
+            self.log(LEGACY_AVERAGE_PREPROCESSING_UI_ERROR_MESSAGE, level=logging.ERROR)
+            self.debug("Legacy Average Preprocessing UI failed to import.")
+            return
+        adv_win = advanced_window(master=self)
         adv_win.geometry(self.settings.get('gui', 'advanced_size', '1050x850'))
 
     def _set_controls_enabled(self, enabled: bool):

--- a/tests/test_startup_imports_no_customtkinter.py
+++ b/tests/test_startup_imports_no_customtkinter.py
@@ -1,0 +1,27 @@
+"""Startup import checks for avoiding CustomTkinter on PySide6 launch."""
+
+from __future__ import annotations
+
+import sys
+
+
+def _clear_customtkinter_modules() -> None:
+    sys.modules.pop("customtkinter", None)
+
+
+def test_mainwindow_import_does_not_load_customtkinter() -> None:
+    _clear_customtkinter_modules()
+
+    from Main_App.PySide6_App.GUI.main_window import MainWindow
+
+    assert MainWindow is not None
+    assert "customtkinter" not in sys.modules
+
+
+def test_average_preprocessing_import_does_not_load_customtkinter() -> None:
+    _clear_customtkinter_modules()
+
+    import Tools.Average_Preprocessing as average_preprocessing
+
+    assert average_preprocessing is not None
+    assert "customtkinter" not in sys.modules


### PR DESCRIPTION
### Motivation
- Prevent the legacy CustomTkinter-based Average Preprocessing UI from being imported at package import time so the PySide6 app can start even when `tkinter`/`customtkinter` is broken or unavailable.
- Preserve the legacy code as-is but ensure it is only loaded on demand, and surface a clear non-blocking error if the legacy UI is requested but cannot be imported.
- Add a lightweight automated check to assert that importing the PySide6 `MainWindow` and `Tools.Average_Preprocessing` does not load `customtkinter` during startup.

### Description
- Reworked `src/Tools/Average_Preprocessing/__init__.py` to lazy-load legacy symbols using `get_legacy_advanced_analysis_window()` and `get_legacy_advanced_averaging_processing()` and added an informative constant `LEGACY_AVERAGE_PREPROCESSING_UI_ERROR_MESSAGE` for runtime errors, plus tkinter diagnostics logging via `_log_tkinter_diagnostics()`.
- Implemented `__getattr__` in the package to expose `AdvancedAnalysisWindow` and `run_advanced_averaging_processing` on demand without importing the legacy modules at package import time.
- Updated the legacy UI launcher in `src/fpvs_app.py` to call `get_legacy_advanced_analysis_window()` and log a non-blocking error using the existing logging pattern when the legacy UI cannot be imported instead of importing `AdvancedAnalysisWindow` at module load time.
- Added `tests/test_startup_imports_no_customtkinter.py` which asserts that importing `Main_App.PySide6_App.GUI.main_window.MainWindow` and `Tools.Average_Preprocessing` does not populate `sys.modules` with `customtkinter`.

### Testing
- Added unit tests: `tests/test_startup_imports_no_customtkinter.py` (not executed here because the environment lacks the referenced Windows virtualenv helper binaries).
- Attempted to run `pytest` via the project-prescribed Windows venv command `.\.venv\Scripts\python -m pytest -q`, but the command failed in this environment with `No such file or directory` because a Windows `.venv\Scripts` layout is not available here; therefore tests were not executed.
- Attempted `ruff` and `mypy` via the same Windows venv paths (`.venv\Scripts\ruff` and `.venv\Scripts\mypy`) and both checks could not be run for the same reason. The new test file is small and uses only standard library imports.
- Manual code inspection and local static checks were performed during development (file diffs and quick module import scans) and confirm the package no longer performs eager imports of `customtkinter` at import time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975797ac6b8832c82b61d45400015d6)