### PR TITLE
Expand Statistical Analysis docs and add Rossion harmonic selection page

### DIFF
--- a/docs/statistical-analysis.md
+++ b/docs/statistical-analysis.md
@@ -1,137 +1,165 @@
 # Statistical Analysis
 
-This page summarizes the statistical models used by the FPVS Toolbox and
-how to interpret the outputs produced by the **Statistical Analysis**
-module.
-
-All analyses are run on preprocessed FPVS data after spectral analysis
-and ROI aggregation.
+This page summarizes the statistical methods used by the FPVS Toolbox
+**Statistical Analysis** module for end users. It focuses on the primary
+output measure (**Summed BCA**) and how to interpret results in the
+single-group and multi-group workflows.
 
 ---
 
-## Data analyzed
+## How the methods work together (high-level)
 
-- The primary dependent variable is the **summed baseline-corrected
-  oddball amplitude (Summed BCA)**.
-- Analyses are performed at the level of:
-  - subject × condition × ROI.
+1. **Summed BCA DV is defined** from the ROI-aggregated spectral outputs.
+2. **Harmonics are selected** (e.g., Rossion method) to decide which
+   oddball harmonics contribute to the DV.
+3. A **subject × condition × ROI table** of Summed BCA values is built.
+4. **RM-ANOVA** and/or a **linear mixed-effects model** summarize
+   condition, ROI, and interaction effects.
+5. **Post-hoc paired t-tests** (within each ROI) follow a significant
+   interaction to explain which condition pairs differ.
 
-Unless otherwise noted, all sections below refer to Summed BCA.
+Interpretation guide (single-group):
+
+- **Overall response present:** Summed BCA values are consistently above
+  zero and/or the mixed-model intercept is positive. Note that RM-ANOVA
+  tests differences among conditions and ROIs; it does not directly test
+  DV vs 0 (Not found in code: an explicit one-sample test on Summed BCA
+  within the main RM-ANOVA pipeline). See “Not found in code” notes below.
+- **Condition main effect:** responses differ across experimental
+  conditions (averaged across ROIs).
+- **ROI main effect:** responses differ across ROIs (averaged across
+  conditions).
+- **Condition × ROI interaction:** the condition effect depends on which
+  ROI is considered.
+
+Cautions:
+
+- **Multiple comparisons:** post-hoc tests are corrected for false
+  discovery rate; still interpret effect sizes and confidence intervals.
+- **Harmonic sets can differ by ROI** (Rossion method). This can make ROI
+  differences partly reflect different harmonic selections.
+- **Assumptions:** check normality and sphericity (RM-ANOVA) and residual
+  diagnostics (mixed model) as part of reporting.
+
+---
+
+## Summed BCA DV and harmonic selection
+
+The DV used for statistical analysis is the **Summed baseline-corrected
+oddball amplitude (Summed BCA)**. It is computed per
+**subject × condition × ROI** by summing BCA across selected oddball
+harmonics and then averaging across ROI channels.
+
+- **Source data:** The DV is computed from the **“BCA (uV)”** sheet in the
+  spectral/ROI output file; Z-score information used for harmonic
+  selection comes from the **“Z Score”** sheet.
+- **ROI aggregation:** The ROI mean is computed after summing selected
+  harmonics for each channel within the ROI.
+
+For detailed harmonic selection rules (Rossion method), see:
+**[Rossion harmonic selection](statistics/rossion-harmonic-selection.md)**.
 
 ---
 
 ## Single-group analyses
 
-Single-group mode analyzes one experimental group at a time.
-
 ### Repeated-measures ANOVA (RM-ANOVA)
 
