### PR TITLE
Add DV_TRACE extreme cell logging

### DIFF
--- a/src/Tools/Stats/PySide6/dv_policies.py
+++ b/src/Tools/Stats/PySide6/dv_policies.py
@@ -560,6 +560,7 @@ def _log_dv_trace_dv_table_summary(
         return
     expected_rows = len(subjects) * len(conditions) * len(rois_map)
     finite_values: list[float] = []
+    cell_values: list[tuple[float, str, str, str]] = []
     valid_rows = 0
     for pid in subjects:
         for cond in conditions:
@@ -568,7 +569,9 @@ def _log_dv_trace_dv_table_summary(
                 val = roi_vals.get(roi_name, np.nan)
                 if val is not None and np.isfinite(val):
                     valid_rows += 1
-                    finite_values.append(float(val))
+                    float_val = float(val)
+                    finite_values.append(float_val)
+                    cell_values.append((float_val, str(pid), str(cond), str(roi_name)))
     nan_rows = expected_rows - valid_rows
     dv_min = float(np.nanmin(finite_values)) if finite_values else np.nan
     dv_mean = float(np.nanmean(finite_values)) if finite_values else np.nan
@@ -610,6 +613,37 @@ def _log_dv_trace_dv_table_summary(
             roi_max,
             roi_std,
         )
+    if cell_values:
+        min_values = sorted(cell_values, key=lambda entry: entry[0])
+        max_values = sorted(cell_values, key=lambda entry: entry[0], reverse=True)
+        abs_values = sorted(cell_values, key=lambda entry: abs(entry[0]), reverse=True)
+        for rank, (dv_value, pid, cond, roi_name) in enumerate(min_values[:3], start=1):
+            logger.info(
+                "DV_TRACE dv_extreme which=min rank=%d pid=%s condition=%s roi=%s dv=%s",
+                rank,
+                pid,
+                cond,
+                roi_name,
+                dv_value,
+            )
+        for rank, (dv_value, pid, cond, roi_name) in enumerate(max_values[:3], start=1):
+            logger.info(
+                "DV_TRACE dv_extreme which=max rank=%d pid=%s condition=%s roi=%s dv=%s",
+                rank,
+                pid,
+                cond,
+                roi_name,
+                dv_value,
+            )
+        for rank, (dv_value, pid, cond, roi_name) in enumerate(abs_values[:3], start=1):
+            logger.info(
+                "DV_TRACE dv_extreme which=abs rank=%d pid=%s condition=%s roi=%s dv=%s",
+                rank,
+                pid,
+                cond,
+                roi_name,
+                dv_value,
+            )
 
 
 def build_group_mean_z_preview_payload(


### PR DESCRIPTION
### Motivation
- Make it easy to identify the single most extreme DV table cell(s) (by pid/condition/ROI) produced by `prepare_summed_bca_data()` so outliers (e.g. -79.96) can be found instantly across RM-ANOVA, Mixed Model, and Posthoc runs.
- Preserve all existing DV computations, harmonic selection, and current DV_TRACE summary logs while providing targeted extreme-value tracing when enabled.

### Description
- Enhanced `_log_dv_trace_dv_table_summary` in `src/Tools/Stats/PySide6/dv_policies.py` to accumulate per-cell tuples `(float_val, pid, condition, roi)` for all finite DV entries while iterating the DV table. 
- After existing ROI summary logs, added computations that sort the collected cells to produce the most negative, most positive, and largest-absolute-value entries, each ranked and limited to up to 3 rows per category, skipping `NaN`/`inf` values. 
- Emitted new INFO-level DV_TRACE log lines using the existing `logger = logging.getLogger("Tools.Stats")` guard and the existing `_dv_trace_enabled()` check, logging rows in the format shown in the spec and using `%s` to preserve full float precision. 
- No other logic, computations, names, or existing DV_TRACE messages were changed.

### Testing
- Ran `ruff check src/Tools/Stats/PySide6/dv_policies.py` and the file passed linting. 
- Ran `pytest` for the repository and collection failed due to missing runtime dependencies (`numpy`, `pandas`, `PySide6`) in the environment so functional verification is manual as described (set `FPVS_STATS_DV_TRACE=1` and run the Stats flows to observe the new `DV_TRACE dv_extreme ...` lines).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768d6d7264832cb30875280970b568)