### PR TITLE
Fix Manual Outlier Exclusion dialog, persist main-panel exclusions, and apply exclusions before DV compute

### DIFF
--- a/src/Tools/Stats/PySide6/stats_manual_exclusion_dialog.py
+++ b/src/Tools/Stats/PySide6/stats_manual_exclusion_dialog.py
@@ -1,0 +1,108 @@
+"""Manual outlier exclusion dialog for the Stats tool."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+)
+
+
+class ManualOutlierExclusionDialog(QDialog):
+    manualExclusionsApplied = Signal(set)
+
+    def __init__(
+        self,
+        *,
+        candidates: Iterable[str],
+        flagged_map: dict[str, list[str]] | None = None,
+        preselected: Iterable[str] | None = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Manual Outlier Exclusion")
+        self.setModal(True)
+
+        self.selected_pids: set[str] = set(preselected or [])
+        self._flagged_map = flagged_map or {}
+
+        layout = QVBoxLayout(self)
+
+        search_row = QHBoxLayout()
+        search_label = QLabel("Search:")
+        self.search_input = QLineEdit()
+        self.search_input.setPlaceholderText("Filter participants…")
+        search_row.addWidget(search_label)
+        search_row.addWidget(self.search_input, 1)
+        layout.addLayout(search_row)
+
+        self.list_widget = QListWidget()
+        self.list_widget.setSelectionMode(QAbstractItemView.NoSelection)
+        layout.addWidget(self.list_widget)
+
+        for pid in candidates:
+            flags = self._flagged_map.get(pid, [])
+            suffix = f" (FLAGGED: {', '.join(flags)})" if flags else ""
+            item = QListWidgetItem(f"{pid}{suffix}")
+            item.setData(Qt.UserRole, pid)
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Checked if pid in self.selected_pids else Qt.Unchecked)
+            self.list_widget.addItem(item)
+
+        controls_row = QHBoxLayout()
+        self.select_all_btn = QPushButton("Select all")
+        self.select_none_btn = QPushButton("Select none")
+        controls_row.addWidget(self.select_all_btn)
+        controls_row.addWidget(self.select_none_btn)
+        controls_row.addStretch(1)
+        layout.addLayout(controls_row)
+
+        self.button_box = QDialogButtonBox(QDialogButtonBox.Apply | QDialogButtonBox.Cancel)
+        layout.addWidget(self.button_box)
+        self.apply_button = self.button_box.button(QDialogButtonBox.Apply)
+        if self.apply_button is not None:
+            self.apply_button.setEnabled(self.list_widget.count() > 0)
+
+        self.search_input.textChanged.connect(self._apply_filter)
+        self.select_all_btn.clicked.connect(self._select_all)
+        self.select_none_btn.clicked.connect(self._select_none)
+        if self.apply_button is not None:
+            self.apply_button.clicked.connect(self._apply_changes)
+        self.button_box.rejected.connect(self.reject)
+
+    def _apply_filter(self, text: str) -> None:
+        filter_text = text.strip().lower()
+        for idx in range(self.list_widget.count()):
+            item = self.list_widget.item(idx)
+            pid = str(item.data(Qt.UserRole)).lower()
+            item.setHidden(bool(filter_text) and filter_text not in pid)
+
+    def _select_all(self) -> None:
+        for idx in range(self.list_widget.count()):
+            item = self.list_widget.item(idx)
+            item.setCheckState(Qt.Checked)
+
+    def _select_none(self) -> None:
+        for idx in range(self.list_widget.count()):
+            item = self.list_widget.item(idx)
+            item.setCheckState(Qt.Unchecked)
+
+    def _apply_changes(self) -> None:
+        selections = set()
+        for idx in range(self.list_widget.count()):
+            item = self.list_widget.item(idx)
+            if item.checkState() == Qt.Checked:
+                selections.add(str(item.data(Qt.UserRole)))
+        self.selected_pids = selections
+        self.manualExclusionsApplied.emit(set(selections))
+        self.accept()

--- a/tests/test_stats_manual_exclusion.py
+++ b/tests/test_stats_manual_exclusion.py
@@ -1,7 +1,28 @@
 from __future__ import annotations
 
+import pandas as pd
+from PySide6.QtCore import Qt
+
+from Tools.Stats.PySide6 import stats_workers
 from Tools.Stats.PySide6.stats_core import PipelineId, StepId
+from Tools.Stats.PySide6.stats_manual_exclusion_dialog import ManualOutlierExclusionDialog
 from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+
+
+def test_manual_exclusion_dialog_apply_emits_and_closes(qtbot) -> None:
+    dialog = ManualOutlierExclusionDialog(
+        candidates=["P1", "P2"],
+        flagged_map={},
+        preselected=set(),
+    )
+    qtbot.addWidget(dialog)
+
+    dialog.list_widget.item(0).setCheckState(Qt.Checked)
+    with qtbot.waitSignal(dialog.manualExclusionsApplied, timeout=1000) as blocker:
+        qtbot.mouseClick(dialog.apply_button, Qt.LeftButton)
+
+    assert blocker.args[0] == {"P1"}
+    assert dialog.result() == dialog.Accepted
 
 
 def test_manual_exclusion_state_in_payload(qtbot, monkeypatch) -> None:
@@ -11,9 +32,9 @@ def test_manual_exclusion_state_in_payload(qtbot, monkeypatch) -> None:
 
     window.subjects = ["P1", "P2", "P3"]
     window.subject_data = {
-        "P1": {"A": "P1_A.xlsx"},
-        "P2": {"A": "P2_A.xlsx"},
-        "P3": {"A": "P3_A.xlsx"},
+        "P1": {"A": {"ROI": 1.0}},
+        "P2": {"A": {"ROI": 1.0}},
+        "P3": {"A": {"ROI": 1.0}},
     }
     window.conditions = ["A", "B"]
     window._populate_conditions_panel(window.conditions)
@@ -21,11 +42,60 @@ def test_manual_exclusion_state_in_payload(qtbot, monkeypatch) -> None:
     window._current_base_freq = 6.0
     window._current_alpha = 0.05
 
-    window._manual_excluded_pids = ["P2"]
     window._reconcile_manual_exclusions(window.subjects)
 
-    assert "P2" in window.manual_exclusion_list.toPlainText()
-    assert "Excluded: 1 participant" in window.manual_exclusion_summary_label.text()
+    dialog = ManualOutlierExclusionDialog(
+        candidates=window.subjects,
+        flagged_map={},
+        preselected=window.manual_excluded_pids,
+        parent=window,
+    )
+    qtbot.addWidget(dialog)
+
+    def _apply_changes(selections: set[str]) -> None:
+        window.manual_excluded_pids = set(selections)
+        window._update_manual_exclusion_summary()
+
+    dialog.manualExclusionsApplied.connect(_apply_changes)
+    dialog.list_widget.item(1).setCheckState(Qt.Checked)
+    qtbot.mouseClick(dialog.apply_button, Qt.LeftButton)
+
+    assert "P2" in window.manual_exclusion_list.toolTip()
+    assert window.manual_exclusion_summary_label.text() == "Excluded: 1"
 
     kwargs, _handler = window.get_step_config(PipelineId.SINGLE, StepId.RM_ANOVA)
     assert kwargs["manual_excluded_pids"] == ["P2"]
+
+
+def test_manual_exclusion_filters_before_dv_compute(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_prepare_summed_bca_data(*, subjects, subject_data, **_kwargs):
+        seen["subjects"] = list(subjects)
+        seen["subject_data"] = dict(subject_data)
+        return {"P1": {"A": {"ROI": 1.0}}}
+
+    def _fake_run_rm_anova(*_args, **_kwargs):
+        return "ok", pd.DataFrame()
+
+    monkeypatch.setattr(stats_workers, "prepare_summed_bca_data", _fake_prepare_summed_bca_data)
+    monkeypatch.setattr(stats_workers, "analysis_run_rm_anova", _fake_run_rm_anova)
+
+    stats_workers.run_rm_anova(
+        progress_cb=lambda *_args: None,
+        message_cb=lambda *_args: None,
+        subjects=["P1", "P2"],
+        conditions=["A"],
+        conditions_all=["A"],
+        subject_data={
+            "P1": {"A": {"ROI": 1.0}},
+            "P2": {"A": {"ROI": 2.0}},
+        },
+        base_freq=6.0,
+        rois={"ROI": ["Cz"]},
+        rois_all={"ROI": ["Cz"]},
+        manual_excluded_pids=["P2"],
+    )
+
+    assert seen["subjects"] == ["P1"]
+    assert "P2" not in seen["subject_data"]


### PR DESCRIPTION
### Motivation
- The Manual Outlier Exclusion dialog previously did not persist selections or close on Apply, and the Main Stats window lacked a persistent, visible manual-exclusion panel before runs.  
- Manual exclusions were not reliably included in analysis payloads and therefore were not applied before DV computation.  
- Improve UX by reusing a single dialog from both the flagged-report and main window and ensure exclusions affect all analysis pipelines without changing inferential logic.

### Description
- Add a new `ManualOutlierExclusionDialog` (PySide6) that uses checkbox items with `Qt.UserRole` to store PID identity, supports Search + Select all/none, emits `manualExclusionsApplied(set)` on Apply, and calls `accept()` to close (`src/Tools/Stats/PySide6/stats_manual_exclusion_dialog.py`).
- Replace the ad-hoc dialog code in the main Stats window with the new dialog, pre-checking items via `preselected` and passing `flagged_map`; connect the dialog signal to update a persistent `self.manual_excluded_pids: set[str]` on the main window (`src/Tools/Stats/PySide6/stats_main_window.py`).
- Make `manual_excluded_pids` persistent on the Stats window (now a `set[str]`), add `_update_manual_exclusion_summary()` to show an elided, comma-separated read-only display with tooltip, and wire Clear/Edit operations to the new dialog/panel.
- Ensure every analysis payload includes `manual_excluded_pids` (converted to a sorted list where payloads expect lists) and rely on existing worker function `_apply_manual_exclusions()` so manual exclusions are filtered before `prepare_summed_bca_data()` and DV computation (no changes to DV definitions or model logic).
- Move the Manual Outlier Exclusion panel to be above the log via a vertical `QSplitter` so it is visible before any run and has reasonable default size constraints; maintain DPI/scaling by using existing layout widgets and spacing.
- Tests: add pytest-qt unit tests covering (a) dialog Apply emits and closes, (b) main-window wiring (summary + payload contains excluded PIDs), and (c) worker `run_rm_anova` behavior when `manual_excluded_pids` is supplied to confirm filtering occurs before DV preparation (`tests/test_stats_manual_exclusion.py`).

### Testing
- Ran the test suite with `python -m pytest -q`; collection failed in this environment due to missing external runtime dependencies (notably `numpy`, `pandas`, and PySide6), so full test execution could not complete (new dialog unit tests added for pytest-qt).  
- Ran the linter with `ruff check .`; reported unrelated lint issues elsewhere in the repo (no new lint failures introduced by this change).  
- To execute the new tests locally or in CI (with GUI test support), run `python -m pytest tests/test_stats_manual_exclusion.py -q` and to run the whole test-suite run `python -m pytest -q` after installing test dependencies (`pytest-qt`, `PySide6`, `pandas`, `numpy`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69781a5ab99c832caaf294f35ae09cea)