-- Within-subject factors:
-  - **Condition**
-  - **ROI**
-- Implementation:
-  - When available, the toolbox uses **Pingouin’s** `rm_anova`, reporting:
-    - uncorrected p-values;
-    - Greenhouse–Geisser (GG) and Huynh–Feldt (HF) corrected p-values.
-  - Otherwise, it falls back to **statsmodels** `AnovaRM`
-    (uncorrected p-values only).
-- Effects of interest typically include:
-  - main effect of condition;
-  - main effect of ROI;
-  - condition × ROI interaction.
+- **Within-subject factors:** Condition and ROI (plus their interaction).
+- **Implementation:**
+  - Primary path: **Pingouin** `rm_anova` (detailed table when available,
+    including Greenhouse–Geisser and Huynh–Feldt corrections).
+  - Fallback: **statsmodels** `AnovaRM` if Pingouin is not available.
+- **Outputs:** F statistic, numerator/denominator degrees of freedom,
+  p-values, and **partial eta-squared** effect sizes.
 
-### Post-hoc tests
+Interpretation:
 
-- Pairwise **paired t-tests** between conditions.
-- Tests are run **separately within each ROI**.
-- Multiple-comparison control:
-  - p-values are corrected using the **Benjamini–Hochberg false discovery
-    rate (FDR)** procedure.
-  - Exports include:
-    - raw p-values;
-    - FDR-adjusted p-values (`p_fdr_bh`);
-    - effect sizes (e.g., Cohen’s d).
+- **F statistic:** ratio of variance explained by the effect to residual
+  variance (larger F → stronger evidence for an effect).
+- **df1/df2:** numerator/denominator degrees of freedom for the effect.
+- **GG/HF corrections:** appear when Pingouin can compute sphericity
+  corrections.
+
+For more details, see: **[RM-ANOVA details](statistics/rm-anova.md)**.
+
+### Post-hoc tests (interaction breakdown)
+
+- **Paired t-tests** between **all condition pairs**, run **separately
+  within each ROI**.
+- **Correction:** Benjamini–Hochberg FDR **within each ROI** (i.e., each
+  ROI’s condition-pair family is corrected independently).
+- **Effect size:** **Cohen’s dz** for paired samples, based on the
+  subject-wise condition differences.
+
+For more details, see: **[Post-hoc tests](statistics/posthoc-tests.md)**.
 
 ### Linear mixed-effects model (single group)
 
-- A **linear mixed-effects model** is fit to Summed BCA with:
-  - fixed effects: **condition**, **ROI**, and **condition × ROI**
-    interaction;
-  - random effects: **random intercept for each subject**.
-- No additional multiple-comparison correction is applied to individual
-  coefficients in this model; interpretation focuses on the pattern and
-  significance of fixed-effect terms.
+- **Library:** statsmodels `MixedLM`.
+- **Fixed effects:** condition, ROI, and condition × ROI interaction.
+- **Random effects:** **random intercept for subject**.
+- **Coding:** condition and ROI are **sum-coded** by default when present
+  (no explicit coding is set for other factors).
+
+For more details, see: **[Mixed model details](statistics/mixed-model.md)**.
 
 ---
 
 ## Multi-group analyses
 
-Multi-group mode (often referred to as “Lela mode”) compares two or more
-groups (e.g., different hormonal status, clinical vs control).
+Multi-group mode compares two or more groups (e.g., clinical vs control).
 
 ### Between-group ANOVA (mixed ANOVA)
 
-- Factors:
-  - **Group** (between-subjects)
-  - **Condition** (within-subjects)
-- Dependent variable:
-  - Summed BCA, typically **collapsed across ROI** for this test.
-- Implementation:
-  - When available, the toolbox uses **Pingouin’s** `mixed_anova`.
-- Key effects:
-  - main effect of group;
-  - main effect of condition;
-  - group × condition interaction.
+- **Factors:** Group (between-subjects) × Condition (within-subjects).
+- **DV:** Summed BCA, typically **collapsed across ROI** for this test.
+- **Implementation:** Pingouin `mixed_anova` is required; the fallback
+  does not support a between-group factor.
 
 ### Between-group mixed model
 
