### PR TITLE
Fix manual exclusions default and add guardrails in Ratio Calculator

### DIFF
--- a/src/Tools/Ratio_Calculator/pipeline.py
+++ b/src/Tools/Ratio_Calculator/pipeline.py
@@ -107,13 +107,16 @@ def run_ratio_calculator(
         raise RuntimeError("No paired participants found between the two folders.")
 
     manual_set = set(manual_list)
+    paired_set = set(pids_paired)
+    assert manual_set.issubset(paired_set)
     manual_in_paired = _sorted_pids([p for p in pids_paired if p in manual_set])
-    manual_not_found = _sorted_pids([p for p in manual_list if p not in set(pids_paired)])
+    manual_not_found = _sorted_pids([p for p in manual_list if p not in paired_set])
 
     _log("MANUAL EXCLUSION REPORT")
     _log(f"  Manual exclude list: {manual_list}")
     _log(f"  Found among paired:  {manual_in_paired}")
     _log(f"  Not found in paired: {manual_not_found}")
+    _log(f"  Counts: excluded {len(manual_in_paired)} / paired {len(pids_paired)} -> used {len(pids_paired) - len(manual_in_paired)}")
     _log("-" * 110)
 
     part_rows: list[dict[str, object]] = []


### PR DESCRIPTION
### Motivation
- Prevent manual exclusions from implicitly excluding all participants by ensuring the UI defaults to an empty selection and exposing counts so users cannot silently reduce `Used after MANUAL exclusions` to 0.
- Add explicit runtime guardrails and lightweight validation so the tool forces an explicit confirmation when all paired participants are excluded while keeping exclusion behavior local to the Ratio Calculator.

### Description
- GUI: in `src/Tools/Ratio_Calculator/gui.py` connect `exclude_list.itemChanged` to a new `_update_exclusion_status` method, add an `exclusion_status` `QLabel` that shows `Excluded: X / Paired: N → Used: M`, and add a `Clear exclusions` button that clears checks; ensure the exclusion status is updated on participant load and when selection changes.
- GUI: when populating the participant checklist, set each item to `Qt.Unchecked` and wrap additions with `blockSignals(True)`/`blockSignals(False)` so the default selection is empty and the status label updates only after loading.
- GUI: before starting processing compute `manual_set`, `paired_set`, `n_paired`, `n_excl`, and `n_used`, assert `manual_set.issubset(paired_set)` and show a blocking `QMessageBox` titled `All participants excluded` when `n_used == 0` offering `Go Back` (abort cleanly) or `Continue Anyway` (proceed with current behavior).
- Pipeline: in `src/Tools/Ratio_Calculator/pipeline.py` add the same subset assertion and an explicit log line summarizing counts `excluded / paired -> used` so runs include a compact confirmation of exclusion counts at the start of processing.
- Behavior: no changes to computed metrics, plotting logic, or saved outputs; manual exclusions remain local to the Ratio Calculator and the list passed downstream remains the actual manual exclusion list.

### Testing
- Ran linter with `ruff check src` and it passed.
- Ran `pytest`, which attempted to collect and execute tests but failed during collection due to missing environment dependencies (`numpy`, `pandas`, and `PySide6`), causing import errors; failures are environmental and unrelated to the logic changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698940e8c2a4832caff8a8e9bef18d1c)