### PR TITLE
Stats: Manual Outlier Exclusion UI + QC flag‑only reporting and exports

### DIFF
--- a/src/Tools/Stats/PySide6/stats_controller.py
+++ b/src/Tools/Stats/PySide6/stats_controller.py
@@ -35,7 +35,7 @@ from .stats_data_loader import (
 )
 from .stats_subjects import canonical_group_and_phase_from_manifest, canonical_group_label
 from Main_App.PySide6_App.Backend.project import EXCEL_SUBFOLDER_NAME, STATS_SUBFOLDER_NAME
-from .stats_outlier_exclusion import OutlierExclusionReport
+from .stats_run_report import StatsRunReport
 
 logger = logging.getLogger(__name__)
 
@@ -105,9 +105,7 @@ class StatsViewProtocol:
         self, pipeline_id: PipelineId, step_id: StepId
     ) -> tuple[dict, Callable[[dict], None]]: ...
 
-    def store_outlier_exclusion_report(
-        self, pipeline_id: PipelineId, report: OutlierExclusionReport
-    ) -> None: ...
+    def store_run_report(self, pipeline_id: PipelineId, report: StatsRunReport) -> None: ...
 
     def ensure_results_dir(self) -> str: ...
 
@@ -707,6 +705,7 @@ class StatsController:
             "conditions_all": anova_kwargs.get("conditions_all", []),
             "subject_data": anova_kwargs.get("subject_data", {}),
             "subject_groups": anova_kwargs.get("subject_groups", {}),
+            "manual_excluded_pids": anova_kwargs.get("manual_excluded_pids", []),
             "roi_map": anova_kwargs.get("rois", {}),
             "rois_all": anova_kwargs.get("rois_all", anova_kwargs.get("rois", {})),
             "base_freq": anova_kwargs.get("base_freq", 6.0),
@@ -931,9 +930,9 @@ class StatsController:
             if dv_variants:
                 self._view.store_dv_variants_payload(pipeline_id, dv_variants)
 
-            dv_exclusion_report = payload.get("dv_exclusion_report") if isinstance(payload, dict) else None
-            if isinstance(dv_exclusion_report, OutlierExclusionReport):
-                self._view.store_outlier_exclusion_report(pipeline_id, dv_exclusion_report)
+            run_report = payload.get("run_report") if isinstance(payload, dict) else None
+            if isinstance(run_report, StatsRunReport):
+                self._view.store_run_report(pipeline_id, run_report)
 
             state.current_step_index = len(state.steps)
             self._complete_pipeline(pipeline_id)

--- a/src/Tools/Stats/PySide6/stats_outlier_exclusion.py
+++ b/src/Tools/Stats/PySide6/stats_outlier_exclusion.py
@@ -16,14 +16,16 @@ from Tools.Stats.PySide6.stats_qc_exclusion import (
     format_qc_violation,
 )
 
-OUTLIER_REASON_LIMIT = "HARD_DV_LIMIT"
-OUTLIER_REASON_NONFINITE = "DV_NONFINITE"
+OUTLIER_REASON_LIMIT = "DV_HARD_LIMIT"
+OUTLIER_REASON_NONFINITE = "REQUIRED_EXCLUSION_NONFINITE"
 OUTLIER_REASON_MAD = "MAD_OUTLIER"
+OUTLIER_REASON_MANUAL = "MANUAL"
 
 OUTLIER_REASON_FRIENDLY = {
     OUTLIER_REASON_LIMIT: "Exceeded hard cutoff (±{abs_limit:g} DV)",
     OUTLIER_REASON_MAD: "Unusually extreme compared to the group (robust rule)",
-    OUTLIER_REASON_NONFINITE: "Non-finite DV value",
+    OUTLIER_REASON_NONFINITE: "Required exclusion: non-finite DV value",
+    OUTLIER_REASON_MANUAL: "Manually excluded",
     QC_REASON_SUMABS: "QC sum(|BCA|) robust outlier (threshold {threshold_used:.2f})",
     QC_REASON_MAXABS: "QC max(|BCA|) robust outlier (threshold {threshold_used:.2f})",
 }
