### PR TITLE
Add PNG exports alongside SVG for SNR plots

### DIFF
--- a/tests/test_plot_generator_export_svg_smoke.py
+++ b/tests/test_plot_generator_export_svg_smoke.py
@@ -46,5 +46,10 @@ def test_snr_export_svg_smoke(qtbot, tmp_path, monkeypatch):
 
     worker._run()
 
-    assert list(out_dir.rglob("*.svg"))
-    assert not list(out_dir.rglob("*.png"))
+    svg_files = list(out_dir.rglob("*.svg"))
+    assert svg_files
+    png_files = list(out_dir.rglob("*.png"))
+    assert png_files
+    svg_stems = {path.with_suffix("").name for path in svg_files}
+    png_stems = {path.with_suffix("").name for path in png_files}
+    assert svg_stems == png_stems


### PR DESCRIPTION
### Motivation
- Provide quick-view raster images for every SNR plot already exported as SVG without changing existing SVG outputs or UI flows.
- Keep export behavior SVG-first and non-blocking while reporting non-fatal PNG failures with structured logs.

### Description
- Extended `_save_figure` in `src/Tools/Plot_Generator/worker.py` to, immediately after a successful SVG save, derive a same-folder PNG path by swapping the suffix and save the same `fig` to that PNG using `format='png'` and the existing `save_kwargs` (reusing `dpi` if present). 
- PNG export is gated to run only when `out_path.suffix.lower() == '.svg'`, emits progress via `_emit`, and logs structured errors (operation `snr_plot_export_png`) without treating PNG failure as a fatal export error. 
- Updated smoke test `tests/test_plot_generator_export_svg_smoke.py` to assert that at least one `.svg` exists and that a matching `.png` exists for each SVG (matching base filenames). 
- No SVG save calls, kwargs, filenames, directory logic, UI controls, black-box files, or computation/orderings were changed.

### Testing
- Updated unit test `tests/test_plot_generator_export_svg_smoke.py` to assert matching `.svg`/`.png` pairs; test file changes are committed. 
- Attempted to run the project Windows-oriented verification commands but could not execute them in this environment because the repo expects Windows venv paths; the attempted commands and outcomes were: ` .venv\Scripts\python -m pytest -q` (not run here: `.venv` not available in bash), ` .venv\Scripts\ruff check .` (not run here), and ` .venv\Scripts\mypy src --strict` (not run here). 
- Manual inspection and automated grep/smoke-test update confirm the PNG write code path is directly after the existing `fig.savefig(out_path, **save_kwargs)` call and that logging/emits follow the existing patterns; CI/Windows should run the updated test and linters successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988df254950832cb264d6369e109164)