### PR TITLE
Add QC exclusion screening before DV computation

### DIFF
--- a/src/Tools/Stats/PySide6/stats_qc_exclusion.py
+++ b/src/Tools/Stats/PySide6/stats_qc_exclusion.py
@@ -1,0 +1,402 @@
+"""QC exclusion helpers for the Stats tool."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.Legacy.excel_io import safe_read_excel
+from Tools.Stats.Legacy.stats_analysis import (
+    SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
+    _match_freq_column,
+    filter_to_oddball_harmonics,
+    get_included_freqs,
+)
+
+logger = logging.getLogger("Tools.Stats")
+
+QC_REASON_SUMABS = "QC_SUMABS"
+QC_REASON_MAXABS = "QC_MAXABS"
+
+QC_DEFAULT_THRESHOLD_SUMABS = 3.5
+QC_DEFAULT_THRESHOLD_MAXABS = 3.5
+
+
+@dataclass(frozen=True)
+class QcViolation:
+    condition: str
+    roi: str
+    metric: str
+    value: float
+    robust_center: float
+    robust_spread: float
+    robust_score: float
+    threshold_used: float
+    trigger_harmonic_hz: Optional[float] = None
+    roi_mean_bca_at_trigger: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class QcParticipantReport:
+    participant_id: str
+    reasons: list[str]
+    n_violations: int
+    worst_value: float
+    worst_condition: str
+    worst_roi: str
+    worst_metric: str
+    robust_center: float
+    robust_spread: float
+    robust_score: float
+    threshold_used: float
+    trigger_harmonic_hz: Optional[float]
+    roi_mean_bca_at_trigger: Optional[float]
+    violations: list[QcViolation]
+
+
+@dataclass(frozen=True)
+class QcExclusionSummary:
+    n_subjects_before: int
+    n_subjects_excluded: int
+    n_subjects_after: int
+    threshold_sumabs: float
+    threshold_maxabs: float
+
+
+@dataclass(frozen=True)
+class QcExclusionReport:
+    summary: QcExclusionSummary
+    participants: list[QcParticipantReport]
+    screened_conditions: list[str]
+    screened_rois: list[str]
+
+
+def format_qc_violation(violation: QcViolation) -> str:
+    trigger = ""
+    if violation.trigger_harmonic_hz is not None:
+        trigger = (
+            f", trigger_hz={violation.trigger_harmonic_hz:.3f}, "
+            f"roi_mean_bca={violation.roi_mean_bca_at_trigger:.4f}"
+        )
+    return (
+        f"{violation.metric} condition={violation.condition} roi={violation.roi} "
+        f"value={violation.value:.4f} score={violation.robust_score:.3f} "
+        f"threshold={violation.threshold_used:.2f} center={violation.robust_center:.4f} "
+        f"spread={violation.robust_spread:.4f}{trigger}"
+    )
+
+
+def _log_message(log_func: Optional[Callable[[str], None]], message: str) -> None:
+    if log_func:
+        log_func(message)
+    else:
+        logger.info(message)
+
+
+def _build_qc_harmonic_domain(
+    columns: Iterable[object],
+    base_freq: float,
+    log_func: Optional[Callable[[str], None]],
+) -> list[float]:
+    freq_candidates = get_included_freqs(base_freq, columns, lambda m: _log_message(log_func, m))
+    if not freq_candidates:
+        return []
+    oddball_list = filter_to_oddball_harmonics(
+        freq_candidates,
+        base_freq,
+        every_n=SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
+        tol=1e-3,
+    )
+    return [freq for freq, _k in oddball_list]
+
+
+def _robust_center_spread(values: np.ndarray) -> tuple[float, float]:
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return float("nan"), float("nan")
+    center = float(np.median(finite))
+    mad = float(np.median(np.abs(finite - center)))
+    if mad > 0:
+        return center, float(1.4826 * mad)
+    q1, q3 = np.percentile(finite, [25, 75])
+    iqr = float(q3 - q1)
+    if iqr > 0:
+        return center, float(0.7413 * iqr)
+    return center, 0.0
+
+
+def _robust_score(value: float, center: float, spread: float) -> float:
+    if not np.isfinite(value):
+        return float("nan")
+    if spread > 0:
+        return (value - center) / spread
+    if not np.isfinite(center):
+        return float("nan")
+    if value == center:
+        return 0.0
+    # Fallback for zero spread: any deviation from the center is treated as extreme.
+    return float("inf") if value > center else float("-inf")
+
+
+def run_qc_exclusion(
+    *,
+    subjects: list[str],
+    subject_data: Dict[str, Dict[str, str]],
+    conditions_all: list[str],
+    rois_all: Dict[str, List[str]],
+    base_freq: float,
+    threshold_sumabs: float = QC_DEFAULT_THRESHOLD_SUMABS,
+    threshold_maxabs: float = QC_DEFAULT_THRESHOLD_MAXABS,
+    log_func: Optional[Callable[[str], None]] = None,
+) -> tuple[set[str], QcExclusionReport]:
+    screened_conditions = list(conditions_all or [])
+    if not screened_conditions:
+        screened_conditions = sorted(
+            {
+                cond
+                for subj in subject_data.values()
+                for cond in (subj or {}).keys()
+            },
+            key=repr,
+        )
+    screened_rois = sorted(rois_all.keys()) if isinstance(rois_all, dict) else []
+
+    _log_message(
+        log_func,
+        "QC screening all conditions/ROIs in the project (independent of selections)…",
+    )
+    logger.info(
+        "stats_qc_screen_start",
+        extra={
+            "n_subjects": len(subjects),
+            "n_conditions": len(screened_conditions),
+            "n_rois": len(screened_rois),
+        },
+    )
+
+    qc_values: dict[tuple[str, str], dict[str, dict[str, object]]] = {}
+
+    for pid in subjects:
+        for cond_name in screened_conditions:
+            file_path = subject_data.get(pid, {}).get(cond_name)
+            if not file_path:
+                _log_message(log_func, f"QC: Missing file for {pid} {cond_name}: {file_path}")
+                continue
+            if not Path(file_path).exists():
+                _log_message(log_func, f"QC: Missing file for {pid} {cond_name}: {file_path}")
+                continue
+            try:
+                df_bca = safe_read_excel(file_path, sheet_name="BCA (uV)", index_col="Electrode")
+            except Exception as exc:  # noqa: BLE001
+                _log_message(log_func, f"QC: Failed to read BCA sheet from {file_path}: {exc}")
+                continue
+
+            df_bca.index = df_bca.index.astype(str).str.upper().str.strip()
+            harmonic_freqs = _build_qc_harmonic_domain(df_bca.columns, base_freq, log_func)
+            if not harmonic_freqs:
+                _log_message(
+                    log_func,
+                    f"QC: No harmonic columns found for {pid} {cond_name}; skipping.",
+                )
+                continue
+            col_map = {freq: _match_freq_column(df_bca.columns, freq) for freq in harmonic_freqs}
+
+            for roi_name, roi_channels in (rois_all or {}).items():
+                roi_chans = [
+                    str(ch).strip().upper()
+                    for ch in (roi_channels or [])
+                    if str(ch).strip().upper() in df_bca.index
+                ]
+                if not roi_chans:
+                    _log_message(
+                        log_func,
+                        f"QC: No overlapping BCA data for ROI {roi_name} in {file_path}.",
+                    )
+                    continue
+                df_roi = df_bca.loc[roi_chans].dropna(how="all")
+                if df_roi.empty:
+                    _log_message(log_func, f"QC: No BCA data for ROI {roi_name} in {file_path}.")
+                    continue
+
+                mean_values: list[float] = []
+                max_abs_value = float("nan")
+                max_abs_freq: Optional[float] = None
+                max_abs_raw: Optional[float] = None
+
+                for freq_val in harmonic_freqs:
+                    col_bca = col_map.get(freq_val)
+                    if not col_bca:
+                        continue
+                    series = pd.to_numeric(df_roi[col_bca], errors="coerce").replace(
+                        [np.inf, -np.inf], np.nan
+                    )
+                    mean_val = float(series.mean(skipna=True))
+                    if not np.isfinite(mean_val):
+                        continue
+                    mean_values.append(mean_val)
+                    abs_val = abs(mean_val)
+                    if not np.isfinite(max_abs_value) or abs_val > max_abs_value:
+                        max_abs_value = abs_val
+                        max_abs_freq = float(freq_val)
+                        max_abs_raw = mean_val
+
+                if not mean_values:
+                    _log_message(
+                        log_func,
+                        f"QC: No finite harmonic means for {pid} {cond_name} {roi_name}.",
+                    )
+                    continue
+
+                qc_sumabs = float(np.sum(np.abs(mean_values)))
+                qc_maxabs = float(max_abs_value)
+                cell_key = (cond_name, roi_name)
+                pid_entry = qc_values.setdefault(cell_key, {}).setdefault(pid, {})
+                pid_entry["sumabs"] = qc_sumabs
+                pid_entry["maxabs"] = qc_maxabs
+                pid_entry["maxabs_freq"] = max_abs_freq
+                pid_entry["maxabs_raw"] = max_abs_raw
+
+    participants: list[QcParticipantReport] = []
+    excluded_ids: set[str] = set()
+
+    for (cond_name, roi_name), pid_map in qc_values.items():
+        pids = sorted(pid_map.keys())
+        sumabs_values = np.array(
+            [pid_map[pid].get("sumabs", float("nan")) for pid in pids], dtype=float
+        )
+        maxabs_values = np.array(
+            [pid_map[pid].get("maxabs", float("nan")) for pid in pids], dtype=float
+        )
+        sumabs_center, sumabs_spread = _robust_center_spread(sumabs_values)
+        maxabs_center, maxabs_spread = _robust_center_spread(maxabs_values)
+
+        for idx, pid in enumerate(pids):
+            violations: list[QcViolation] = []
+
+            sumabs_value = float(sumabs_values[idx])
+            sumabs_score = _robust_score(sumabs_value, sumabs_center, sumabs_spread)
+            if np.isfinite(sumabs_score) and abs(sumabs_score) > threshold_sumabs:
+                violations.append(
+                    QcViolation(
+                        condition=cond_name,
+                        roi=roi_name,
+                        metric=QC_REASON_SUMABS,
+                        value=sumabs_value,
+                        robust_center=sumabs_center,
+                        robust_spread=sumabs_spread,
+                        robust_score=sumabs_score,
+                        threshold_used=threshold_sumabs,
+                    )
+                )
+
+            maxabs_value = float(maxabs_values[idx])
+            maxabs_score = _robust_score(maxabs_value, maxabs_center, maxabs_spread)
+            if np.isfinite(maxabs_score) and abs(maxabs_score) > threshold_maxabs:
+                meta = pid_map[pid]
+                violations.append(
+                    QcViolation(
+                        condition=cond_name,
+                        roi=roi_name,
+                        metric=QC_REASON_MAXABS,
+                        value=maxabs_value,
+                        robust_center=maxabs_center,
+                        robust_spread=maxabs_spread,
+                        robust_score=maxabs_score,
+                        threshold_used=threshold_maxabs,
+                        trigger_harmonic_hz=meta.get("maxabs_freq"),
+                        roi_mean_bca_at_trigger=meta.get("maxabs_raw"),
+                    )
+                )
+
+            if not violations:
+                continue
+
+            excluded_ids.add(pid)
+            existing = next((p for p in participants if p.participant_id == pid), None)
+            if existing:
+                combined = list(existing.violations) + violations
+                worst = max(combined, key=lambda v: abs(v.value))
+                reasons = sorted(set(existing.reasons + [v.metric for v in violations]))
+                trigger_hz = existing.trigger_harmonic_hz
+                trigger_val = existing.roi_mean_bca_at_trigger
+                maxabs_candidates = [v for v in combined if v.metric == QC_REASON_MAXABS]
+                if maxabs_candidates:
+                    maxabs_worst = max(maxabs_candidates, key=lambda v: abs(v.value))
+                    trigger_hz = maxabs_worst.trigger_harmonic_hz
+                    trigger_val = maxabs_worst.roi_mean_bca_at_trigger
+                participants.remove(existing)
+                participants.append(
+                    QcParticipantReport(
+                        participant_id=pid,
+                        reasons=reasons,
+                        n_violations=len(combined),
+                        worst_value=worst.value,
+                        worst_condition=worst.condition,
+                        worst_roi=worst.roi,
+                        worst_metric=worst.metric,
+                        robust_center=worst.robust_center,
+                        robust_spread=worst.robust_spread,
+                        robust_score=worst.robust_score,
+                        threshold_used=worst.threshold_used,
+                        trigger_harmonic_hz=trigger_hz,
+                        roi_mean_bca_at_trigger=trigger_val,
+                        violations=combined,
+                    )
+                )
+            else:
+                worst = max(violations, key=lambda v: abs(v.value))
+                maxabs_candidates = [v for v in violations if v.metric == QC_REASON_MAXABS]
+                trigger_hz = worst.trigger_harmonic_hz
+                trigger_val = worst.roi_mean_bca_at_trigger
+                if maxabs_candidates:
+                    maxabs_worst = max(maxabs_candidates, key=lambda v: abs(v.value))
+                    trigger_hz = maxabs_worst.trigger_harmonic_hz
+                    trigger_val = maxabs_worst.roi_mean_bca_at_trigger
+                participants.append(
+                    QcParticipantReport(
+                        participant_id=pid,
+                        reasons=sorted({v.metric for v in violations}),
+                        n_violations=len(violations),
+                        worst_value=worst.value,
+                        worst_condition=worst.condition,
+                        worst_roi=worst.roi,
+                        worst_metric=worst.metric,
+                        robust_center=worst.robust_center,
+                        robust_spread=worst.robust_spread,
+                        robust_score=worst.robust_score,
+                        threshold_used=worst.threshold_used,
+                        trigger_harmonic_hz=trigger_hz,
+                        roi_mean_bca_at_trigger=trigger_val,
+                        violations=violations,
+                    )
+                )
+
+    participants = sorted(participants, key=lambda p: p.participant_id)
+    summary = QcExclusionSummary(
+        n_subjects_before=len(subjects),
+        n_subjects_excluded=len(excluded_ids),
+        n_subjects_after=max(0, len(subjects) - len(excluded_ids)),
+        threshold_sumabs=float(threshold_sumabs),
+        threshold_maxabs=float(threshold_maxabs),
+    )
+    report = QcExclusionReport(
+        summary=summary,
+        participants=participants,
+        screened_conditions=screened_conditions,
+        screened_rois=screened_rois,
+    )
+    logger.info(
+        "stats_qc_screen_complete",
+        extra={
+            "n_subjects": len(subjects),
+            "n_excluded": len(excluded_ids),
+            "n_conditions": len(screened_conditions),
+            "n_rois": len(screened_rois),
+        },
+    )
+    return excluded_ids, report

--- a/tests/test_stats_qc_exclusion.py
+++ b/tests/test_stats_qc_exclusion.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from Tools.Stats.Legacy import excel_io
+from Tools.Stats.PySide6.dv_policies import prepare_summed_bca_data
+from Tools.Stats.PySide6.stats_qc_exclusion import QC_REASON_MAXABS, run_qc_exclusion
+
+
+def _make_bca_df(max_value: float) -> pd.DataFrame:
+    data = {
+        "1.2_Hz": [0.1, 0.1],
+        "2.4_Hz": [0.1, 0.1],
+        "3.6_Hz": [0.1, 0.1],
+        "4.8_Hz": [0.1, 0.1],
+        "7.2_Hz": [max_value, max_value],
+    }
+    df = pd.DataFrame(data, index=["O1", "O2"])
+    df.index.name = "Electrode"
+    return df
+
+
+def test_qc_exclusion_independent_of_selected_conditions(monkeypatch) -> None:
+    subject_data = {
+        "P1": {"A": "P1_A.xlsx", "B": "P1_B.xlsx"},
+        "P2": {"A": "P2_A.xlsx", "B": "P2_B.xlsx"},
+        "P3": {"A": "P3_A.xlsx", "B": "P3_B.xlsx"},
+    }
+    conditions_all = ["A", "B"]
+    rois = {"Occipital": ["O1", "O2"]}
+    normal_df = _make_bca_df(0.1)
+    extreme_df = _make_bca_df(1000.0)
+
+    def _fake_read_excel(path, sheet_name, *, index_col=None, use_cache=True):
+        _ = sheet_name, index_col, use_cache
+        if "P3_B" in str(path):
+            return extreme_df.copy()
+        return normal_df.copy()
+
+    monkeypatch.setattr(excel_io, "safe_read_excel", _fake_read_excel)
+
+    excluded, report = run_qc_exclusion(
+        subjects=list(subject_data.keys()),
+        subject_data=subject_data,
+        conditions_all=conditions_all,
+        rois_all=rois,
+        base_freq=6.0,
+        threshold_sumabs=3.5,
+        threshold_maxabs=3.5,
+        log_func=None,
+    )
+
+    assert "P3" in excluded
+    assert any(
+        QC_REASON_MAXABS in participant.reasons
+        for participant in report.participants
+        if participant.participant_id == "P3"
+    )
+
+    dv_data = prepare_summed_bca_data(
+        subjects=list(subject_data.keys()),
+        conditions=["A"],
+        subject_data=subject_data,
+        base_freq=6.0,
+        log_func=lambda _m: None,
+        rois=rois,
+        dv_policy=None,
+    )
+
+    assert dv_data is not None
+    assert set(dv_data.keys()) == set(subject_data.keys())
+    assert set(dv_data["P1"].keys()) == {"A"}


### PR DESCRIPTION
### Motivation
- Introduce a dataset-adaptive QC screening layer that runs before DV computation to detect hardware-like failures independent of DV harmonic selection and the user’s selected conditions/ROIs.
- Ensure the existing inferential DV computation and downstream exclusion logic remain unchanged while surfacing QC reasons in the same exclusion UI/export flows.

### Description
- New QC module: added `src/Tools/Stats/PySide6/stats_qc_exclusion.py` implementing cell-wise QC (participant × condition × ROI) that reads the "BCA (uV)" sheet, normalizes electrode labels, builds a fixed harmonic domain via `get_included_freqs` + `filter_to_oddball_harmonics`, computes ROI-mean BCA per harmonic, then computes `qc_sumabs` and `qc_maxabs` and robust MAD/IQR based scores with safe fallbacks for zero spread.
- Worker integration: updated `src/Tools/Stats/PySide6/stats_workers.py` to run a single QC prepass (cached via a `qc_state`) before calling `prepare_summed_bca_data`; filtered participants are removed prior to DV computation and original DV-based exclusions are preserved and merged with QC reasons via `merge_exclusion_reports`.
- Controller/UI wiring and exports: extended step payloads to carry `conditions_all`, `rois_all`, `qc_config`, and `qc_state` from `stats_main_window.py` through `stats_controller.py` into workers; updated the outlier/exclusion dialog and the Excel export so QC reasons/fields appear alongside DV-based exclusions (fields include robust_center, robust_spread, robust_score, threshold_used, trigger_harmonic_hz, roi_mean_bca_at_trigger, and a violations summary).
- Tests: added `tests/test_stats_qc_exclusion.py` which monkeypatches Excel reads to simulate normal and extreme BCA tables and asserts that QC excludes the extreme participant regardless of the selected-condition list and that DV preparation (`prepare_summed_bca_data`) remains callable and unchanged in shape.

### Testing
- Ran `python -m pytest -q` in this environment; test collection failed with import errors due to missing runtime/dev dependencies (`numpy`, `pandas`, `PySide6`) causing multiple import errors during collection (50 errors), so the new test could not be executed here.
- Ran `ruff check src tests`; the repo contains pre-existing lint issues (not introduced by this change) that cause `ruff` to report errors, so linting did not fully pass in this environment.
- Intended local validation: the added unit test `tests/test_stats_qc_exclusion.py` is focused and mocks `safe_read_excel`; in an environment with dependencies installed the test should verify QC exclusion independence from selected conditions and that DV preparation still runs (run with `python -m pytest tests/test_stats_qc_exclusion.py -q`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b86fb704832c9c0352511b5fcc0e)