@@ -41,6 +43,17 @@ class OutlierExclusionSummary:
     n_subjects_excluded: int
     n_subjects_after: int
     abs_limit: float
+    n_subjects_flagged: int = 0
+    n_subjects_required_excluded: int = 0
+
+
+@dataclass(frozen=True)
+class DvViolation:
+    participant_id: str
+    condition: str
+    roi: str
+    value: float
+    reason: str
 
 
 @dataclass(frozen=True)
@@ -59,6 +72,8 @@ class OutlierParticipantReport:
     trigger_harmonic_hz: float | None = None
     roi_mean_bca_at_trigger: float | None = None
     violations: list[str] = field(default_factory=list)
+    dv_violations: list[DvViolation] = field(default_factory=list)
+    required_exclusion: bool = False
 
 
 @dataclass(frozen=True)
@@ -86,7 +101,7 @@ def apply_hard_dv_exclusion(
     roi_col: str | None = None,
     value_col: str | None = None,
 ) -> tuple[pd.DataFrame, OutlierExclusionReport]:
-    """Exclude entire participants when any DV cell exceeds a hard limit."""
+    """Flag DV outliers, excluding only participants with non-finite values."""
 
     if dv_long_df is None or dv_long_df.empty:
         summary = OutlierExclusionSummary(0, 0, 0, float(abs_limit))
@@ -110,13 +125,16 @@ def apply_hard_dv_exclusion(
     violation_mask = ~finite_mask | limit_mask
 
     violations = df.loc[violation_mask].copy()
-    excluded_pids = sorted(violations[participant_col].unique())
+    flagged_pids = sorted(violations[participant_col].unique())
+    required_exclusions = sorted(
+        df.loc[~finite_mask, participant_col].dropna().unique().tolist()
+    )
 
-    filtered_df = df.loc[~df[participant_col].isin(excluded_pids)].copy()
+    filtered_df = df.loc[~df[participant_col].isin(required_exclusions)].copy()
 
     participants = []
-    if excluded_pids:
-        for pid in excluded_pids:
+    if flagged_pids:
+        for pid in flagged_pids:
             pid_rows = df.loc[df[participant_col] == pid]
             pid_values = pid_rows[value_col].to_numpy()
             pid_finite = np.isfinite(pid_values)
@@ -143,6 +161,18 @@ def apply_hard_dv_exclusion(
 
             finite_abs_values = np.abs(pid_values[pid_finite])
             max_abs_dv = float(finite_abs_values.max()) if finite_abs_values.size else float("nan")
+            dv_violations = [
+                DvViolation(
+                    participant_id=str(pid),
+                    condition=str(row[condition_col]),
+                    roi=str(row[roi_col]),
+                    value=float(row[value_col]),
+                    reason=OUTLIER_REASON_NONFINITE
+                    if not np.isfinite(float(row[value_col]))
+                    else OUTLIER_REASON_LIMIT,
+                )
+                for _, row in pid_violations.iterrows()
+            ]
 
             participants.append(
                 OutlierParticipantReport(
@@ -154,14 +184,18 @@ def apply_hard_dv_exclusion(
                     worst_condition=str(worst_row[condition_col]),
                     worst_roi=str(worst_row[roi_col]),
                     violations=[f"DV cells={int(pid_violations.shape[0])}"],
+                    dv_violations=dv_violations,
+                    required_exclusion=str(pid) in required_exclusions,
                 )
             )
 
     summary = OutlierExclusionSummary(
         n_subjects_before=int(df[participant_col].nunique()),
-        n_subjects_excluded=len(excluded_pids),
+        n_subjects_excluded=len(required_exclusions),
         n_subjects_after=int(filtered_df[participant_col].nunique()),
         abs_limit=float(abs_limit),
+        n_subjects_flagged=len(flagged_pids),
+        n_subjects_required_excluded=len(required_exclusions),
     )
 
     return filtered_df, OutlierExclusionReport(summary=summary, participants=participants)
@@ -222,6 +256,7 @@ def report_to_dataframe(report: OutlierExclusionReport) -> pd.DataFrame:
                 "roi_mean_bca_at_trigger": item.roi_mean_bca_at_trigger,
                 "violations": violation_text,
                 "max_abs_dv": item.max_abs_dv,
+                "required_exclusion": item.required_exclusion,
             }
         )
     return pd.DataFrame(rows)
@@ -232,11 +267,12 @@ def build_outlier_summary_text(report: OutlierExclusionReport) -> str:
     abs_limit = float(summary.abs_limit)
     lines = [
         "QC screened all conditions/ROIs in the project, independent of selections.",
-        "Outlier Exclusion Summary",
-        f"Participants excluded: {summary.n_subjects_excluded} (of {summary.n_subjects_before})",
+        "Outlier Flag Summary",
+        f"Participants flagged: {summary.n_subjects_flagged} (of {summary.n_subjects_before})",
+        f"Required exclusions (non-finite DV): {summary.n_subjects_required_excluded}",
     ]
     if not report.participants:
-        lines.append("No participants were excluded.")
+        lines.append("No participants were flagged.")
         return "\n".join(lines)
 
     for participant in report.participants:
@@ -259,7 +295,7 @@ def build_outlier_summary_text(report: OutlierExclusionReport) -> str:
         else:
             worst_text = "non-finite"
         lines.append(
-            f"{participant.participant_id} was excluded as an outlier because {reason_sentence}. "
+            f"{participant.participant_id} was flagged because {reason_sentence}. "
             f"Worst value: {worst_text} DV ({participant.worst_condition}, {participant.worst_roi})."
         )
 
@@ -275,6 +311,8 @@ def summary_to_dataframe(report: OutlierExclusionReport) -> pd.DataFrame:
                 "n_subjects_excluded": summary.n_subjects_excluded,
                 "n_subjects_after": summary.n_subjects_after,
                 "abs_limit": summary.abs_limit,
+                "n_subjects_flagged": summary.n_subjects_flagged,
+                "n_subjects_required_excluded": summary.n_subjects_required_excluded,
             }
         ]
     )
