### PR TITLE
Avoid importing customtkinter when syncing ROIs from PySide6 Stats window

### DIFF
--- a/src/Tools/Stats/Legacy/stats_helpers.py
+++ b/src/Tools/Stats/Legacy/stats_helpers.py
@@ -129,10 +129,14 @@ def load_rois_from_settings(manager=None):
 
 def apply_rois_to_modules(rois_dict):
     """Update ROI dictionaries in related stats modules."""
-    import Tools.Stats.Legacy.stats as stats_mod
+    import sys
+
     import Tools.Stats.Legacy.stats_analysis as analysis_mod
     import Tools.Stats.Legacy.stats_runners as runners_mod
 
-    stats_mod.ROIS = rois_dict
     analysis_mod.set_rois(rois_dict)
     runners_mod.ROIS = rois_dict
+
+    stats_mod = sys.modules.get("Tools.Stats.Legacy.stats")
+    if stats_mod is not None:
+        setattr(stats_mod, "ROIS", rois_dict)

--- a/tests/test_stats_no_customtkinter_import.py
+++ b/tests/test_stats_no_customtkinter_import.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+
+
+@pytest.mark.qt
+def test_pyside_stats_window_does_not_import_customtkinter(qtbot, tmp_path):
+    sys.modules.pop("customtkinter", None)
+
+    window = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(window)
+    window.show()
+
+    window.refresh_rois()
+
+    assert "customtkinter" not in sys.modules


### PR DESCRIPTION
### Motivation
- Opening the PySide6 Stats tool was triggering an import of the legacy CTk UI (which pulls in `customtkinter`) via `apply_rois_to_modules`, causing AttributeError crashes; the goal is to keep ROI propagation behavior while preventing any CTk UI imports on the PySide6 path.

### Description
- Change `apply_rois_to_modules` to stop directly importing the legacy UI module and instead update the legacy `stats` module only if it is already loaded via `sys.modules`.
- Continue to call `set_rois` on `Tools.Stats.Legacy.stats_analysis` and assign `ROIS` on `Tools.Stats.Legacy.stats_runners` so analysis modules still receive ROI data.
- Add a pytest-qt smoke test `tests/test_stats_no_customtkinter_import.py` that instantiates the PySide6 `StatsWindow`, calls `refresh_rois`, and asserts that `customtkinter` is not present in `sys.modules`.
- Files changed: `src/Tools/Stats/Legacy/stats_helpers.py` and `tests/test_stats_no_customtkinter_import.py`.

### Testing
- Attempted to run the project test/lint/type checks with `.venv\Scripts\python -m pytest -q`, `.venv\Scripts\ruff check .`, and `.venv\Scripts\mypy src --strict`, but these commands failed because the expected `.venv` environment was not available (FAIL).
- Sanity checks confirming the new test file exists and code edits are present succeeded with `test -f tests/test_stats_no_customtkinter_import.py` (PASS).
- Grep/inspection checks verified the new `sys.modules.get("Tools.Stats.Legacy.stats")` usage and that `analysis_mod.set_rois` and `runners_mod.ROIS` assignments remain (PASS).
- The added pytest-qt smoke test is present and marked `@pytest.mark.qt` so it will run in CI where `PySide6` and a Qt test environment are available; it has not been executed here due to the missing venv/GUI environment (NOT RUN).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764addf278832ca383371eefaf30cf)