### PR TITLE
Simplify Stats GUI log: hide per-harmonic details and surface RM-ANOVA/post-hoc/LMM highlights

### DIFF
--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -1948,9 +1948,7 @@ class StatsWindow(QMainWindow):
         output_text = payload.get("output_text") or ""
         findings = payload.get("findings") or []
         if update_text:
-            self.output_text.append(
-                output_text.strip() or "(Harmonic check returned empty text. See logs for details.)"
-            )
+            self.output_text.append("Harmonic details were exported to Harmonic Results.xlsx.")
         self._harmonic_results[pipeline_id] = findings
         self.harmonic_check_results_data = findings
         self._update_export_buttons()


### PR DESCRIPTION
### Motivation
- The GUI log is too noisy due to per-harmonic significance narrative; the user-visible log should emphasize high-level statistical highlights (RM-ANOVA, post-hoc, mixed model) while retaining harmonic exports and computations.
- Keep console/file logging and Excel exports unchanged and only alter what is appended to the GUI text widget.

### Description
- Replace verbose harmonic text appended to the GUI with a single informational line by changing `_apply_harmonic_results` to append `"Harmonic details were exported to Harmonic Results.xlsx."` in `src/Tools/Stats/PySide6/stats_main_window.py`.
- Remove the Harmonic Check section from the end-of-run summary and refactor the summary generator in `src/Tools/Stats/PySide6/summary_utils.py` to prioritize three compact sections: `RM-ANOVA`, `Post-hoc comparisons`, and `Mixed model`, and only show interactions if present.
- Add targeted summarizers: `_summarize_rm_anova` (lists significant main effects with p-values) and `_summarize_posthocs` (lists only significant FDR-corrected post-hoc findings with ROI/contrast, corrected p, dz/d, and direction), and adjust mixed-model messaging to a concise bullet.
- Do not modify harmonic computations or Excel exports; only the GUI text output and the rule-based summary assembly were changed.

### Testing
- Ran linter: `python -m ruff check src/Tools/Stats/PySide6`, which did not fully pass because it surfaced pre-existing lint issues elsewhere in the stats package (unrelated to these changes).
- Ran unit test collection: `python -m pytest`, which failed during collection due to missing runtime dependencies in the environment (`numpy`, `pandas`, `PySide6`) and thus did not exercise GUI runtime behavior.
- Verified in-repo diffs and commits that only `src/Tools/Stats/PySide6/stats_main_window.py` and `src/Tools/Stats/PySide6/summary_utils.py` were modified and that no export or computation code was altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b2afb110832c9bacc1a67966ad8b)