### PR TITLE
Plain-language Mixed Model summary for Stats GUI

### DIFF
--- a/tests/test_mixed_model_plain_language.py
+++ b/tests/test_mixed_model_plain_language.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from Tools.Stats.PySide6.summary_utils import format_mixed_model_plain_language
+
+
+def test_format_mixed_model_plain_language_describes_direction_and_interactions():
+    df = pd.DataFrame(
+        {
+            "Term": [
+                "Intercept",
+                "C(condition, Sum)[S.Green Fruit vs Green Veg]",
+                "C(roi, Sum)[S.Right Occipito Temporal]",
+                "C(condition, Sum)[S.Green Fruit vs Green Veg]:C(roi, Sum)[S.Right Occipito Temporal]",
+            ],
+            "P>|z|": [0.0005, 0.001, 0.026, 0.02],
+            "Estimate": [0.8, -0.4, 0.3, 0.1],
+        }
+    )
+
+    lines = format_mixed_model_plain_language(df, alpha=0.05)
+    summary = "\n".join(lines)
+
+    assert "Overall response present" in summary
+    assert "lower" in summary
+    assert "higher" in summary
+    assert "interaction" in summary

--- a/tests/test_summary_utils_mixed_model.py
+++ b/tests/test_summary_utils_mixed_model.py
@@ -9,12 +9,13 @@ from Tools.Stats.PySide6.summary_utils import (
 
 def test_mixed_model_summary_populates_when_terms_present():
     df = pd.DataFrame({
-        "Effect": ["group", "condition"],
+        "Effect": ["Intercept", "C(condition, Sum)[S.Test Condition]"],
         "P>|z|": [0.01, 0.2],
+        "Estimate": [1.2, -0.5],
     })
 
     frames = StatsSummaryFrames(mixed_model_terms=df)
     summary = build_summary_from_frames(frames, SummaryConfig())
 
-    assert "Mixed model: significant group effect" in summary
+    assert "Overall response present" in summary
     assert "no summary is available" not in summary


### PR DESCRIPTION
### Motivation
- Improve the GUI "Mixed model" summary so non-stat users see concise, plain-language interpretations while leaving all statistical computations, exports, and numeric reporting unchanged.

### Description
- Replace the previous technical mixed-model bullets with `format_mixed_model_plain_language(...)` which emits human-friendly lines derived from the Mixed Model results table while preserving p-values and coefficient signs.
- Add helper functions `_format_p_value`, `_extract_sum_coded_label`, `_is_intercept`, `_is_condition_main_effect`, `_is_roi_main_effect`, and `_is_interaction_term` and integrate them into `_summarize_mixed_model` in `src/Tools/Stats/PySide6/summary_utils.py`.
- Map sum-coded term names to readable labels, report `Intercept`, `Condition`, `ROI`, and interaction messages, and include direction language (`higher`/`lower`) when an estimate is present and non-zero.
- Update and add unit tests: modify `tests/test_summary_utils_mixed_model.py` and add `tests/test_mixed_model_plain_language.py` to validate intercept, directionality, and interaction messaging.

### Testing
- Ran static checks with `ruff check .`, which reported many pre-existing lint issues in the repository and therefore did not pass (issues are unrelated to the mixed-model changes).
- Ran unit tests with `pytest tests/test_summary_utils_mixed_model.py tests/test_mixed_model_plain_language.py`, which errored during collection because `pandas` is not available in the current test environment; the new tests exercise `format_mixed_model_plain_language` and should pass when dependencies are installed.
- No statistical computations, thresholds, contrasts, correction methods, model formulas, or Excel exports were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697776cc7b90832ca77cc6e6631ec43c)