@@ -355,21 +393,266 @@ def merge_exclusion_reports(
         dv_report.summary.n_subjects_before,
         qc_report.summary.n_subjects_before,
     )
-    n_excluded = len({p.participant_id for p in combined_participants})
+    n_flagged = len({p.participant_id for p in combined_participants})
+    n_required = dv_report.summary.n_subjects_required_excluded
     summary = OutlierExclusionSummary(
         n_subjects_before=n_before,
-        n_subjects_excluded=n_excluded,
-        n_subjects_after=max(0, n_before - n_excluded),
+        n_subjects_excluded=n_required,
+        n_subjects_after=max(0, n_before - n_required),
         abs_limit=float(dv_report.summary.abs_limit),
+        n_subjects_flagged=n_flagged,
+        n_subjects_required_excluded=n_required,
     )
     qc_metadata = {
         "screened_conditions": qc_report.screened_conditions,
         "screened_rois": qc_report.screened_rois,
-        "threshold_sumabs": qc_report.summary.threshold_sumabs,
-        "threshold_maxabs": qc_report.summary.threshold_maxabs,
+        "warn_threshold": qc_report.summary.warn_threshold,
+        "critical_threshold": qc_report.summary.critical_threshold,
+        "warn_abs_floor_sumabs": qc_report.summary.warn_abs_floor_sumabs,
+        "critical_abs_floor_sumabs": qc_report.summary.critical_abs_floor_sumabs,
+        "warn_abs_floor_maxabs": qc_report.summary.warn_abs_floor_maxabs,
+        "critical_abs_floor_maxabs": qc_report.summary.critical_abs_floor_maxabs,
     }
     return OutlierExclusionReport(
         summary=summary,
         participants=combined_participants,
         qc_metadata=qc_metadata,
     )
