### PR TITLE
Make ratio plots thread-safe and add diagnostic logging

### DIFF
--- a/src/Tools/Ratio_Calculator/pipeline.py
+++ b/src/Tools/Ratio_Calculator/pipeline.py
@@ -205,6 +205,7 @@ def run_ratio_calculator(
         settings.png_dpi,
         condition_label_a,
         condition_label_b,
+        log_func=_log,
     )
 
     df_group_sums_plot = df_group_sums_used.rename(columns={"mean_sum_SNR": "mean", "sem_sum_SNR": "sem"}).copy()
@@ -221,6 +222,7 @@ def run_ratio_calculator(
         settings.png_dpi,
         condition_label_a,
         condition_label_b,
+        log_func=_log,
     )
 
     df_group_sums_plot = df_group_sums_used.rename(columns={"mean_sum_BCA_uV": "mean", "sem_sum_BCA_uV": "sem"}).copy()
@@ -241,6 +243,7 @@ def run_ratio_calculator(
         settings.png_dpi,
         condition_label_a,
         condition_label_b,
+        log_func=_log,
     )
 
     ratio_label = f"{condition_label_a} / {condition_label_b}"
@@ -266,6 +269,7 @@ def run_ratio_calculator(
         run_label,
         settings.png_dpi,
         xlabel="ROI",
+        log_func=_log,
     )
 
     make_raincloud_figure_roi_x(
@@ -286,6 +290,7 @@ def run_ratio_calculator(
         run_label,
         settings.png_dpi,
         xlabel="ROI",
+        log_func=_log,
     )
 
     make_raincloud_figure_roi_x(
@@ -306,6 +311,7 @@ def run_ratio_calculator(
         run_label,
         settings.png_dpi,
         xlabel="ROI",
+        log_func=_log,
     )
 
     out_xlsx = out_dir / f"Metrics_{run_label}.xlsx"

--- a/tests/test_ratio_calculator_plots.py
+++ b/tests/test_ratio_calculator_plots.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from Tools.Ratio_Calculator.constants import ROI_DEFS_DEFAULT
+from Tools.Ratio_Calculator.plots import PlotPanel, make_raincloud_figure_roi_x
+
+
+def _build_ratio_frames() -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(202401)
+    rois = list(ROI_DEFS_DEFAULT.keys())
+    included_pids = [f"P{i:03d}" for i in range(1, 11)]
+    excluded_pids = [f"P{i:03d}" for i in range(11, 13)]
+
+    rows: list[dict[str, object]] = []
+    for roi in rois:
+        for pid in included_pids:
+            rows.append(
+                {
+                    "participant_id": pid,
+                    "ROI": roi,
+                    "val": float(rng.normal(loc=1.1, scale=0.15)),
+                    "is_manual_excluded": False,
+                }
+            )
+        for pid in excluded_pids:
+            rows.append(
+                {
+                    "participant_id": pid,
+                    "ROI": roi,
+                    "val": float(rng.normal(loc=0.9, scale=0.2)),
+                    "is_manual_excluded": True,
+                }
+            )
+
+    df_part_all = pd.DataFrame(rows)
+    df_group_used = (
+        df_part_all[~df_part_all["is_manual_excluded"]]
+        .groupby("ROI", as_index=False)["val"]
+        .agg(mean="mean", sem=lambda x: float(np.std(x, ddof=1) / np.sqrt(len(x))))
+    )
+    return df_part_all, df_group_used
+
+
+def test_ratio_plot_saves_png(tmp_path: Path) -> None:
+    df_part_all, df_group_used = _build_ratio_frames()
+    out_base = tmp_path / "ratio_plot"
+    make_raincloud_figure_roi_x(
+        df_part_all,
+        df_group_used,
+        PlotPanel(val_col="val", mean_col="mean", sem_col="sem", ylabel="Ratio", hline_y=1.0, ylim=None),
+        out_base,
+        ROI_DEFS_DEFAULT,
+        palette_choice="vibrant",
+        run_label="unit-test",
+        png_dpi=72,
+        xlabel="ROI",
+    )
+
+    assert out_base.with_suffix(".png").exists()
+    assert out_base.with_suffix(".pdf").exists()


### PR DESCRIPTION
### Motivation
- Prevent Matplotlib GUI-backend warnings when plotting from worker threads and ensure plots are generated reliably in headless contexts.
- Fix a bug where included-participant overlays (violin/box/scatter/mean+SEM) were missing and only excluded markers appeared by normalizing the exclusion column.
- Provide minimal diagnostic logging to help detect cases where all participants end up marked excluded.

### Description
- Switched the Ratio Calculator plotting module to a non-interactive backend by calling `matplotlib.use("Agg")` and replaced `pyplot` usage with the figure-only API using `Figure` and `FigureCanvas` in `src/Tools/Ratio_Calculator/plots.py` to avoid GUI startup in worker threads.
- Replaced `plt.Line2D`/`plt.get_cmap`/`plt.subplots`/`plt.subplots_adjust`/`plt.savefig` usage with `Line2D`/`cm.get_cmap`/`Figure` + `FigureCanvas`/`fig.subplots_adjust`/`fig.savefig` respectively, and removed reliance on `plt.close` for Agg figures.
- Normalized the manual exclusion flag at the start of plotting functions with `fillna(False).astype(bool)` to prevent all points being treated as excluded and added an optional `log_func` parameter to `make_raincloud_figure` and `make_raincloud_figure_roi_x` to emit per-ROI counts and a warning when included counts are zero.
- Wired the pipeline plotting calls in `src/Tools/Ratio_Calculator/pipeline.py` to pass the existing pipeline logger (`_log`) into the plotting functions, and added a small regression test `tests/test_ratio_calculator_plots.py` that generates synthetic data and verifies PNG/PDF output files are produced.
- No changes to metrics or output filenames; only plotting/backend safety and diagnostics were modified.

### Testing
- Ran linter: `python -m ruff check src/Tools/Ratio_Calculator/plots.py tests/test_ratio_calculator_plots.py` and it passed.
- Attempted to run the new test with `python -m pytest tests/test_ratio_calculator_plots.py` but collection failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'numpy'`), so the test could not execute here; the test is included and should pass in a normal dev environment with `numpy`/`pandas`/`matplotlib` installed.
- Manual inspection of the changes confirms plotting is now backend-agnostic and the code logs included/excluded counts per ROI to the provided logger when present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893f206074832cad898a4905a03ae2)