-- A **linear mixed-effects model** is fit to Summed BCA with:
-  - fixed effects: **group**, **condition**, **ROI**, and their
-    interactions;
-  - random effects: **random intercept per subject**.
-- This model allows testing whether the pattern of responses across
-  conditions and ROIs differs by group while accounting for repeated
-  measures within subjects.
+- **Fixed effects:** group, condition, ROI, and all interactions.
+- **Random effects:** random intercept for subject.
 
 ### Group contrasts
 
-- Pairwise **group comparisons** are computed separately for each
-  condition × ROI combination.
-- Implementation:
-  - **Welch’s t-tests** (unequal variances) between groups.
-- Multiple-comparison control:
-  - p-values are corrected with **Benjamini–Hochberg FDR**.
-  - Exports include:
-    - raw p-values;
-    - FDR-adjusted p-values;
-    - effect sizes (e.g., Cohen’s d).
+- **Welch’s t-tests** (unequal variances) for each
+  **condition × ROI** combination.
+- **Correction:** Benjamini–Hochberg FDR across all contrasts in the
+  output table.
+- **Effect size:** Cohen’s d for independent groups.
 
 ---
 
-## Output files and interpretation
+## Outliers, QC flags, and manual exclusions
 
-- All model results are written to Excel in the project’s  
-  **`3 - Statistical Analysis Results`** folder.
-- Typical exports include:
-  - ANOVA tables (F, df, p, corrected p when applicable);
-  - mixed-model summaries (fixed-effect estimates, standard errors,
-    t-values, p-values);
-  - post-hoc and group-contrast tables with raw and FDR-adjusted p-values
-    and effect sizes.
-
-Consult these Excel tables when reporting results in manuscripts or
-presentations.
+The Stats tool can generate **QC and DV flags** and separate them from
+**manual exclusions**. See
+**[Outliers and QC](statistics/outliers-and-qc.md)** for details.
 
 ---
 
-## General notes
+## Output files
 
-- Unless otherwise noted, the **default alpha level is 0.05**.
-- FDR correction reduces the chance of false positives when running many
-  post-hoc tests but does not guarantee that all significant findings
-  will replicate.
-- Users remain responsible for:
-  - checking model assumptions (normality, sphericity, etc.);
-  - choosing effect sizes and contrasts that match their hypotheses;
-  - transparently reporting all relevant results in line with field
-    standards.
+- Results are written to the project’s **“3 - Statistical Analysis
+  Results”** folder.
+- Common exports include:
+  - RM-ANOVA tables.
+  - Mixed-model fixed-effects tables.
+  - Post-hoc tables with raw and FDR-adjusted p-values plus effect sizes.
+  - Rossion DV definition export (when using Rossion selection).
+  - Flagged and excluded participant reports (if QC/outlier checks are
+    enabled).
+
+---
+
+## Not found in code (documentation transparency)
+
+The following details were **not found in code** while preparing this
+page:
+
+- An explicit one-sample test against zero as part of the RM-ANOVA
+  pipeline. (Searched in `src/Tools/Stats/PySide6/stats_workers.py`,
+  `src/Tools/Stats/Legacy/stats_analysis.py`, and
+  `src/Tools/Stats/Legacy/repeated_m_anova.py`.)