+
+
+def collect_flagged_pid_map(
+    qc_report: QcExclusionReport | None,
+    dv_report: OutlierExclusionReport | None,
+) -> dict[str, list[str]]:
+    flagged: dict[str, set[str]] = {}
+    if qc_report:
+        for participant in qc_report.participants:
+            flagged.setdefault(participant.participant_id, set()).update(participant.reasons)
+    if dv_report:
+        for participant in dv_report.participants:
+            flagged.setdefault(participant.participant_id, set()).update(participant.reasons)
+    return {pid: sorted(reasons) for pid, reasons in flagged.items()}
+
+
+def _qc_threshold_metadata(qc_report: QcExclusionReport | None) -> dict[str, float]:
+    if not qc_report:
+        return {
+            "warn_threshold": float("nan"),
+            "critical_threshold": float("nan"),
+            "warn_abs_floor_sumabs": float("nan"),
+            "critical_abs_floor_sumabs": float("nan"),
+            "warn_abs_floor_maxabs": float("nan"),
+            "critical_abs_floor_maxabs": float("nan"),
+        }
+    summary = qc_report.summary
+    return {
+        "warn_threshold": summary.warn_threshold,
+        "critical_threshold": summary.critical_threshold,
+        "warn_abs_floor_sumabs": summary.warn_abs_floor_sumabs,
+        "critical_abs_floor_sumabs": summary.critical_abs_floor_sumabs,
+        "warn_abs_floor_maxabs": summary.warn_abs_floor_maxabs,
+        "critical_abs_floor_maxabs": summary.critical_abs_floor_maxabs,
+    }
+
+
+def build_flagged_participants_tables(
+    qc_report: QcExclusionReport | None,
+    dv_report: OutlierExclusionReport | None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    details: list[dict[str, object]] = []
+    qc_meta = _qc_threshold_metadata(qc_report)
+
+    if qc_report:
+        for participant in qc_report.participants:
+            for violation in participant.violations:
+                details.append(
+                    {
+                        "participant_id": participant.participant_id,
+                        "flag_type": violation.metric,
+                        "severity": violation.severity,
+                        "condition": violation.condition,
+                        "roi": violation.roi,
+                        "metric_value": violation.value,
+                        "robust_center": violation.robust_center,
+                        "robust_spread": violation.robust_spread,
+                        "robust_score": violation.robust_score,
+                        "threshold_used": violation.threshold_used,
+                        "abs_floor_used": violation.abs_floor_used,
+                        "trigger_harmonic_hz": violation.trigger_harmonic_hz,
+                        "roi_mean_bca_at_trigger": violation.roi_mean_bca_at_trigger,
+                        "reason_text": format_qc_violation(violation),
+                    }
+                )
+
+    if dv_report:
+        for participant in dv_report.participants:
+            for dv_violation in participant.dv_violations:
+                details.append(
+                    {
+                        "participant_id": participant.participant_id,
+                        "flag_type": dv_violation.reason,
+                        "severity": "REQUIRED" if dv_violation.reason == OUTLIER_REASON_NONFINITE else "FLAG",
+                        "condition": dv_violation.condition,
+                        "roi": dv_violation.roi,
+                        "metric_value": dv_violation.value,
+                        "robust_center": None,
+                        "robust_spread": None,
+                        "robust_score": None,
+                        "threshold_used": dv_report.summary.abs_limit,
+                        "abs_floor_used": None,
+                        "trigger_harmonic_hz": None,
+                        "roi_mean_bca_at_trigger": None,
+                        "reason_text": format_outlier_reason(
+                            dv_violation.reason,
+                            abs_limit=dv_report.summary.abs_limit,
+                        ),
+                    }
+                )
+
+    details_df = pd.DataFrame(
+        details,
+        columns=[
+            "participant_id",
+            "flag_type",
+            "severity",
+            "condition",
+            "roi",
+            "metric_value",
+            "robust_center",
+            "robust_spread",
+            "robust_score",
+            "threshold_used",
+            "abs_floor_used",
+            "trigger_harmonic_hz",
+            "roi_mean_bca_at_trigger",
+            "reason_text",
+        ],
+    )
+
+    summary_rows: list[dict[str, object]] = []
+    if not details_df.empty:
+        grouped = details_df.groupby("participant_id", sort=True)
+        for pid, group in grouped:
+            values = group["metric_value"].to_numpy()
+            finite_mask = np.isfinite(values)
+            worst_idx = None
+            if values.size:
+                worst_scores = np.where(finite_mask, np.abs(values), np.inf)
+                worst_idx = int(np.argmax(worst_scores))
+            worst_row = group.iloc[worst_idx] if worst_idx is not None else group.iloc[0]
+            summary_rows.append(
+                {
+                    "participant_id": pid,
+                    "flag_types": ", ".join(sorted(set(group["flag_type"].tolist()))),
+                    "n_flags": int(group.shape[0]),
+                    "worst_value": worst_row["metric_value"],
+                    "worst_condition": worst_row["condition"],
+                    "worst_roi": worst_row["roi"],
+                    "reason_text": "; ".join(sorted(set(group["reason_text"].tolist()))),
+                    **qc_meta,
+                }
+            )
+    summary_df = pd.DataFrame(
+        summary_rows,
+        columns=[
+            "participant_id",
+            "flag_types",
+            "n_flags",
+            "worst_value",
+            "worst_condition",
+            "worst_roi",
+            "reason_text",
+            "warn_threshold",
+            "critical_threshold",
+            "warn_abs_floor_sumabs",
+            "critical_abs_floor_sumabs",
+            "warn_abs_floor_maxabs",
+            "critical_abs_floor_maxabs",
+        ],
+    )
+    if summary_df.empty and qc_meta:
+        summary_df = pd.DataFrame(
+            [],
+            columns=[
+                "participant_id",
+                "flag_types",
+                "n_flags",
+                "worst_value",
+                "worst_condition",
+                "worst_roi",
+                "reason_text",
+                "warn_threshold",
+                "critical_threshold",
+                "warn_abs_floor_sumabs",
+                "critical_abs_floor_sumabs",
+                "warn_abs_floor_maxabs",
+                "critical_abs_floor_maxabs",
+            ],
+        )
+    return summary_df, details_df
+
+
+def export_flagged_participants_report(
+    save_path: str | bytes | "os.PathLike[str]",
+    qc_report: QcExclusionReport | None,
+    dv_report: OutlierExclusionReport | None,
+    log_func,
+) -> None:
+    summary_df, details_df = build_flagged_participants_tables(qc_report, dv_report)
+    with pd.ExcelWriter(save_path, engine="xlsxwriter") as writer:
+        _auto_format_and_write_excel(writer, summary_df, "Flag Summary", log_func)
+        _auto_format_and_write_excel(writer, details_df, "Flag Details", log_func)
+
+
+def export_excluded_participants_report(
+    save_path: str | bytes | "os.PathLike[str]",
+    *,
+    manual_excluded: list[str],
+    required_exclusions: list[DvViolation],
+    log_func,
+) -> None:
+    rows = []
+    for pid in manual_excluded:
+        rows.append(
+            {
+                "participant_id": pid,
+                "exclusion_reason": OUTLIER_REASON_MANUAL,
+                "worst_value": None,
+                "worst_condition": None,
+                "worst_roi": None,
+            }
+        )
+    grouped: dict[str, DvViolation] = {}
+    for violation in required_exclusions:
+        current = grouped.get(violation.participant_id)
+        if current is None:
+            grouped[violation.participant_id] = violation
+            continue
+        current_val = current.value
+        candidate_val = violation.value
+        current_score = np.inf if not np.isfinite(current_val) else abs(current_val)
+        candidate_score = np.inf if not np.isfinite(candidate_val) else abs(candidate_val)
+        if candidate_score >= current_score:
+            grouped[violation.participant_id] = violation
+    for violation in grouped.values():
+        rows.append(
+            {
+                "participant_id": violation.participant_id,
+                "exclusion_reason": OUTLIER_REASON_NONFINITE,
+                "worst_value": violation.value,
+                "worst_condition": violation.condition,
+                "worst_roi": violation.roi,
+            }
+        )
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "participant_id",
+            "exclusion_reason",
+            "worst_value",
+            "worst_condition",
+            "worst_roi",
+        ],
+    )
+    with pd.ExcelWriter(save_path, engine="xlsxwriter") as writer:
+        _auto_format_and_write_excel(writer, df, "Excluded Participants", log_func)

