### PR TITLE
Make Flagged Participants Report summary-only, compact rows, and add copy-details

### DIFF
--- a/src/Tools/Stats/PySide6/stats_outlier_exclusion.py
+++ b/src/Tools/Stats/PySide6/stats_outlier_exclusion.py
@@ -268,6 +268,21 @@ def format_flag_types_display(flag_types: Iterable[str]) -> str:
     return ", ".join(labels)
 
 
+def build_flagged_participant_summary(
+    *,
+    severity: str,
+    flag_type: str | None,
+    worst_text: str,
+    n_flags: int,
+) -> str:
+    safe_severity = str(severity).strip() or "FLAG"
+    friendly_flag = format_flag_type_display(flag_type) if flag_type else "Unknown flag"
+    summary = f"{safe_severity}: {friendly_flag}. Worst: {worst_text}"
+    if n_flags > 1:
+        summary += f". +{n_flags - 1} more flags"
+    return summary.replace("\n", " ")
+
+
 def format_worst_value_display(
     flag_type: str | None,
     value: float,


### PR DESCRIPTION
### Motivation
- Improve readability of the Flagged Participants Report by showing a single-line summary per participant in the main table while preserving multi-line full details in the Details panel and tooltips.
- Prevent tall, wrap-driven row expansion so the dialog remains compact and scrollable for large result sets.
- Ensure copy operations reflect the visible table content and provide an explicit way to copy full multi-line details for a selected participant.

### Description
- Added `build_flagged_participant_summary` helper to `src/Tools/Stats/PySide6/stats_outlier_exclusion.py` to produce a single-line, newline-free summary such as `"{severity}: {friendly_flag_type}. Worst: {formatted_worst_value}. +{n_more} more flags"`.
- Updated `src/Tools/Stats/PySide6/stats_main_window.py` to use the new summary text in the table Explanation column, set `table.setWordWrap(False)`, `table.setTextElideMode(Qt.ElideRight)`, `table.verticalHeader().setSectionResizeMode(QHeaderView.Fixed)` and `table.verticalHeader().setDefaultSectionSize(...)`, and `table.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)` to enforce compact rows and proper scrolling behavior.
- Kept the full multi-line details in the existing Details panel and set those full details as tooltips on the Explanation cell when available.
- Adjusted the Copy behavior so `Copy table` exports the summary text visible in the table and added a `Copy details` button that copies the full multi-line details for the currently selected participant.
- Added tests in `tests/test_stats_flagged_participants_report.py` covering a 3-row fake dataset (P12, P17, P22) and a unit test for the summary helper to assert single-line output and "+N more flags" behavior.

### Testing
- Ran `pytest -q`; collection failed with repository-wide import errors (missing runtime deps such as `numpy`, `pandas`, and `PySide6` and other environment-specific collection issues), so the test run did not complete successfully and the new tests were not executed to completion.
- Ran `ruff check .`; this produced lint failures from pre-existing files across the repo (not introduced by these changes), so repo lint status remains failing independent of this change.
- Ran `mypy src --strict`; this aborted due to an unrelated syntax error in `src/Compiler_Script.py`, so strict type-checking did not complete.
- The UI changes are limited to `src/Tools/Stats/PySide6/*` and do not modify `src/Main_App/Legacy_App/**` or `src/Tools/SourceLocalization/**`, and no statistical detection or threshold logic was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989117992e4832c9c7e90560900b989)