### PR TITLE
Stats UI: switch to horizontal splitter for landscape layout

### DIFF
--- a/tests/test_stats_layout_smoke.py
+++ b/tests/test_stats_layout_smoke.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 pytest.importorskip("PySide6")
-from PySide6.QtWidgets import QPushButton, QTextEdit, QVBoxLayout  # noqa: E402
+from PySide6.QtCore import Qt  # noqa: E402
+from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QSplitter, QTextEdit  # noqa: E402
 
 from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow  # noqa: E402
 
@@ -21,7 +22,17 @@ def test_stats_window_layout_smoke(qtbot, tmp_path, app):
     window.show()
 
     layout = window.centralWidget().layout()
-    assert isinstance(layout, QVBoxLayout)
+    splitter = None
+    for idx in range(layout.count()):
+        item = layout.itemAt(idx)
+        if item is None:
+            continue
+        widget = item.widget()
+        if isinstance(widget, QSplitter):
+            splitter = widget
+            break
+    assert splitter is not None
+    assert splitter.orientation() == Qt.Horizontal
 
     buttons = window.findChildren(QPushButton)
     texts = {btn.text() for btn in buttons}
@@ -31,3 +42,19 @@ def test_stats_window_layout_smoke(qtbot, tmp_path, app):
     log_widget = window.findChild(QTextEdit)
     assert log_widget is not None
     assert log_widget.isVisible()
+
+    left_pane = splitter.widget(0)
+    right_pane = splitter.widget(1)
+    assert left_pane is not None
+    assert right_pane is not None
+    assert left_pane.isAncestorOf(window.conditions_group)
+    assert right_pane.isAncestorOf(window.output_text)
+
+    group_boxes = window.findChildren(QGroupBox)
+    analysis_box = next(box for box in group_boxes if box.title() == "Analysis Controls")
+    single_group_box = next(box for box in group_boxes if box.title() == "Single Group Analysis")
+    between_group_box = next(box for box in group_boxes if box.title() == "Between-Group Analysis")
+    analysis_layout = analysis_box.layout()
+    assert isinstance(analysis_layout, QHBoxLayout)
+    assert analysis_layout.indexOf(single_group_box) != -1
+    assert analysis_layout.indexOf(between_group_box) != -1


### PR DESCRIPTION
### Motivation
- The Stats tool UI stacks many controls vertically which causes cramped views on typical screens and forces excessive scrolling. The intent is to present settings on the left and run/output on the right in a landscape layout without changing any processing, wiring, or behavior.

### Description
- Replaced the top-level vertical layout with a horizontal layout containing a `QSplitter(Qt.Horizontal)` so the window presents two resizable panes (left settings, right run/output). The window default size was adjusted to landscape-friendly dimensions (`setMinimumSize(900,650)` / `resize(1200,800`).
- Moved existing widgets into two panes without renaming or rebuilding widgets: the LEFT scrollable pane contains `Included Conditions` → `Summed BCA definition` → `Also compute DV variants (export only)` in that order, and the RIGHT pane contains the data-folder row + action buttons, the `Analysis Controls` (with `Single Group` and `Between-Group` group boxes arranged side-by-side), status/ROI labels, and the expanding analysis output `QTextEdit`.
- Preserved all widget object names and existing signal/slot connections (only widget re-parenting / layout changes were made), and added scrollability to the left pane to keep options accessible on short screens.
- Updated the lightweight smoke test `tests/test_stats_layout_smoke.py` to validate the new structure (top-level `QSplitter` horizontal orientation, left pane contains `Included Conditions`, right pane contains the `output_text`, and `Single Group` / `Between-Group` boxes are side-by-side in the `Analysis Controls`).

### Testing
- Updated unit test: `tests/test_stats_layout_smoke.py` (verifies `QSplitter` is present and oriented horizontally, left/right pane placement, and horizontal analysis controls). The test file was modified to assert the new layout structure.
- Attempted to run the project automated checks as requested but the environment lacks the referenced virtualenv scripts, so the runs failed: running `.venv/Scripts/python -m pytest -q` failed with missing interpreter, `.venv/Scripts/ruff check .` failed with missing executable, and `.venv/Scripts/mypy src --strict` failed with missing executable; therefore automated test/linter runs could not be completed in this environment.
- Manual verification (code inspection) confirms: a `QSplitter` was added, the left `QScrollArea` contains the group boxes in the required order, `Analysis Controls` uses a `QHBoxLayout` to keep `Single Group` and `Between-Group` side-by-side, and the `output_text` remains available and expanded in the right pane.

Files changed
- src/Tools/Stats/PySide6/stats_main_window.py
- tests/test_stats_layout_smoke.py

Notes/Risks
- Only layout/container changes were made; no signal re-binding, widget renames, or analysis logic changes were introduced, but the left scroll area may slightly change tab traversal order on some platforms.
- Automated checks (pytest, ruff, mypy) were not executable in this environment due to missing `.venv` scripts; please run the usual CI tooling in the project environment to confirm all checks pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764d71ec78832c800b4f07cef4e994)