### PR TITLE
Delay Rossion two-consecutive-nonsignificant stop rule until after first significant harmonic

### DIFF
--- a/src/Tools/Stats/PySide6/group_harmonics.py
+++ b/src/Tools/Stats/PySide6/group_harmonics.py
@@ -322,6 +322,7 @@ def select_rossion_harmonics_by_roi(
     for roi_name in rois:
         selected: list[float] = []
         nonsig_run = 0
+        found_any_sig = False
         stop_reason = "end_of_domain"
         stop_fail_harmonics: list[float] = []
         scanned = 0
@@ -334,10 +335,13 @@ def select_rossion_harmonics_by_roi(
             is_sig = bool(np.isfinite(mean_z) and mean_z > z_threshold)
             if is_sig:
                 selected.append(float(freq_val))
+                found_any_sig = True
                 nonsig_run = 0
                 stop_fail_harmonics = []
                 failure_run = []
             else:
+                if not found_any_sig:
+                    continue
                 nonsig_run += 1
                 stop_fail_harmonics.append(float(freq_val))
                 failure_run.append((float(freq_val), float(mean_z)))
@@ -348,6 +352,9 @@ def select_rossion_harmonics_by_roi(
                     stop_fail_harmonics = stop_fail_harmonics[-stop_after_n:]
                     stop_at_harmonic = float(freq_val)
                     break
+
+        if not found_any_sig:
+            stop_reason = "end_of_domain_no_sig"
 
         selected_map[str(roi_name)] = selected
         meta_by_roi[str(roi_name)] = {


### PR DESCRIPTION
### Motivation
- Prevent premature stopping during Rossion harmonic selection by ensuring the "two consecutive nonsignificant" rule is only applied after the first significant harmonic has been observed for a given ROI.

### Description
- Add a per-ROI boolean `found_any_sig` that is set to `True` on the first significant harmonic and initialized `False` otherwise.
- Before `found_any_sig` is `True`, skip incrementing `nonsig_run` and skip failure tracking while still counting `scanned` harmonics.
- After the first significant harmonic, preserve the existing `nonsig_run` / `stop_fail_harmonics` / `failure_run` logic and stop when `nonsig_run >= stop_after_n` as before.
- If the entire domain is scanned and no significant harmonic is found, set `stop_reason` to `"end_of_domain_no_sig"` while preserving metadata keys and DV_TRACE logging.

### Testing
- Ran `pytest`, which aborted during collection due to missing environment dependencies (`ModuleNotFoundError` for `numpy`, `pandas`, and `PySide6`) so no unit tests could be executed to completion in this environment.
- Ran `ruff check .`, which reported pre-existing lint issues in the repository unrelated to this change and did not indicate problems introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768abc5800832ca6678928c5f9d3ec)