### PR TITLE
Polish Ratio Calculator UI: fix bolding, participant table, auto-load, and add division icon

### DIFF
--- a/src/Main_App/PySide6_App/GUI/icons.py
+++ b/src/Main_App/PySide6_App/GUI/icons.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon, QPainter, QPalette, QPixmap
+from PySide6.QtWidgets import QApplication
+
+
+@lru_cache(maxsize=4)
+def division_icon(size: int = 16) -> QIcon:
+    pixmap = QPixmap(size, size)
+    pixmap.fill(Qt.transparent)
+
+    painter = QPainter(pixmap)
+    painter.setRenderHint(QPainter.Antialiasing, True)
+    painter.setPen(QApplication.palette().color(QPalette.ButtonText))
+
+    font = QApplication.font()
+    font.setBold(True)
+    font.setPixelSize(max(1, int(size * 0.9)))
+    painter.setFont(font)
+    painter.drawText(pixmap.rect(), Qt.AlignCenter, "÷")
+    painter.end()
+
+    return QIcon(pixmap)

--- a/src/Main_App/PySide6_App/GUI/menu_bar.py
+++ b/src/Main_App/PySide6_App/GUI/menu_bar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from PySide6.QtWidgets import QMenuBar, QMainWindow
 from PySide6.QtGui import QAction
 from Main_App.Legacy_App.eloreta_launcher import open_eloreta_tool
+from Main_App.PySide6_App.GUI.icons import division_icon
 from Tools.Ratio_Calculator.launcher import open_ratio_calculator_tool
 from Tools.Average_Preprocessing.New_PySide6.main_window import AdvancedAveragingWindow  # noqa: F401
 
@@ -28,15 +29,17 @@ def build_menu_bar(parent: QMainWindow) -> QMenuBar:
     # Tools
     tools_menu = menu_bar.addMenu("Tools")
     items = [
-        ("Stats Toolbox",                              parent.open_stats_analyzer),
-        ("Source Localization (eLORETA/sLORETA)",      lambda: open_eloreta_tool(parent)),
-        ("Image Resizer",                              parent.open_image_resizer),
-        ("Generate SNR Plots",                         parent.open_plot_generator),
-        ("Ratio Calculator",                           lambda: open_ratio_calculator_tool(parent)),
-        ("Average Epochs in Pre-Processing Phase",     parent.open_epoch_averaging),
+        ("Stats Toolbox",                              parent.open_stats_analyzer, None),
+        ("Source Localization (eLORETA/sLORETA)",      lambda: open_eloreta_tool(parent), None),
+        ("Image Resizer",                              parent.open_image_resizer, None),
+        ("Generate SNR Plots",                         parent.open_plot_generator, None),
+        ("Ratio Calculator",                           lambda: open_ratio_calculator_tool(parent), division_icon()),
+        ("Average Epochs in Pre-Processing Phase",     parent.open_epoch_averaging, None),
     ]
-    for text, slot in items:
+    for text, slot, icon in items:
         action = QAction(text, parent)
+        if icon:
+            action.setIcon(icon)
         action.triggered.connect(slot)
         tools_menu.addAction(action)
         tools_menu.addSeparator()

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QHBoxLayout,
 )
+from Main_App.PySide6_App.GUI.icons import division_icon
 from Tools.Ratio_Calculator.launcher import open_ratio_calculator_tool
 
 # ---- Tunables -------------------------------------------------------------
@@ -203,7 +204,13 @@ def init_sidebar(self) -> None:
 
     # SNR Plots: theme icon or drawn bar chart (no external files)
     make_button(lay, "btn_graphs", "SNR Plots", chart_icon(), self.open_plot_generator)
-    make_button(lay, "btn_ratio", "Ratio Calculator", "view-statistics", lambda: open_ratio_calculator_tool(self))
+    make_button(
+        lay,
+        "btn_ratio",
+        "Ratio Calculator",
+        division_icon(ICON_PX),
+        lambda: open_ratio_calculator_tool(self),
+    )
 
     make_button(lay, "btn_image", "Image Resizer", "camera-photo", self.open_image_resizer)
     make_button(lay, "btn_epoch", "Epoch Averaging", "view-refresh", self.open_epoch_averaging)


### PR DESCRIPTION
### Motivation
- Remove unintended bold styling inherited by inputs/logs while keeping bold for section titles, left-field captions, and buttons.
- Fix the Participant Exclusions widget so the checkbox column contains only checkboxes and the “Participant ID” column contains PIDs.
- Make participants load automatically when the tool opens or when A/B condition folders change, and add a generated division-sign icon for the Ratio Calculator entry in the Tools menu (and sidebar).

### Description
- Scoped title/caption bolding: replaced broad font usage with a `QGroupBox::title` stylesheet via `_apply_groupbox_title_style` and explicit bold caption labels via `_make_caption_label`, and set button fonts bold individually in `_apply_button_styling` so line edits, combo boxes, table cells, and logs remain normal-weight.
- Participant exclusions remodelled: replaced the `QListWidget` exclude list with a two-column `QTableWidget` (`Exclude` checkbox column + `Participant ID` column) and updated population/filtering/collection logic to set checkable items in column 0 and PID text in column 1, preserving filter and exclusion controls.
- Auto-load participants and remove button: removed the explicit “Load participants” button and added auto-load behavior (via `_maybe_autoload_participants(force=True)`) triggered on initial refresh, condition swap, browse, and condition selection changes; added helpers `_clear_participants`, `_update_participant_counts`, and `_set_status_message` to manage counts/status.
- Menu/sidebar icon: added `src/Main_App/PySide6_App/GUI/icons.py` with a cached `division_icon(size)` that draws a centered “÷” on a transparent `QPixmap`, and applied that `QIcon` to the Ratio Calculator `QAction` in the Tools menu and the sidebar button.

### Testing
- Ran linter: executed `python -m ruff check src` and it passed with no issues.
- Ran test suite: executed `python -m pytest` but collection failed due to missing runtime dependencies in this environment (import errors for `PySide6`, `numpy`, and `pandas`), so GUI-dependent tests could not be executed here.
- No automated UI runtime tests were executed because the test environment lacks `PySide6`; code paths for auto-load and table population were validated via code inspection and unit-style adjustments in the GUI module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69894cd57248832c9b068f7b30c7fbfd)