--- a/docs/statistics/mixed-model.md
+++ b/docs/statistics/mixed-model.md
@@ -1,0 +1,58 @@
+# Linear mixed-effects model (Summed BCA)
+
+The FPVS Toolbox provides a linear mixed-effects model (LMM) for Summed
+BCA, allowing you to model repeated measures within subjects while
+estimating condition/ROI effects.
+
+---
+
+## Implementation
+
+- **Library:** statsmodels `MixedLM`.
+- **Random effects:** random intercept for each subject (default).
+- **Fixed effects (single group):** condition, ROI, and their interaction.
+- **Fixed effects (multi-group):** group, condition, ROI, and all
+  interactions.
+
+---
+
+## Coding of categorical variables
+
+- **Condition and ROI** are **sum-coded** by default when present.
+- **Group coding:** Not found in code. The model does not explicitly set
+  group contrasts, so statsmodels’ default coding likely applies.
+
+---
+
+## How to interpret coefficients
+
+- **Intercept:** average Summed BCA across all conditions/ROIs (and
+  groups, if using sum coding). A positive intercept suggests an overall
+  response above zero.
+- **Condition terms:** how each condition deviates from the overall mean
+  (under sum coding).
+- **ROI terms:** how each ROI deviates from the overall mean.
+- **Interaction terms:** whether condition effects differ by ROI (or by
+  group in multi-group mode).
+
+---
+
+## Relationship to RM-ANOVA
+
+- **RM-ANOVA** is the traditional repeated-measures approach (balanced
+  designs, sphericity corrections).
+- **Mixed model** provides a flexible alternative that can handle some
+  missing data (after exclusions) and gives coefficient-level estimates.
+
+---
+
+## Not found in code (documentation transparency)
+
+The following details were **not found in code** while preparing this
+page:
+
+- A user-facing toggle to enable random slopes or likelihood-ratio tests
+  (the helper supports these, but the Stats tool calls it with random
+  intercept only and no LRTs). (Searched in
+  `src/Tools/Stats/Legacy/mixed_effects_model.py` and
+  `src/Tools/Stats/PySide6/stats_workers.py`.)

--- a/docs/statistics/outliers-and-qc.md
+++ b/docs/statistics/outliers-and-qc.md
@@ -1,0 +1,67 @@
+# Outliers, QC flags, and manual exclusions
+
+The Statistical Analysis module separates **flags** (informational) from
+**exclusions** (participants actually removed from analysis). This lets
+you review QC warnings before deciding whether to exclude anyone.
+
+---
+
+## What is flagged vs. excluded
+
+### QC flags (informational)
+
+- QC screening examines all **conditions and ROIs in the project**, even
+  if you later select a subset for analysis.
+- QC uses robust thresholds on **sum(|BCA|)** and **max(|BCA|)** metrics
+  (across oddball harmonics) to flag unusually large responses.
+- QC flags **do not automatically remove participants**. They appear in
+  the *Flagged Participants* report so you can review them.
+
+### DV hard-limit flags (informational)
+
+- A **hard DV limit** (absolute value) flags participants whose Summed
+  BCA values exceed the limit.
+- These are also **flags only** unless the value is non-finite.
+
+### Required exclusions (automatic)
+
+- Participants with **non-finite Summed BCA values** are **required
+  exclusions** and are removed from analyses.
+
+### Manual exclusions (user-controlled)
+
+- You can manually select participants to exclude. This is the only
+  user-controlled exclusion step.
+- Manual exclusions are applied before analyses run.
+
+---
+
+## Where to find the reports
+
+Exports live in **“3 - Statistical Analysis Results”** and include:
+
+- **Flagged Participants.xlsx**
+  - *Flag Summary* and *Flag Details* tabs for QC and DV flags.
+- **Excluded Participants.xlsx**
+  - Records manual exclusions and required non-finite exclusions.
+
+---
+
+## Interpretation tips
+
+- Use **Flagged Participants.xlsx** to document quality concerns and
+  justify any manual exclusions in your reporting.
+- Because QC flags do **not** remove participants automatically, the
+  final sample size depends on **manual exclusions** plus required
+  non-finite exclusions.
+
+---
+
+## Not found in code (documentation transparency)
+
+The following details were **not found in code** while preparing this
+page:
+
+- A setting to automatically exclude QC-flagged participants. (Searched
+  in `src/Tools/Stats/PySide6/stats_workers.py` and
+  `src/Tools/Stats/PySide6/stats_outlier_exclusion.py`.)