--- a/src/Tools/Stats/PySide6/stats_run_report.py
+++ b/src/Tools/Stats/PySide6/stats_run_report.py
@@ -1,0 +1,17 @@
+"""Run report structures for Stats flagging/exclusion workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from Tools.Stats.PySide6.stats_outlier_exclusion import OutlierExclusionReport, DvViolation
+from Tools.Stats.PySide6.stats_qc_exclusion import QcExclusionReport
+
+
+@dataclass(frozen=True)
+class StatsRunReport:
+    manual_excluded_pids: list[str]
+    qc_report: QcExclusionReport | None
+    dv_report: OutlierExclusionReport | None
+    required_exclusions: list[DvViolation]
+    final_modeled_pids: list[str]

--- a/tests/test_stats_manual_exclusion.py
+++ b/tests/test_stats_manual_exclusion.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from Tools.Stats.PySide6.stats_core import PipelineId, StepId
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+
+
+def test_manual_exclusion_state_in_payload(qtbot, monkeypatch) -> None:
+    monkeypatch.setattr(StatsWindow, "_load_default_data_folder", lambda self: None, raising=False)
+    window = StatsWindow(project_dir=".")
+    qtbot.addWidget(window)
+
+    window.subjects = ["P1", "P2", "P3"]
+    window.subject_data = {
+        "P1": {"A": "P1_A.xlsx"},
+        "P2": {"A": "P2_A.xlsx"},
+        "P3": {"A": "P3_A.xlsx"},
+    }
+    window.conditions = ["A", "B"]
+    window._populate_conditions_panel(window.conditions)
+    window.rois = {"ROI": ["Cz"]}
+    window._current_base_freq = 6.0
+    window._current_alpha = 0.05
+
+    window._manual_excluded_pids = ["P2"]
+    window._reconcile_manual_exclusions(window.subjects)
+
+    assert "P2" in window.manual_exclusion_list.toPlainText()
+    assert "Excluded: 1 participant" in window.manual_exclusion_summary_label.text()
+
+    kwargs, _handler = window.get_step_config(PipelineId.SINGLE, StepId.RM_ANOVA)
+    assert kwargs["manual_excluded_pids"] == ["P2"]

--- a/tests/test_stats_outlier_exclusion.py
+++ b/tests/test_stats_outlier_exclusion.py
@@ -19,10 +19,10 @@ def test_apply_hard_dv_exclusion_filters_participants() -> None:
 
     filtered, report = apply_hard_dv_exclusion(df, 50.0)
 
-    assert set(filtered["subject"].unique()) == {"P2"}
+    assert set(filtered["subject"].unique()) == {"P1", "P2"}
     assert report.summary.n_subjects_before == 3
-    assert report.summary.n_subjects_excluded == 2
-    assert report.summary.n_subjects_after == 1
+    assert report.summary.n_subjects_excluded == 1
+    assert report.summary.n_subjects_after == 2
 
     reasons_by_pid = {item.participant_id: set(item.reasons) for item in report.participants}
     assert reasons_by_pid["P1"] == {OUTLIER_REASON_LIMIT}

--- a/tests/test_stats_qc_exclusion.py
+++ b/tests/test_stats_qc_exclusion.py
@@ -39,18 +39,16 @@ def test_qc_exclusion_independent_of_selected_conditions(monkeypatch) -> None:
 
     monkeypatch.setattr(excel_io, "safe_read_excel", _fake_read_excel)
 
-    excluded, report = run_qc_exclusion(
+    report = run_qc_exclusion(
         subjects=list(subject_data.keys()),
         subject_data=subject_data,
         conditions_all=conditions_all,
         rois_all=rois,
         base_freq=6.0,
-        threshold_sumabs=3.5,
-        threshold_maxabs=3.5,
         log_func=None,
     )
 
-    assert "P3" in excluded
+    assert report.summary.n_subjects_flagged == 1
     assert any(
         QC_REASON_MAXABS in participant.reasons
         for participant in report.participants


### PR DESCRIPTION
### Motivation
- Reduce aggressive automatic exclusions by making QC / DV checks flag-only while preserving existing DV definition and pipeline order.  
- Provide a default-enabled Manual Outlier Exclusion workflow so users can explicitly exclude participants from all modeling and exports.  
- Produce an auditable flagged-participant report (GUI + Excel) so users can inspect QC/DV flags and re-run with manual exclusions.

### Description
- Converted QC screening to a flag-only workflow with tiered severity (WARNING/CRITICAL), robust scoring (median+MAD fallback), and configurable absolute floors; QC now returns a `QcExclusionReport` rather than an automatic excluded-PID set.  Files changed: `src/Tools/Stats/PySide6/stats_qc_exclusion.py`.  
- Converted DV/hard-limit logic to produce flags and only perform required exclusions for non-finite DV that would otherwise crash modeling; added detailed DV violation records. Files changed: `src/Tools/Stats/PySide6/stats_outlier_exclusion.py`.  
- Added a `StatsRunReport` structure and threaded run-report plumbing through workers and controller so GUI receives `qc_report`, `dv_report`, `required_exclusions`, `manual_excluded_pids`, and `final_modeled_pids`. Files changed: `src/Tools/Stats/PySide6/stats_run_report.py`, `src/Tools/Stats/PySide6/stats_workers.py`, `src/Tools/Stats/PySide6/stats_controller.py`.  
- Implemented Manual Outlier Exclusion UI (panel + Edit dialog) enabled by default, session-persistent, reconciled on project rescan, and included in the worker payloads; added post-run Flagged Participants report dialog and two Excel exports (`Flagged Participants.xlsx` and `Excluded Participants.xlsx`). Files changed: `src/Tools/Stats/PySide6/stats_main_window.py`, `src/Tools/Stats/PySide6/stats_outlier_exclusion.py` (exports).  
- Tests updated/added: `tests/test_stats_qc_exclusion.py`, `tests/test_stats_outlier_exclusion.py` (adjusted expectations for flag-only behavior), and new smoke test `tests/test_stats_manual_exclusion.py` (payload inclusion check).

### Testing
- Ran code style check with `python -m ruff check .`; this run reported many lint issues unrelated to the Stats changes (existing violations in SourceLocalization modules and tests), so no Stats-specific lint failures were introduced by this PR.  Result: lint run completed with errors (existing project issues).  
- Ran the test suite with `python -m pytest -q`; test collection aborted due to missing runtime/test environment dependencies in this CI snapshot (missing packages: `numpy`, `pandas`, `PySide6`, `pytestqt`), so full automated test execution could not be completed here.  
- Local unit changes: updated assertions in `tests/test_stats_qc_exclusion.py` and `tests/test_stats_outlier_exclusion.py` to expect flag-only reports, and added `tests/test_stats_manual_exclusion.py` to assert manual exclusions are included in the worker payload; these tests are present and exercise the new UI/payload plumbing but could not be executed in this environment due to dependency issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d2e48c6c832cb61423aa12757cfc)