### PR TITLE
Stats tool UX polish: outlier summary, tooltips, default Rossion; remove Group Mean‑Z

### DIFF
--- a/src/Tools/Stats/PySide6/dv_variants.py
+++ b/src/Tools/Stats/PySide6/dv_variants.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from Tools.Stats.PySide6.dv_policies import (
     FIXED_K_POLICY_NAME,
-    GROUP_MEAN_Z_POLICY_NAME,
     LEGACY_POLICY_NAME,
     ROSSION_POLICY_NAME,
     normalize_dv_policy,
@@ -20,7 +19,6 @@ from Tools.Stats.PySide6.dv_policies import (
 DV_POLICY_SHORT_NAMES = {
     LEGACY_POLICY_NAME: "Legacy",
     FIXED_K_POLICY_NAME: "FixedK",
-    GROUP_MEAN_Z_POLICY_NAME: "GroupMeanZUnion",
     ROSSION_POLICY_NAME: "Rossion",
 }
 

--- a/src/Tools/Stats/PySide6/group_harmonics.py
+++ b/src/Tools/Stats/PySide6/group_harmonics.py
@@ -1,11 +1,11 @@
-"""Helpers for Group Mean-Z and Rossion harmonic selection."""
+"""Helpers for Rossion harmonic selection."""
 from __future__ import annotations
 
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Sequence
+from typing import Callable, Dict, Iterable, List
 
 import numpy as np
 import pandas as pd
@@ -21,13 +21,6 @@ from Tools.Stats.Legacy.stats_analysis import (
 
 logger = logging.getLogger("Tools.Stats")
 _DV_TRACE_ENV = "FPVS_STATS_DV_TRACE"
-
-
-@dataclass(frozen=True)
-class GroupMeanZSummary:
-    harmonic_freqs: List[float]
-    mean_z_table: pd.DataFrame
-    columns: pd.Index
 
 
 @dataclass(frozen=True)
@@ -377,114 +370,3 @@ def select_rossion_harmonics_by_roi(
                 failure_run,
             )
     return selected_map, meta_by_roi
-
-
-def compute_union_harmonics_by_roi(
-    mean_z_table: pd.DataFrame,
-    *,
-    conditions: Sequence[str],
-    z_threshold: float,
-) -> dict[str, list[float]]:
-    union_map: dict[str, list[float]] = {}
-    if mean_z_table.empty:
-        return union_map
-
-    filtered = mean_z_table[mean_z_table["condition"].isin(conditions)]
-    grouped = filtered.groupby("roi")
-    for roi_name, roi_df in grouped:
-        sig_df = roi_df[roi_df["mean_z"] > z_threshold]
-        harmonics = sorted(sig_df["harmonic_hz"].unique().tolist())
-        union_map[str(roi_name)] = harmonics
-    return union_map
-
-
-def build_group_mean_z_summary(
-    *,
-    subjects: List[str],
-    conditions: List[str],
-    subject_data: Dict[str, Dict[str, str]],
-    base_freq: float,
-    rois: Dict[str, List[str]],
-    z_threshold: float,
-    log_func: Callable[[str], None],
-) -> GroupMeanZSummary:
-    columns = _find_first_z_columns(subjects, conditions, subject_data, log_func)
-    harmonic_freqs = _build_harmonic_domain(columns, base_freq, log_func)
-    if not harmonic_freqs:
-        raise RuntimeError(
-            "Group Mean-Z harmonics selection produced an empty list. "
-            "Verify Z-score sheets and base frequency."
-        )
-
-    roi_map = rois
-    mean_values: dict[tuple[str, str, float], list[float]] = {}
-
-    for pid in subjects:
-        for cond_name in conditions:
-            file_path = subject_data.get(pid, {}).get(cond_name)
-            if not file_path:
-                log_func(f"Missing file for {pid} {cond_name}: {file_path}")
-                continue
-            if not Path(file_path).exists():
-                log_func(f"Missing file for {pid} {cond_name}: {file_path}")
-                continue
-            try:
-                df_z = safe_read_excel(
-                    file_path, sheet_name=SUMMED_BCA_Z_SHEET_NAME, index_col="Electrode"
-                )
-            except Exception as exc:  # noqa: BLE001
-                log_func(f"Failed to read Z sheet from {file_path}: {exc}")
-                continue
-
-            df_z.index = df_z.index.astype(str).str.upper().str.strip()
-            col_map = {freq: _match_freq_column(df_z.columns, freq) for freq in harmonic_freqs}
-
-            for roi_name, roi_channels in roi_map.items():
-                roi_chans = [
-                    str(ch).strip().upper()
-                    for ch in (roi_channels or [])
-                    if str(ch).strip().upper() in df_z.index
-                ]
-                if not roi_chans:
-                    log_func(f"No overlapping Z data for ROI {roi_name} in {file_path}.")
-                    continue
-                df_roi = df_z.loc[roi_chans].dropna(how="all")
-                if df_roi.empty:
-                    log_func(f"No Z data for ROI {roi_name} in {file_path}.")
-                    continue
-
-                for freq_val in harmonic_freqs:
-                    col_z = col_map.get(freq_val)
-                    if not col_z:
-                        continue
-                    series = pd.to_numeric(df_roi[col_z], errors="coerce").replace(
-                        [np.inf, -np.inf], np.nan
-                    )
-                    mean_val = float(series.mean(skipna=True))
-                    if not np.isfinite(mean_val):
-                        continue
-                    key = (cond_name, roi_name, float(freq_val))
-                    mean_values.setdefault(key, []).append(mean_val)
-
-    rows = []
-    for (cond_name, roi_name, freq_val), values in mean_values.items():
-        mean_val = float(np.nanmean(values)) if values else np.nan
-        rows.append(
-            {
-                "condition": cond_name,
-                "roi": roi_name,
-                "harmonic_hz": float(freq_val),
-                "mean_z": mean_val,
-                "significant": bool(mean_val > z_threshold),
-            }
-        )
-
-    mean_z_table = pd.DataFrame(rows)
-    if not mean_z_table.empty:
-        mean_z_table = mean_z_table.sort_values(["roi", "condition", "harmonic_hz"])
-
-    return GroupMeanZSummary(
-        harmonic_freqs=harmonic_freqs,
-        mean_z_table=mean_z_table,
-        columns=columns,
-    )

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -42,9 +42,7 @@ from Tools.Stats.Legacy.stats_analysis import (
     SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
 )
 from Tools.Stats.PySide6.dv_policies import (
-    GROUP_MEAN_Z_POLICY_NAME,
     ROSSION_POLICY_NAME,
-    build_group_mean_z_preview_payload,
     build_rossion_preview_payload,
     normalize_dv_policy,
     prepare_summed_bca_data,
@@ -872,7 +870,7 @@ def run_group_contrasts(
     }
 
 
-def run_group_mean_z_preview(
+def run_harmonics_preview(
     progress_cb,
     message_cb,
     *,
@@ -885,16 +883,6 @@ def run_group_mean_z_preview(
 ):
     settings = dv_policy or {}
     policy_name = settings.get("name")
-    if policy_name == GROUP_MEAN_Z_POLICY_NAME:
-        return build_group_mean_z_preview_payload(
-            subjects=subjects,
-            conditions=conditions,
-            subject_data=subject_data,
-            base_freq=base_freq,
-            rois=rois,
-            log_func=message_cb,
-            dv_policy=dv_policy,
-        )
     if policy_name == ROSSION_POLICY_NAME:
         return build_rossion_preview_payload(
             subjects=subjects,
@@ -905,7 +893,7 @@ def run_group_mean_z_preview(
             log_func=message_cb,
             dv_policy=dv_policy,
         )
-    raise RuntimeError("Preview requires Group Mean-Z or Rossion policy.")
+    raise RuntimeError("Preview requires the Rossion policy.")
 
 
 def run_harmonic_check(


### PR DESCRIPTION
### Motivation
- Make the Outlier Exclusion report readable to non-technical users and provide an easy way to copy a human-friendly summary. 
- Prefer the Rossion harmonic-selection method as the safe, visible default for DV selection. 
- Remove the deprecated/unused Group Mean‑Z option and its dead code paths to simplify the UI and backend. 
- Improve overall discoverability by adding concise tooltips to major controls and reword the DV-variants export copy to be less technical.

### Description
- Added friendly outlier reason mappings and summary builders in `src/Tools/Stats/PySide6/stats_outlier_exclusion.py`, including `OUTLIER_REASON_FRIENDLY`, `format_outlier_reason`, and `build_outlier_summary_text` to produce per-participant plain-language sentences and formatted worst-value text. 
- Updated the Outlier Exclusion dialog in `src/Tools/Stats/PySide6/stats_main_window.py` to show a read-only summary panel above the table, a `Copy summary` button (copies only the human-friendly text), and to use renamed user-facing table headers `exclusion_reason` and `violations` while preserving TSV table copy/export behavior. 
- Defaulted the primary DV method to Rossion by setting `_dv_policy_name` to `ROSSION_POLICY_NAME` and adjusted preview plumbing to use a harmonics-only preview path (`run_harmonics_preview`) so the UI reflects Rossion immediately on open. 
- Removed the Group Mean‑Z UI option and deleted its backend/variant paths by: removing `GROUP_MEAN_Z_POLICY_NAME` usage, deleting Group Mean‑Z preview and preparation logic, removing its short name in `dv_variants`, and pruning Group Mean‑Z helpers from `group_harmonics.py`, while keeping all Primary DV computations unchanged (Rossion/Fixed-K/Legacy remain). 
- Rewrote the DV variants/exports section label and Fixed‑K checkbox label text and added a short tooltip for the Fixed‑K checkbox, plus added concise tooltips to many major controls (method selector, outlier settings, condition selection, ROI label, run/export buttons, preview button, and several others) to improve usability without changing behavior. 
- Minor cleanup to keep imports and signatures consistent after removal of Group Mean‑Z code and to ensure the changed UI still writes the same DV metadata/export files (only label/content text changed for optional exports and outlier summary). 
- Files changed: `stats_main_window.py`, `stats_outlier_exclusion.py`, `dv_policies.py`, `dv_variants.py`, `group_harmonics.py`, `stats_workers.py` (all under `src/Tools/Stats/PySide6`).

### Testing
- Lint/static checks: ran `python -m ruff check` on the modified Stats modules and the targeted files `src/Tools/Stats/PySide6/...` passed for the updated files (no ruff errors in the changed files). 
- Grep/search proof: ran `rg -n "Group Mean-Z"` and related queries and confirmed no UI-facing occurrences of "Group Mean-Z" remain in the Stats PySide6 code. 
- Runtime smoke (manual steps to validate; not executed in CI here due to GUI/env limits): launch app, open Stats tool to confirm Rossion is selected by default; open Outlier Exclusion report after a run to confirm the summary appears and `Copy summary` and `Copy table` behave as described. 
- Automated tests: attempted `python -m pytest` in this environment but collection failed due to missing runtime dependencies (`numpy`, `pandas`, `PySide6`) in the test environment, therefore full test-suite runs could not be completed here; no changes were made that alter Primary DV statistical calculations. 
- Summary of verification outcomes: table-copy/TSV behavior preserved (only header names changed), outlier reason mapping and summary builder present and wired to UI, Rossion shown as default on startup in code, Group Mean‑Z code and UI option removed, and ruff checks on the modified files passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976adfa1814832ca3cac7111102e961)