### PR TITLE
Force manual update checks to bypass debounce

### DIFF
--- a/src/Main_App/PySide6_App/GUI/main_window.py
+++ b/src/Main_App/PySide6_App/GUI/main_window.py
@@ -1355,7 +1355,7 @@ class MainWindow(QMainWindow, FileSelectionMixin, ProcessingMixin):
 
     def check_for_updates(self) -> None:
         update_manager.check_for_updates_async(
-            self, silent=False, notify_if_no_update=True
+            self, silent=False, notify_if_no_update=True, force=True
         )
 
     def quit(self) -> None:

--- a/src/Main_App/PySide6_App/GUI/update_manager.py
+++ b/src/Main_App/PySide6_App/GUI/update_manager.py
@@ -40,9 +40,10 @@ def check_for_updates_async(
     app: QWidget,
     silent: bool = True,
     notify_if_no_update: bool = True,
+    force: bool = False,
 ) -> None:
     """Menu action: check in background. Popups only if silent=False."""
-    if _should_skip_update_check():
+    if not force and _should_skip_update_check():
         _log(app, "Skipping update check (checked recently).")
         return
     job = _CheckJob()

--- a/tests/test_update_manager_manual_force.py
+++ b/tests/test_update_manager_manual_force.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QThreadPool
+from PySide6.QtWidgets import QApplication, QMessageBox, QWidget
+
+from config import FPVS_TOOLBOX_VERSION
+from Main_App.PySide6_App.GUI import update_manager
+
+
+def test_manual_force_bypasses_debounce(monkeypatch, qtbot) -> None:
+    QApplication.instance() or QApplication([])
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    monkeypatch.setattr(update_manager, "_should_skip_update_check", lambda: True)
+
+    class DummyResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {
+                "tag_name": f"v{FPVS_TOOLBOX_VERSION}",
+                "html_url": "https://example.test/release",
+            }
+
+    monkeypatch.setattr(update_manager.requests, "get", lambda *_args, **_kwargs: DummyResponse())
+
+    captured: dict[str, str] = {}
+
+    def fake_information(_parent, title: str, text: str) -> int:
+        captured["title"] = title
+        captured["text"] = text
+        return QMessageBox.Ok
+
+    monkeypatch.setattr(update_manager.QMessageBox, "information", fake_information)
+
+    class DummyPool:
+        def start(self, job) -> None:  # noqa: ANN001
+            job.run()
+
+    monkeypatch.setattr(QThreadPool, "globalInstance", lambda: DummyPool())
+
+    update_manager.check_for_updates_async(
+        parent,
+        silent=False,
+        notify_if_no_update=True,
+        force=True,
+    )
+
+    qtbot.waitUntil(lambda: "title" in captured, timeout=1000)
+    assert captured["title"] == "Up to Date"
+    assert f"v{FPVS_TOOLBOX_VERSION}" in captured["text"]


### PR DESCRIPTION
### Motivation
- Manual "Check for Updates…" could return early due to the 24h debounce and appear to do nothing, so the manual action must always provide immediate user-visible feedback while leaving startup checks unchanged.  
- Preserve existing behavior for startup checks and avoid touching processing pipeline or black-box modules.  

### Description
- Added a `force: bool = False` parameter to `check_for_updates_async()` and only apply the debounce when `force is False`.  
- Changed the manual call site so the menu action always forces a real check by calling `check_for_updates_async(..., force=True)` from `MainWindow.check_for_updates()`.  
- Added a pytest-qt smoke test `tests/test_update_manager_manual_force.py` that simulates a debounced state and asserts the "Up to Date" dialog is shown when the manual check is forced.  
- Files changed: `src/Main_App/PySide6_App/GUI/update_manager.py`, `src/Main_App/PySide6_App/GUI/main_window.py`, `tests/test_update_manager_manual_force.py`.

### Testing
- Ran the test suite with `python -m pytest -q`; RESULT: FAIL due to collection errors (53 errors) caused by missing optional runtime dependencies and PySide6-related import stubs in this environment, so the new test was not executed.  
- Ran `ruff check .`; RESULT: FAIL with 73 lint violations reported (mostly existing style issues outside the changed files).  
- Ran `mypy src --strict`; RESULT: FAIL due to an existing syntax error in `src/Compiler_Script.py` which prevented type checking from completing.  

Run commands to reproduce locally/CI:  
- `python -m pytest -q`  
- `ruff check .`  
- `mypy src --strict`  

Note: the change is minimal and safe: the default API behavior is preserved (`force=False`), the manual menu now passes `force=True`, the `_CheckJob` remains a `QRunnable` performing network I/O and emitting signals only, and UI updates continue to be scheduled via `QTimer.singleShot` to run on the GUI thread. The added pytest-qt smoke test is designed to pass in an environment with `PySide6`, `pytest-qt`, and the optional numeric/IO dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795e12bbb8832cad58564b31d97b31)