### PR TITLE
Audit dz sign handling in post-hoc summaries

### DIFF
--- a/scripts/debug_paired_dz_sign.py
+++ b/scripts/debug_paired_dz_sign.py
@@ -1,0 +1,32 @@
+"""Debug helper for paired Cohen's dz sign consistency."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+from scipy import stats
+
+
+def report_paired_signs(a: Iterable[float], b: Iterable[float]) -> None:
+    """Print mean/SD of paired diffs, dz, and paired t-stat for arrays A and B."""
+    a_arr = np.asarray(a, dtype=float)
+    b_arr = np.asarray(b, dtype=float)
+    if a_arr.shape != b_arr.shape:
+        raise ValueError("A and B must have the same shape for paired comparisons.")
+    diff = a_arr - b_arr
+    mean_diff = float(np.mean(diff))
+    sd_diff = float(np.std(diff, ddof=1))
+    dz = mean_diff / sd_diff if sd_diff != 0 else np.nan
+    t_stat, p_val = stats.ttest_rel(a_arr, b_arr)
+
+    print("Paired sign check")
+    print(f"mean(A-B) = {mean_diff:.6f}")
+    print(f"sd(A-B, ddof=1) = {sd_diff:.6f}")
+    print(f"dz = {dz:.6f}")
+    print(f"t = {t_stat:.6f} (p = {p_val:.6f})")
+
+
+if __name__ == "__main__":
+    sample_a = [1.1, 1.4, 1.6, 1.9, 2.0]
+    sample_b = [1.4, 1.3, 1.2, 1.8, 1.7]
+    report_paired_signs(sample_a, sample_b)

--- a/tests/test_posthoc_dz_sign.py
+++ b/tests/test_posthoc_dz_sign.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+from scipy import stats
+
+
+def _load_posthoc_module():
+    module_path = Path(__file__).resolve().parents[1] / "src" / "Tools" / "Stats" / "Legacy" / "posthoc_tests.py"
+    spec = importlib.util.spec_from_file_location("posthoc_tests", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError("Failed to load posthoc_tests module for sign check.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sign(val: float) -> int:
+    if val == 0 or np.isnan(val):
+        return 0
+    return 1 if val > 0 else -1
+
+
+def test_paired_dz_sign_matches_mean_and_t():
+    posthoc_module = _load_posthoc_module()
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    b = np.array([1.5, 1.8, 2.1, 3.2, 3.9])
+    diff = a - b
+
+    dz, _, _ = posthoc_module._paired_effect_size_and_ci(diff)
+    t_stat, _ = stats.ttest_rel(a, b)
+
+    mean_sign = _sign(float(diff.mean()))
+    dz_sign = _sign(float(dz))
+    t_sign = _sign(float(t_stat))
+
+    assert mean_sign == dz_sign == t_sign


### PR DESCRIPTION
### Motivation
- Ensure Cohen's dz sign is interpreted consistently with the paired t-statistic and the printed mean difference to avoid misleading summary text.
- Surface developer warnings when dz and mean-diff signs disagree without changing any statistical results or exports.

### Description
- Added a small sign-consistency guard to the post-hoc summary generator that logs a developer warning if `sign(mean_diff)` and `sign(dz)` disagree, and chooses summary direction from `mean_diff` when available; the summary now prints `|dz|` to avoid sign confusion when flipping `A vs B` for readability (`src/Tools/Stats/PySide6/summary_utils.py`).
- Kept statistical computation unchanged; Cohen's dz is still computed as `mean(diff) / std(diff, ddof=1)` with paired diffs computed as `A - B` (see `src/Tools/Stats/Legacy/posthoc_tests.py` and related `stats_analysis.py`).
- Added a small debug helper script to print `mean(A-B)`, `sd(A-B, ddof=1)`, `dz`, and the paired `t` for manual checks (`scripts/debug_paired_dz_sign.py`).
- Added a focused test that loads the legacy posthoc routine and asserts `sign(mean_diff) == sign(dz) == sign(t)` for a simple paired example (`tests/test_posthoc_dz_sign.py`).

### Testing
- Ran the unit-style test: `python -m pytest tests/test_posthoc_dz_sign.py` — result: 1 passed.
- Ran the local linter: `python -m ruff check src/Tools/Stats/PySide6/summary_utils.py scripts/debug_paired_dz_sign.py tests/test_posthoc_dz_sign.py` — result: all checks passed.
- Executed the debug helper: `python scripts/debug_paired_dz_sign.py` — it printed `mean(A-B)`, sample `sd`, `dz`, and `t` as expected.

Files changed: `src/Tools/Stats/PySide6/summary_utils.py`, `scripts/debug_paired_dz_sign.py`, `tests/test_posthoc_dz_sign.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776e2df7f4832ca51b870704572457)