### PR TITLE
Make legacy Stats import lazy in PySide6 main window

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -173,11 +173,6 @@ from Tools.Average_Preprocessing.New_PySide6.main_window import (
     AdvancedAveragingWindow,
 )
 from Tools.Stats import StatsWindow as PysideStatsWindow
-if os.getenv("FPVS_TEST_MODE") or os.getenv("PYTEST_CURRENT_TEST"):
-    def launch_ctk_stats(*_args, **_kwargs):
-        return None
-else:
-    from Tools.Stats.Legacy.stats import StatsAnalysisWindow as launch_ctk_stats
 from config import FPVS_TOOLBOX_VERSION
 from . import update_manager
 from .file_menu import init_file_menu
@@ -1399,7 +1394,33 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
                 self._child_windows = []
             self._child_windows.append(window)
         else:
-            launch_ctk_stats(master=self)
+            try:
+                from Tools.Stats.Legacy.stats import StatsAnalysisWindow
+            except Exception as exc:
+                logger.warning(
+                    "Legacy stats window unavailable; skipping launch.",
+                    exc_info=exc,
+                )
+                status_bar = self.statusBar()
+                if status_bar:
+                    status_bar.showMessage(
+                        "Legacy Stats is unavailable in this environment.",
+                        5000,
+                    )
+                return
+            try:
+                StatsAnalysisWindow(master=self)
+            except Exception as exc:
+                logger.warning(
+                    "Legacy stats launch failed.",
+                    exc_info=exc,
+                )
+                status_bar = self.statusBar()
+                if status_bar:
+                    status_bar.showMessage(
+                        "Legacy Stats could not be launched.",
+                        5000,
+                    )
 
     def open_image_resizer(self) -> None:
         cmd = [sys.executable]

--- a/tests/test_startup_imports_no_customtkinter.py
+++ b/tests/test_startup_imports_no_customtkinter.py
@@ -9,13 +9,21 @@ def _clear_customtkinter_modules() -> None:
     sys.modules.pop("customtkinter", None)
 
 
+def _clear_legacy_stats_modules() -> None:
+    for name in list(sys.modules):
+        if name.startswith("Tools.Stats.Legacy"):
+            sys.modules.pop(name, None)
+
+
 def test_mainwindow_import_does_not_load_customtkinter() -> None:
     _clear_customtkinter_modules()
+    _clear_legacy_stats_modules()
 
     from Main_App.PySide6_App.GUI.main_window import MainWindow
 
     assert MainWindow is not None
     assert "customtkinter" not in sys.modules
+    assert "Tools.Stats.Legacy.stats" not in sys.modules
 
 
 def test_average_preprocessing_import_does_not_load_customtkinter() -> None:


### PR DESCRIPTION
### Motivation
- Prevent importing the legacy CustomTkinter-based Stats UI at PySide6 app startup to avoid triggering tkinter/customtkinter and crashing the app.
- Preserve the legacy Stats launcher but make it lazy so PySide6-only starts succeed and the legacy path fails gracefully when unavailable.

### Description
- Removed the module-level eager import of `Tools.Stats.Legacy.stats` from `src/Main_App/PySide6_App/GUI/main_window.py` so legacy code is not brought in on import.
- Replaced direct call with a lazy import inside `MainWindow.open_stats_analyzer()` that `try`/`except`s the import and logs a warning while showing a non-blocking status-bar message when unavailable. 
- Added an additional `try`/`except` around constructing the legacy `StatsAnalysisWindow` to surface launch failures via structured logging and status-bar messaging. 
- Updated `tests/test_startup_imports_no_customtkinter.py` to clear any `Tools.Stats.Legacy` modules from `sys.modules` before importing `MainWindow` and assert that the legacy stats module is not loaded as a side effect.

### Testing
- Ran `python -m pytest -q tests/test_startup_imports_no_customtkinter.py`, which collected the two tests: one test passed and one failed when importing `MainWindow` due to a missing environment dependency (`pandas`) causing `ModuleNotFoundError`; this indicates the lazy import change prevented CustomTkinter-related imports but full app import still touches other optional legacy code that requires extra packages. 
- Attempted to run the repo-local verification commands from the instructions (`.venv/Scripts/python -m pytest -q`, `.venv/Scripts/ruff check .`, `.venv/Scripts/mypy src --strict`) but the `.venv`-scoped executables were not present in this environment so those gated checks could not be executed. 
- Ran `python -m ruff check .` which reported baseline lint issues unrelated to this change (73 errors in the tree). 
- Ran `python -m mypy src --strict` which failed due to an unrelated syntax/mypy error in `src/Compiler_Script.py`. 
- Verified that `compileall` succeeded for the modified GUI module and the updated test file. 

Files touched: `src/Main_App/PySide6_App/GUI/main_window.py`, `tests/test_startup_imports_no_customtkinter.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697581b96c64832cad254a5fe211b88f)