--- a/docs/statistics/posthoc-tests.md
+++ b/docs/statistics/posthoc-tests.md
@@ -1,0 +1,52 @@
+# Post-hoc tests (interaction breakdown)
+
+Post-hoc tests are run **after** an interaction is found in RM-ANOVA.
+They explain **which condition pairs** differ **within each ROI**.
+
+---
+
+## What is tested
+
+- **Within each ROI**, the tool runs **paired t-tests** for every pair of
+  conditions.
+- The analysis is **within-subject**, so each test uses subject-wise
+  differences between the two conditions.
+
+---
+
+## Multiple-comparison correction
+
+- **Correction method:** Benjamini–Hochberg FDR (`fdr_bh`).
+- **Correction family:** applied **within each ROI** (all condition-pair
+  tests for that ROI are corrected together).
+
+---
+
+## Effect sizes and outputs
+
+Each pairwise result includes:
+
+- **t statistic** and **p-value** (raw and FDR-adjusted).
+- **Cohen’s dz** (paired-samples effect size), computed as mean difference
+  divided by the standard deviation of paired differences.
+- **Mean difference** (Condition A − Condition B) and 95% CI.
+- **Shapiro p-value** for paired differences (informational only).
+
+Interpretation tips:
+
+- **Direction:** a positive mean difference means Condition A > Condition
+  B for Summed BCA.
+- **Effect size (dz):** larger absolute values indicate stronger
+  condition differences within the ROI.
+
+---
+
+## Not found in code (documentation transparency)
+
+The following details were **not found in code** while preparing this
+page:
+
+- A user-facing setting to change the post-hoc correction method from
+  Benjamini–Hochberg FDR to another option. (Searched in
+  `src/Tools/Stats/Legacy/posthoc_tests.py` and
+  `src/Tools/Stats/PySide6/stats_workers.py`.)

--- a/docs/statistics/rm-anova.md
+++ b/docs/statistics/rm-anova.md
@@ -1,0 +1,57 @@
+# RM-ANOVA details (Summed BCA)
+
+The FPVS Toolbox uses repeated-measures ANOVA (RM-ANOVA) to test
+within-subject effects of **Condition**, **ROI**, and their interaction on
+Summed BCA.
+
+---
+
+## Implementation
+
+- **Primary library:** Pingouin `rm_anova` (when installed).
+- **Fallback library:** statsmodels `AnovaRM` (when Pingouin is not
+  available).
+
+The output is normalized into a consistent table that includes:
+
+- **Effect** (Condition, ROI, Condition × ROI)
+- **F Value** (F statistic)
+- **Num DF / Den DF** (degrees of freedom)
+- **Pr > F** (p-value)
+- **partial eta squared** (effect size)
+- **Pr > F (GG)** and **Pr > F (HF)** when Pingouin provides sphericity
+  corrections
+
+---
+
+## How to read the table
+
+- **F statistic:** ratio of explained variance to residual variance. A
+  larger F indicates stronger evidence for an effect.
+- **Num DF / Den DF:** degrees of freedom for the effect and error.
+- **p-values:** use the GG/HF corrected columns when available (they
+  adjust for sphericity violations).
+- **partial eta squared:** effect size, computed from F and dfs when not
+  provided by the library.
+
+---
+
+## Notes for end users
+
+- RM-ANOVA requires a **balanced design** (each subject must have all
+  required condition × ROI combinations). If the data are unbalanced, the
+  analysis reports an error and lists missing combinations.
+- RM-ANOVA focuses on **differences among conditions and ROIs**; it does
+  not directly test whether Summed BCA is different from zero.
+
+---
+
+## Not found in code (documentation transparency)
+
+The following details were **not found in code** while preparing this
+page:
+
+- A user-facing setting that toggles sphericity correction methods
+  (Pingouin decides this internally). (Searched in
+  `src/Tools/Stats/Legacy/repeated_m_anova.py` and
+  `src/Tools/Stats/PySide6/stats_main_window.py`.)

--- a/docs/statistics/rossion-harmonic-selection.md
+++ b/docs/statistics/rossion-harmonic-selection.md
@@ -1,0 +1,139 @@
+# Rossion harmonic selection (Summed BCA)
+
+This page explains the **Rossion method** used to define which oddball
+harmonics contribute to the Summed BCA DV. The method is **ROI-specific**
+and is based on **group mean Z-scores** computed from the Z-score sheet in
+your spectral output files.
+
+---
+
+## What the method produces
+
+For each ROI, the Rossion method produces a list of oddball harmonics
+(Hz). That list is then used to compute Summed BCA for **every subject
+and every condition** in that ROI.
+
+- **Per ROI:** each ROI gets its own selected harmonic set.
+- **Per subject × condition × ROI:** Summed BCA is the sum of BCA values
+  over those selected harmonics, averaged across channels in the ROI.
+
+---
+
+## Inputs and data sources
+
+The Rossion method uses the same per-subject, per-condition Excel output
+files that store ROI-aggregated spectral data.
+
+- **Z-score source:** the **“Z Score”** sheet is used to compute group mean
+  Z-values for each ROI and harmonic.
+- **BCA source:** the **“BCA (uV)”** sheet provides the BCA amplitudes to
+  be summed once harmonics are selected.
+- **Column format:** frequency bins are read from columns that end in
+  `_Hz` (e.g., `1.2_Hz`).
+
+---
+
+## Step 1: Build the candidate harmonic domain
+
+The tool builds the candidate harmonic list using the following steps:
+
+1. **Read frequency columns** from the Z-score sheet (columns ending in
+   `_Hz`).
+2. **Exclude base-rate harmonics:** any column that is an exact multiple
+   of the base frequency is removed (tolerance 1e-6).
+3. **Select oddball harmonics:** oddball harmonics are defined as
+   multiples of (base frequency / every_n), with the default
+   `every_n = 5` and tolerance 1e-3.
+4. **Optional exclusion of harmonic 1:** if “Exclude harmonic 1” is
+   enabled, harmonic number 1 is removed from the list.
+
+Result: an ordered list of oddball harmonic frequencies (Hz) that are
+candidates for the Rossion selection rule.
+
+---
+
+## Step 2: Compute group mean Z per ROI and harmonic
+
+For each subject, condition, ROI, and harmonic in the domain:
+
+- The tool **averages Z values across the ROI’s channels** (using the
+  channels that are present in the Z-score sheet).
+- These ROI-mean Z values are **pooled across all selected conditions and
+  all subjects**, then averaged to yield a **group mean Z** for each
+  ROI × harmonic.
+
+This produces a table with columns like:
+
+- `roi`
+- `harmonic_hz`
+- `mean_z` (group mean Z across selected conditions and subjects)
+
+---
+
+## Step 3: Rossion selection rule (per ROI)
+
+For each ROI, harmonics are scanned in ascending order:
+
+- **Threshold:** a harmonic is **significant** if group mean Z exceeds the
+  current **Z threshold** (default 1.64). The threshold is set in the
+  Statistical Analysis settings.
+- **Arm after first significant:** non-significant harmonics are ignored
+  until the first significant harmonic is found.
+- **Stop rule:** after the first significant harmonic is found, the
+  algorithm **stops after 2 consecutive non-significant harmonics**.
+
+The selected harmonics are the significant harmonics **before the stop
+rule triggers**.
+
+---
+
+## Step 4: Compute Summed BCA (the DV)
+
+For each subject × condition × ROI:
+
+1. **Read BCA (uV)** values at the selected harmonics for that ROI.
+2. **Sum BCA across selected harmonics** for each channel in the ROI.
+3. **Average across ROI channels** to yield the Summed BCA value.
+
+This produces the DV table used by RM-ANOVA, mixed models, and post-hoc
+comparisons.
+
+---
+
+## Fallback behavior when no harmonics are selected
+
+If the Rossion method selects **no harmonics** for a given ROI, the
+behavior depends on the **Empty list policy** setting:
+
+- **Fallback to Fixed-K (default):** use the Fixed-K selection (default
+  K = 5) instead of the empty list.
+- **Set DV = 0:** keep the harmonic list empty and set Summed BCA to 0
+  for that ROI.
+- **Error:** stop and report an error so you can adjust settings.
+
+The Fixed-K harmonics are also built from oddball harmonics (every_n = 5)
+and can optionally exclude harmonic 1 and base-rate harmonics.
+
+---
+
+## Outputs you can review
+
+When you export results after running the Rossion method, the tool writes
+**Summed BCA DV Definition.xlsx** with:
+
+- **DV Definition** (summary of the policy and thresholds),
+- **ROI Harmonics** (selected harmonics per ROI, fallback use, stop
+  reason),
+- **Mean Z Table** (group mean Z values used for selection).
+
+---
+
+## Not found in code (documentation transparency)
+
+The following details were **not found in code** while preparing this
+page:
+
+- A user-facing description of how Z thresholds are labeled in the UI
+  beyond “minimum group-mean Z value for a harmonic to count as
+  significant.” (Searched in `src/Tools/Stats/PySide6/stats_main_window.py`
+  and `src/Tools/Stats/PySide6/dv_policies.py`.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,12 @@ theme:
 nav:
   - Home: index.md
   - Processing Pipeline: processing-pipeline.md
-  - Statistical Analysis: statistical-analysis.md
+  - Statistical Analysis:
+      - Overview: statistical-analysis.md
+      - Rossion harmonic selection: statistics/rossion-harmonic-selection.md
+      - RM-ANOVA: statistics/rm-anova.md
+      - Post-hoc tests: statistics/posthoc-tests.md
+      - Mixed model: statistics/mixed-model.md
+      - Outliers and QC: statistics/outliers-and-qc.md
   - Relevant Publications: relevant-publications.md
   - Tutorials: tutorials.md


### PR DESCRIPTION
### Motivation

- Improve and expand end-user documentation for the Statistical Analysis module, clarifying the primary DV (Summed BCA), the Rossion harmonic-selection workflow, and how downstream tests relate to the DV. 
- Provide concise, user-facing explanations for RM-ANOVA, post-hoc comparisons, mixed models, and QC/outlier handling so non-developers can interpret outputs and exports.

### Description

- Revised the main overview `docs/statistical-analysis.md` to include a “How the methods work together” summary, an explicit Summed BCA DV definition, interpretation guidance, and links to detailed pages.
- Added a detailed Rossion harmonic selection page at `docs/statistics/rossion-harmonic-selection.md` that documents the candidate harmonic domain, group-mean Z gating, per-ROI selection rules, and fallback policies (Fixed-K / set-zero / error) with explicit references to the Z and BCA sheets (`"Z Score"`, `"BCA (uV)`).
- Added focused supporting pages: `docs/statistics/rm-anova.md`, `docs/statistics/posthoc-tests.md`, `docs/statistics/mixed-model.md`, and `docs/statistics/outliers-and-qc.md` summarizing implementation choices (libraries used), outputs, interpretation, and details that were not found in code.
- Updated `mkdocs.yml` navigation to expose the new pages under a “Statistical Analysis” section.
- Key code sources reviewed to confirm behavior (read-only): `src/Tools/Stats/PySide6/dv_policies.py`, `src/Tools/Stats/PySide6/group_harmonics.py`, `src/Tools/Stats/Legacy/stats_analysis.py`, `src/Tools/Stats/Legacy/repeated_m_anova.py`, `src/Tools/Stats/Legacy/posthoc_tests.py`, `src/Tools/Stats/Legacy/mixed_effects_model.py`, and `src/Tools/Stats/PySide6/stats_main_window.py` (documentation states where specifics were confirmed and where items were “Not found in code”).

### Testing

- Verified repository changes and staged/committed docs; updated MkDocs nav and confirmed the new `statistics/*.md` files exist in `docs/statistics/` and are referenced by `mkdocs.yml`.
- Attempted `mkdocs build` to validate site build, but it failed in this environment because `mkdocs` is not installed (error: `bash: command not found: mkdocs`).
- No unit tests or linters were required for these documentation-only edits; no `src/**` files were changed and black-box directories were not edited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c22ebae8832c9970859ff615d7be)