### PR TITLE
Add Individual Detectability tool (PySide6) with core, worker, UI and tests

### DIFF
--- a/src/Main_App/PySide6_App/GUI/icons.py
+++ b/src/Main_App/PySide6_App/GUI/icons.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QIcon, QPainter, QPalette, QPixmap
+from PySide6.QtGui import QIcon, QPainter, QPalette, QPixmap, QPen
 from PySide6.QtWidgets import QApplication
 
 
@@ -21,6 +21,35 @@ def division_icon(size: int = 16) -> QIcon:
     font.setPixelSize(max(1, int(size * 0.9)))
     painter.setFont(font)
     painter.drawText(pixmap.rect(), Qt.AlignCenter, "÷")
+    painter.end()
+
+    return QIcon(pixmap)
+
+
+@lru_cache(maxsize=4)
+def individual_detectability_icon(size: int = 16) -> QIcon:
+    pixmap = QPixmap(size, size)
+    pixmap.fill(Qt.transparent)
+
+    painter = QPainter(pixmap)
+    painter.setRenderHint(QPainter.Antialiasing, True)
+    color = QApplication.palette().color(QPalette.ButtonText)
+    pen = QPen(color)
+    pen.setWidth(max(1, int(size * 0.08)))
+    painter.setPen(pen)
+
+    center = pixmap.rect().center()
+    radius = int(size * 0.42)
+    painter.drawEllipse(center, radius, radius)
+    painter.drawEllipse(center, int(radius * 0.55), int(radius * 0.55))
+    painter.drawLine(center.x(), int(size * 0.1), center.x(), int(size * 0.9))
+    painter.drawLine(int(size * 0.1), center.y(), int(size * 0.9), center.y())
+
+    font = QApplication.font()
+    font.setBold(True)
+    font.setPixelSize(max(1, int(size * 0.45)))
+    painter.setFont(font)
+    painter.drawText(pixmap.rect(), Qt.AlignCenter, "ID")
     painter.end()
 
     return QIcon(pixmap)

--- a/src/Main_App/PySide6_App/GUI/menu_bar.py
+++ b/src/Main_App/PySide6_App/GUI/menu_bar.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 from PySide6.QtWidgets import QMenuBar, QMainWindow
 from PySide6.QtGui import QAction
 from Main_App.Legacy_App.eloreta_launcher import open_eloreta_tool
-from Main_App.PySide6_App.GUI.icons import division_icon
+from Main_App.PySide6_App.GUI.icons import division_icon, individual_detectability_icon
 from Tools.Ratio_Calculator.launcher import open_ratio_calculator_tool
+from Tools.Individual_Detectability.launcher import open_individual_detectability_tool
 from Tools.Average_Preprocessing.New_PySide6.main_window import AdvancedAveragingWindow  # noqa: F401
 
 def build_menu_bar(parent: QMainWindow) -> QMenuBar:
@@ -34,6 +35,8 @@ def build_menu_bar(parent: QMainWindow) -> QMenuBar:
         ("Image Resizer",                              parent.open_image_resizer, None),
         ("Generate SNR Plots",                         parent.open_plot_generator, None),
         ("Ratio Calculator",                           lambda: open_ratio_calculator_tool(parent), division_icon()),
+        ("Individual Detectability",                   lambda: open_individual_detectability_tool(parent),
+         individual_detectability_icon()),
         ("Average Epochs in Pre-Processing Phase",     parent.open_epoch_averaging, None),
     ]
     for text, slot, icon in items:

--- a/src/Main_App/PySide6_App/GUI/sidebar.py
+++ b/src/Main_App/PySide6_App/GUI/sidebar.py
@@ -16,8 +16,9 @@ from PySide6.QtWidgets import (
     QLabel,
     QHBoxLayout,
 )
-from Main_App.PySide6_App.GUI.icons import division_icon
+from Main_App.PySide6_App.GUI.icons import division_icon, individual_detectability_icon
 from Tools.Ratio_Calculator.launcher import open_ratio_calculator_tool
+from Tools.Individual_Detectability.launcher import open_individual_detectability_tool
 
 # ---- Tunables -------------------------------------------------------------
 ICON_PX = 20          # normalize all icons to the same visual size
@@ -210,6 +211,13 @@ def init_sidebar(self) -> None:
         "Ratio Calculator",
         division_icon(ICON_PX),
         lambda: open_ratio_calculator_tool(self),
+    )
+    make_button(
+        lay,
+        "btn_individual_detectability",
+        "Individual Detectability",
+        individual_detectability_icon(ICON_PX),
+        lambda: open_individual_detectability_tool(self),
     )
 
     make_button(lay, "btn_image", "Image Resizer", "camera-photo", self.open_image_resizer)

--- a/src/Tools/Individual_Detectability/__init__.py
+++ b/src/Tools/Individual_Detectability/__init__.py
@@ -1,0 +1,1 @@
+"""Individual Detectability tool package."""

--- a/src/Tools/Individual_Detectability/core.py
+++ b/src/Tools/Individual_Detectability/core.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import math
+import re
+from typing import Callable, Iterable, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+SHEET_Z = "Z Score"
+SHEET_FULLSNR = "FullSNR"
+ELECTRODE_COL = "Electrode"
+
+_PID_SCP_RE = re.compile(r"SCP0*(\d+)", re.IGNORECASE)
+_PID_P_RE = re.compile(r"\bP0*(\d+)\b", re.IGNORECASE)
+_ILLEGAL_FILENAME = re.compile(r'[<>:"/\\\\|?*]+')
+
+
+@dataclass(frozen=True)
+class DetectabilitySettings:
+    oddball_harmonics_hz: list[float] = field(
+        default_factory=lambda: [1.2, 2.4, 3.6, 4.8, 6.0]
+    )
+    z_threshold: float = 1.64
+    use_bh_fdr: bool = True
+    fdr_alpha: float = 0.05
+    half_window_hz: float = 0.4
+    snr_ymin_fixed: float = 0.0
+    snr_ymax_fixed: float = 2.0
+    snr_show_mid_xtick: bool = True
+    grid_ncols: int = 4
+    use_letter_portrait: bool = True
+
+
+@dataclass(frozen=True)
+class ConditionInfo:
+    name: str
+    path: Path
+    files: list[Path]
+
+
+def parse_participant_id(filename: str) -> str | None:
+    match = _PID_SCP_RE.search(filename)
+    if match:
+        return f"P{int(match.group(1))}"
+    match = _PID_P_RE.search(filename)
+    if match:
+        return f"P{int(match.group(1))}"
+    return None
+
+
+def sanitize_filename_stem(value: str) -> str:
+    cleaned = _ILLEGAL_FILENAME.sub("_", value).strip().strip(".")
+    return cleaned if cleaned else "output"
+
+
+def discover_conditions(root: Path) -> list[ConditionInfo]:
+    if not root.exists():
+        return []
+    subfolders = sorted([p for p in root.iterdir() if p.is_dir()])
+    conditions: list[ConditionInfo] = []
+    for sub in subfolders:
+        files = sorted(sub.glob("*.xlsx"))
+        if files:
+            conditions.append(ConditionInfo(name=sub.name, path=sub, files=files))
+    if conditions:
+        return conditions
+    files = sorted(root.glob("*.xlsx"))
+    if files:
+        return [ConditionInfo(name=root.name, path=root, files=files)]
+    return []
+
+
+def render_topomap_svg(
+    z_values: Sequence[float],
+    electrodes: Sequence[str],
+    z_threshold: float,
+    output_path: Path,
+) -> None:
+    _ensure_no_nan(z_values)
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LinearSegmentedColormap
+    import numpy as np
+    import mne
+
+    z_array = np.asarray(z_values, dtype=float)
+    z_display = np.where(z_array >= z_threshold, z_array, z_threshold)
+    pos = _resolve_biosemi_positions(electrodes)
+    cmap = LinearSegmentedColormap.from_list(
+        "detectability_z",
+        ["#ffffff", "#2166ac", "#b2182b"],
+    )
+    vmax = float(max(float(z_display.max()), z_threshold + 1e-6))
+    fig, ax = plt.subplots(figsize=(2.4, 2.2))
+    mne.viz.plot_topomap(
+        z_display,
+        pos,
+        axes=ax,
+        show=False,
+        vmin=z_threshold,
+        vmax=vmax,
+        contours=0,
+        cmap=cmap,
+    )
+    fig.savefig(output_path, format="svg")
+    plt.close(fig)
+
+
+def generate_condition_figure(
+    condition: ConditionInfo,
+    output_dir: Path,
+    output_stem: str,
+    excluded: set[str],
+    settings: DetectabilitySettings,
+    export_png: bool,
+    log: Callable[[str], None],
+) -> tuple[int, int]:
+    import numpy as np
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+    import mne
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    participants: list[str] = []
+    topo_values: list[np.ndarray] = []
+    spectra: list[tuple[np.ndarray, np.ndarray]] = []
+
+    for excel_path in condition.files:
+        pid = parse_participant_id(excel_path.stem)
+        if not pid:
+            log(f"Skipping {excel_path.name}: could not parse participant ID.")
+            continue
+        if pid in excluded:
+            log(f"Skipping {excel_path.name}: excluded participant {pid}.")
+            continue
+        try:
+            combined_z, sig_mask, electrodes = _load_combined_z(
+                excel_path,
+                settings,
+            )
+            freqs, snr_avg = _load_snr_spectrum(
+                excel_path,
+                settings,
+                sig_mask,
+                electrodes,
+                log,
+            )
+        except Exception as exc:
+            log(f"Error processing {excel_path.name}: {exc}")
+            continue
+        participants.append(pid)
+        topo_values.append(combined_z)
+        spectra.append((freqs, snr_avg))
+
+    if not participants:
+        log(f"No participants to plot for {condition.name}.")
+        return 0, len(condition.files)
+
+    ncols = max(1, int(settings.grid_ncols))
+    nrows = int(math.ceil(len(participants) / ncols))
+    fig_w, fig_h = _figure_size(ncols, nrows, settings.use_letter_portrait)
+    fig = plt.figure(figsize=(fig_w, fig_h))
+    gs = fig.add_gridspec(nrows * 2, ncols, height_ratios=[1, 0.9] * nrows)
+
+    for idx, pid in enumerate(participants):
+        row = (idx // ncols) * 2
+        col = idx % ncols
+        ax_topo = fig.add_subplot(gs[row, col])
+        ax_snr = fig.add_subplot(gs[row + 1, col])
+
+        z_display = np.where(topo_values[idx] >= settings.z_threshold,
+                             topo_values[idx],
+                             settings.z_threshold)
+        _ensure_no_nan(z_display)
+        pos = _resolve_biosemi_positions(electrodes)
+        cmap = _detectability_cmap()
+        vmax = float(max(float(z_display.max()), settings.z_threshold + 1e-6))
+        mne.viz.plot_topomap(
+            z_display,
+            pos,
+            axes=ax_topo,
+            show=False,
+            vmin=settings.z_threshold,
+            vmax=vmax,
+            contours=0,
+            cmap=cmap,
+        )
+        ax_topo.set_title(pid, fontsize=10)
+
+        rel_freqs, snr_avg = spectra[idx]
+        ax_snr.plot(rel_freqs, snr_avg, color="#2166ac", linewidth=1.2)
+        ax_snr.axvline(0, color="#777777", linewidth=0.8, linestyle="--")
+        ax_snr.axhline(1, color="#777777", linewidth=0.8, linestyle="--")
+        ax_snr.set_xlim(-settings.half_window_hz, settings.half_window_hz)
+        ax_snr.set_ylim(settings.snr_ymin_fixed, settings.snr_ymax_fixed)
+        if settings.snr_show_mid_xtick:
+            ax_snr.set_xticks(
+                [-settings.half_window_hz, 0, settings.half_window_hz]
+            )
+        else:
+            ax_snr.set_xticks(
+                [-settings.half_window_hz, settings.half_window_hz]
+            )
+        ax_snr.tick_params(labelsize=8)
+
+    fig.tight_layout()
+    svg_path = output_dir / f"{output_stem}.svg"
+    fig.savefig(svg_path, format="svg")
+    if export_png:
+        png_path = output_dir / f"{output_stem}.png"
+        fig.savefig(png_path, format="png", dpi=600)
+    plt.close(fig)
+    return len(participants), len(condition.files)
+
+
+def _figure_size(ncols: int, nrows: int, use_letter: bool) -> tuple[float, float]:
+    if use_letter:
+        return (8.5, 11.0)
+    width = max(6.0, ncols * 3.0)
+    height = max(4.5, nrows * 3.0)
+    return (width, height)
+
+
+def _ensure_no_nan(values: Sequence[float]) -> None:
+    import numpy as np
+
+    array = np.asarray(values, dtype=float)
+    if np.isnan(array).any():
+        raise ValueError("Z topomap values contain NaNs; cannot render.")
+
+
+def _detectability_cmap():
+    from matplotlib.colors import LinearSegmentedColormap
+
+    return LinearSegmentedColormap.from_list(
+        "detectability_z",
+        ["#ffffff", "#2166ac", "#b2182b"],
+    )
+
+
+def _resolve_biosemi_positions(electrodes: Sequence[str]):
+    import mne
+    import numpy as np
+
+    montage = mne.channels.make_standard_montage("biosemi64")
+    ch_pos = montage.get_positions()["ch_pos"]
+    upper_map = {name.upper(): pos for name, pos in ch_pos.items()}
+    missing = [name for name in electrodes if name.upper() not in upper_map]
+    if missing:
+        example = ", ".join(missing[:5])
+        raise ValueError(
+            "Unrecognized electrodes in Excel export: "
+            f"{example} (and {max(0, len(missing) - 5)} more)."
+        )
+    pos = np.array([upper_map[name.upper()] for name in electrodes], dtype=float)
+    return pos
+
+
+def _load_combined_z(
+    excel_path: Path,
+    settings: DetectabilitySettings,
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    import numpy as np
+    import pandas as pd
+    from scipy.stats import norm
+    import mne
+
+    try:
+        df = pd.read_excel(excel_path, sheet_name=SHEET_Z)
+    except Exception as exc:
+        raise ValueError(f"Missing required sheet '{SHEET_Z}'.") from exc
+    if ELECTRODE_COL not in df.columns:
+        raise ValueError(f"Missing column '{ELECTRODE_COL}' in '{SHEET_Z}'.")
+    electrodes = df[ELECTRODE_COL].astype(str).tolist()
+    freq_cols = _select_harmonic_columns(df, settings.oddball_harmonics_hz)
+    z_values = df[freq_cols].to_numpy(dtype=float)
+    if np.isnan(z_values).any():
+        raise ValueError(f"Found NaNs in '{SHEET_Z}' harmonic columns.")
+    combined = z_values.sum(axis=1) / math.sqrt(len(freq_cols))
+    if settings.use_bh_fdr:
+        pvals = norm.sf(np.abs(combined)) * 2
+        reject, _ = mne.stats.fdr_correction(pvals, alpha=settings.fdr_alpha)
+        sig_mask = reject
+    else:
+        sig_mask = combined >= settings.z_threshold
+    return combined, sig_mask, electrodes
+
+
+def _load_snr_spectrum(
+    excel_path: Path,
+    settings: DetectabilitySettings,
+    sig_mask: np.ndarray,
+    electrodes: Sequence[str],
+    log: Callable[[str], None],
+) -> tuple[np.ndarray, np.ndarray]:
+    import numpy as np
+    import pandas as pd
+
+    try:
+        df = pd.read_excel(excel_path, sheet_name=SHEET_FULLSNR)
+    except Exception as exc:
+        raise ValueError(f"Missing required sheet '{SHEET_FULLSNR}'.") from exc
+    if ELECTRODE_COL not in df.columns:
+        raise ValueError(f"Missing column '{ELECTRODE_COL}' in '{SHEET_FULLSNR}'.")
+    df_electrodes = df[ELECTRODE_COL].astype(str).str.upper().tolist()
+    if [e.upper() for e in electrodes] != df_electrodes:
+        raise ValueError("Electrode ordering mismatch between Z and FullSNR sheets.")
+
+    freq_cols, freqs = _snr_freq_columns(df)
+    snr_data = df[freq_cols].to_numpy(dtype=float)
+
+    sig_indices = np.where(sig_mask)[0]
+    if sig_indices.size == 0:
+        log("No significant electrodes found; using all electrodes for SNR average.")
+        sig_indices = np.arange(snr_data.shape[0])
+
+    base_rel: np.ndarray | None = None
+    harmonic_curves: list[np.ndarray] = []
+
+    for harmonic in settings.oddball_harmonics_hz:
+        mask = (freqs >= harmonic - settings.half_window_hz) & (
+            freqs <= harmonic + settings.half_window_hz
+        )
+        if not mask.any():
+            raise ValueError(
+                f"No SNR points within {settings.half_window_hz} Hz of {harmonic} Hz."
+            )
+        rel = freqs[mask] - harmonic
+        mean_snr = snr_data[sig_indices][:, mask].mean(axis=0)
+        if base_rel is None:
+            base_rel = rel
+            harmonic_curves.append(mean_snr)
+        else:
+            if rel.shape != base_rel.shape or not np.allclose(rel, base_rel):
+                mean_snr = np.interp(base_rel, rel, mean_snr)
+            harmonic_curves.append(mean_snr)
+
+    if base_rel is None:
+        raise ValueError("No harmonics available for SNR averaging.")
+    snr_avg = np.mean(np.vstack(harmonic_curves), axis=0)
+    return base_rel, snr_avg
+
+
+def _snr_freq_columns(df) -> tuple[list[str], np.ndarray]:
+    import numpy as np
+
+    freq_cols: list[str] = []
+    freqs: list[float] = []
+    for col in df.columns:
+        if col == ELECTRODE_COL:
+            continue
+        freq_val = _extract_float(col)
+        if freq_val is None:
+            raise ValueError(f"Invalid frequency column '{col}'.")
+        freq_cols.append(col)
+        freqs.append(freq_val)
+    if not freq_cols:
+        raise ValueError("No frequency columns found in FullSNR sheet.")
+    return freq_cols, np.asarray(freqs, dtype=float)
+
+
+def _select_harmonic_columns(df, harmonics: Iterable[float]) -> list[str]:
+    cols = {}
+    for col in df.columns:
+        if col == ELECTRODE_COL:
+            continue
+        freq_val = _extract_float(col)
+        if freq_val is not None:
+            cols[_round_hz(freq_val)] = col
+    selected: list[str] = []
+    missing: list[str] = []
+    for hz in harmonics:
+        key = _round_hz(hz)
+        col = cols.get(key)
+        if col is None:
+            missing.append(f"{hz:g}")
+        else:
+            selected.append(col)
+    if missing:
+        raise ValueError(
+            "Missing required harmonics in Z Score sheet: "
+            + ", ".join(missing)
+        )
+    return selected
+
+
+def _extract_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value)
+    match = re.search(r"([-+]?\d*\.?\d+)", text)
+    if not match:
+        return None
+    return float(match.group(1))
+
+
+def _round_hz(value: float) -> float:
+    return float(round(float(value), 6))

--- a/src/Tools/Individual_Detectability/individual_detectability.py
+++ b/src/Tools/Individual_Detectability/individual_detectability.py
@@ -1,0 +1,25 @@
+"""PySide6 GUI for the Individual Detectability tool."""
+from __future__ import annotations
+
+if __package__ is None:  # pragma: no cover - executed when run as script
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from PySide6.QtWidgets import QApplication
+
+from Main_App.PySide6_App.utils.theme import apply_light_palette
+from Tools.Individual_Detectability.main_window import IndividualDetectabilityWindow
+
+
+def main() -> None:
+    app = QApplication([])
+    apply_light_palette(app)
+    win = IndividualDetectabilityWindow()
+    win.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Tools/Individual_Detectability/launcher.py
+++ b/src/Tools/Individual_Detectability/launcher.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def open_individual_detectability_tool(parent: Any | None = None) -> None:
+    cmd = [sys.executable]
+    if getattr(sys, "frozen", False):
+        cmd.append("--run-individual-detectability")
+    else:
+        script = Path(__file__).resolve().parent / "individual_detectability.py"
+        cmd.append(str(script))
+    env = os.environ.copy()
+    proj = getattr(parent, "currentProject", None)
+    if proj and hasattr(proj, "project_root"):
+        env["FPVS_PROJECT_ROOT"] = str(proj.project_root)
+    subprocess.Popen(cmd, close_fds=True, env=env)

--- a/src/Tools/Individual_Detectability/main_window.py
+++ b/src/Tools/Individual_Detectability/main_window.py
@@ -1,0 +1,746 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import QThread, Qt, QUrl
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QProgressBar,
+    QPlainTextEdit,
+    QSizePolicy,
+    QSpinBox,
+    QDoubleSpinBox,
+    QStyle,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+    QFileDialog,
+    QHeaderView,
+)
+
+from .core import (
+    ConditionInfo,
+    DetectabilitySettings,
+    discover_conditions,
+    parse_participant_id,
+    sanitize_filename_stem,
+)
+from .worker import IndividualDetectabilityWorker, RunRequest
+
+
+class IndividualDetectabilityWindow(QWidget):
+    def __init__(self, parent: QWidget | None = None, project_root: str | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Individual Detectability")
+        self.resize(1040, 820)
+
+        self._project_root = self._resolve_project_root(project_root)
+        self._last_dir: Optional[Path] = None
+        self._conditions: list[ConditionInfo] = []
+        self._thread: Optional[QThread] = None
+        self._worker: Optional[IndividualDetectabilityWorker] = None
+
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        self.basic_tab = QWidget()
+        self.advanced_tab = QWidget()
+        self.tabs.addTab(self.basic_tab, "Basic")
+        self.tabs.addTab(self.advanced_tab, "Advanced")
+        layout.addWidget(self.tabs)
+
+        self._build_basic_tab()
+        self._build_advanced_tab()
+        self._build_bottom_panel(layout)
+        self._apply_button_styling()
+        self._apply_button_icons()
+
+        self._set_default_input_root()
+        self._refresh_conditions()
+        self._update_run_state()
+
+    @contextmanager
+    def _block_signals(self, widget: QWidget):
+        was_blocked = widget.blockSignals(True)
+        try:
+            yield
+        finally:
+            widget.blockSignals(was_blocked)
+
+    def _resolve_project_root(self, provided_root: str | None) -> Optional[Path]:
+        if provided_root:
+            root = Path(provided_root)
+            if root.exists():
+                return root
+        env_root = os.environ.get("FPVS_PROJECT_ROOT")
+        if env_root:
+            root = Path(env_root)
+            if root.exists():
+                return root
+        proj = getattr(self.parent(), "currentProject", None)
+        if proj and hasattr(proj, "project_root"):
+            root = Path(proj.project_root)
+            if root.exists():
+                return root
+        return None
+
+    def _build_basic_tab(self) -> None:
+        layout = QVBoxLayout(self.basic_tab)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        self._build_input_group(layout)
+        self._build_conditions_group(layout)
+        self._build_output_group(layout)
+        self._build_participant_group(layout)
+        layout.addStretch(1)
+
+    def _build_input_group(self, parent_layout: QVBoxLayout) -> None:
+        group = QGroupBox("Input data")
+        self._apply_groupbox_title_style(group)
+        layout = QFormLayout(group)
+        layout.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        layout.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        layout.setHorizontalSpacing(10)
+        layout.setVerticalSpacing(6)
+
+        self.input_root_edit = QLineEdit()
+        self.input_root_edit.setReadOnly(True)
+        self.input_root_edit.setPlaceholderText("Select Excel root folder")
+        self.input_root_btn = QPushButton("Browse…")
+        self.input_root_btn.clicked.connect(self._browse_input_root)
+        self.refresh_btn = QPushButton("Refresh conditions")
+        self.refresh_btn.clicked.connect(self._refresh_conditions)
+
+        row = QWidget()
+        row_layout = QHBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(6)
+        row_layout.addWidget(self.input_root_edit, 1)
+        row_layout.addWidget(self.input_root_btn)
+
+        layout.addRow(QLabel("Excel root folder"), row)
+        layout.addRow(QLabel(""), self.refresh_btn)
+        parent_layout.addWidget(group)
+
+    def _build_conditions_group(self, parent_layout: QVBoxLayout) -> None:
+        group = QGroupBox("Conditions")
+        self._apply_groupbox_title_style(group)
+        layout = QVBoxLayout(group)
+        layout.setContentsMargins(6, 8, 6, 6)
+        layout.setSpacing(6)
+
+        self.conditions_list = QListWidget()
+        self.conditions_list.itemChanged.connect(self._on_condition_check_changed)
+
+        button_row = QWidget()
+        button_layout = QHBoxLayout(button_row)
+        button_layout.setContentsMargins(0, 0, 0, 0)
+        button_layout.setSpacing(6)
+        self.select_all_btn = QPushButton("Select all")
+        self.select_all_btn.clicked.connect(lambda: self._set_all_conditions(True))
+        self.select_none_btn = QPushButton("Select none")
+        self.select_none_btn.clicked.connect(lambda: self._set_all_conditions(False))
+        button_layout.addWidget(self.select_all_btn)
+        button_layout.addWidget(self.select_none_btn)
+        button_layout.addStretch(1)
+
+        self.conditions_summary = QLabel("Selected conditions: 0 | Total files: 0")
+        self.conditions_summary.setStyleSheet("color: #666;")
+
+        layout.addWidget(self.conditions_list)
+        layout.addWidget(button_row)
+        layout.addWidget(self.conditions_summary)
+        parent_layout.addWidget(group)
+
+    def _build_output_group(self, parent_layout: QVBoxLayout) -> None:
+        group = QGroupBox("Output")
+        self._apply_groupbox_title_style(group)
+        layout = QVBoxLayout(group)
+        layout.setContentsMargins(6, 8, 6, 6)
+        layout.setSpacing(6)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        form.setHorizontalSpacing(10)
+        form.setVerticalSpacing(6)
+
+        self.output_root_edit = QLineEdit()
+        self.output_root_edit.setReadOnly(True)
+        self.output_root_edit.setPlaceholderText("Select output folder")
+        self.output_root_btn = QPushButton("Browse…")
+        self.output_root_btn.clicked.connect(self._browse_output_root)
+        self.output_root_open_btn = QPushButton("Open")
+        self.output_root_open_btn.clicked.connect(self._open_output_folder)
+
+        out_row = QWidget()
+        out_layout = QHBoxLayout(out_row)
+        out_layout.setContentsMargins(0, 0, 0, 0)
+        out_layout.setSpacing(6)
+        out_layout.addWidget(self.output_root_edit, 1)
+        out_layout.addWidget(self.output_root_open_btn)
+        out_layout.addWidget(self.output_root_btn)
+        form.addRow(QLabel("Output folder"), out_row)
+
+        layout.addLayout(form)
+
+        self.output_table = QTableWidget(0, 2)
+        self.output_table.setHorizontalHeaderLabels(["Condition", "Filename stem"])
+        self.output_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.output_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        self.output_table.verticalHeader().setVisible(False)
+        self.output_table.setEditTriggers(QTableWidget.DoubleClicked | QTableWidget.EditKeyPressed)
+
+        self.autofill_btn = QPushButton("Auto-fill stems")
+        self.autofill_btn.clicked.connect(self._autofill_stems)
+
+        format_row = QWidget()
+        format_layout = QHBoxLayout(format_row)
+        format_layout.setContentsMargins(0, 0, 0, 0)
+        format_layout.setSpacing(10)
+        self.export_svg_check = QCheckBox("Export SVG")
+        self.export_svg_check.setChecked(True)
+        self.export_svg_check.setEnabled(False)
+        self.export_png_check = QCheckBox("Also export PNG (600 DPI)")
+        self.open_on_complete_check = QCheckBox("Open output folder on completion")
+        self.open_on_complete_check.setChecked(True)
+        format_layout.addWidget(self.export_svg_check)
+        format_layout.addWidget(self.export_png_check)
+        format_layout.addStretch(1)
+
+        layout.addWidget(self.output_table)
+        layout.addWidget(self.autofill_btn)
+        layout.addWidget(format_row)
+        layout.addWidget(self.open_on_complete_check)
+        parent_layout.addWidget(group)
+
+    def _build_participant_group(self, parent_layout: QVBoxLayout) -> None:
+        group = QGroupBox("Participant filtering (optional)")
+        self._apply_groupbox_title_style(group)
+        layout = QVBoxLayout(group)
+        layout.setContentsMargins(6, 8, 6, 6)
+        layout.setSpacing(6)
+
+        help_text = QLabel(
+            "Checked participants are excluded from figure generation for all selected conditions."
+        )
+        help_text.setWordWrap(True)
+        help_text.setStyleSheet("color: #666;")
+
+        filter_row = QWidget()
+        filter_layout = QHBoxLayout(filter_row)
+        filter_layout.setContentsMargins(0, 0, 0, 0)
+        filter_layout.setSpacing(6)
+        self.participant_search = QLineEdit()
+        self.participant_search.setPlaceholderText("Search participants")
+        self.participant_search.textChanged.connect(self._apply_participant_filter)
+        self.show_excluded_check = QCheckBox("Show only excluded")
+        self.show_excluded_check.stateChanged.connect(self._apply_participant_filter)
+        filter_layout.addWidget(self.participant_search, 1)
+        filter_layout.addWidget(self.show_excluded_check)
+
+        self.participant_table = QTableWidget(0, 2)
+        self.participant_table.setHorizontalHeaderLabels(["Exclude", "Participant ID"])
+        self.participant_table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeToContents
+        )
+        self.participant_table.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.Stretch
+        )
+        self.participant_table.verticalHeader().setVisible(False)
+        self.participant_table.itemChanged.connect(self._apply_participant_filter)
+
+        self.participant_summary = QLabel("Excluded: 0 | Included: 0 | Total detected: 0")
+        self.participant_summary.setStyleSheet("color: #666;")
+
+        layout.addWidget(help_text)
+        layout.addWidget(filter_row)
+        layout.addWidget(self.participant_table)
+        layout.addWidget(self.participant_summary)
+        parent_layout.addWidget(group)
+
+    def _build_advanced_tab(self) -> None:
+        layout = QVBoxLayout(self.advanced_tab)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        settings = DetectabilitySettings()
+
+        harmonics_group = QGroupBox("Harmonics & thresholds")
+        self._apply_groupbox_title_style(harmonics_group)
+        harm_layout = QFormLayout(harmonics_group)
+        harm_layout.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        harm_layout.setHorizontalSpacing(10)
+        harm_layout.setVerticalSpacing(6)
+
+        self.harmonics_edit = QLineEdit(", ".join([str(h) for h in settings.oddball_harmonics_hz]))
+        self.harmonics_edit.textChanged.connect(self._update_summary_text)
+        self.z_threshold_spin = QDoubleSpinBox()
+        self.z_threshold_spin.setDecimals(3)
+        self.z_threshold_spin.setRange(-99.0, 99.0)
+        self.z_threshold_spin.setValue(settings.z_threshold)
+        self.z_threshold_spin.valueChanged.connect(self._update_summary_text)
+        self.use_bh_fdr_check = QCheckBox("Use BH-FDR correction")
+        self.use_bh_fdr_check.setChecked(settings.use_bh_fdr)
+        self.use_bh_fdr_check.stateChanged.connect(self._toggle_fdr_alpha)
+        self.fdr_alpha_spin = QDoubleSpinBox()
+        self.fdr_alpha_spin.setDecimals(4)
+        self.fdr_alpha_spin.setRange(0.0001, 1.0)
+        self.fdr_alpha_spin.setSingleStep(0.01)
+        self.fdr_alpha_spin.setValue(settings.fdr_alpha)
+        self.fdr_alpha_spin.valueChanged.connect(self._update_summary_text)
+
+        harm_layout.addRow(QLabel("Oddball harmonics (Hz)"), self.harmonics_edit)
+        harm_layout.addRow(QLabel("Z threshold"), self.z_threshold_spin)
+        harm_layout.addRow(QLabel(""), self.use_bh_fdr_check)
+        harm_layout.addRow(QLabel("FDR alpha"), self.fdr_alpha_spin)
+
+        snr_group = QGroupBox("SNR mini-spectrum")
+        self._apply_groupbox_title_style(snr_group)
+        snr_layout = QFormLayout(snr_group)
+        snr_layout.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        snr_layout.setHorizontalSpacing(10)
+        snr_layout.setVerticalSpacing(6)
+
+        self.half_window_spin = QDoubleSpinBox()
+        self.half_window_spin.setDecimals(3)
+        self.half_window_spin.setRange(0.01, 20.0)
+        self.half_window_spin.setValue(settings.half_window_hz)
+        self.half_window_spin.valueChanged.connect(self._update_summary_text)
+        self.snr_ymin_spin = QDoubleSpinBox()
+        self.snr_ymin_spin.setDecimals(2)
+        self.snr_ymin_spin.setRange(-10.0, 10.0)
+        self.snr_ymin_spin.setValue(settings.snr_ymin_fixed)
+        self.snr_ymin_spin.valueChanged.connect(self._update_summary_text)
+        self.snr_ymax_spin = QDoubleSpinBox()
+        self.snr_ymax_spin.setDecimals(2)
+        self.snr_ymax_spin.setRange(0.1, 50.0)
+        self.snr_ymax_spin.setValue(settings.snr_ymax_fixed)
+        self.snr_ymax_spin.valueChanged.connect(self._update_summary_text)
+        self.show_mid_xtick_check = QCheckBox("Show 0 Hz tick")
+        self.show_mid_xtick_check.setChecked(settings.snr_show_mid_xtick)
+        self.show_mid_xtick_check.stateChanged.connect(self._update_summary_text)
+
+        snr_layout.addRow(QLabel("Half window (Hz)"), self.half_window_spin)
+        snr_layout.addRow(QLabel("SNR y-min"), self.snr_ymin_spin)
+        snr_layout.addRow(QLabel("SNR y-max"), self.snr_ymax_spin)
+        snr_layout.addRow(QLabel(""), self.show_mid_xtick_check)
+
+        layout_group = QGroupBox("Layout")
+        self._apply_groupbox_title_style(layout_group)
+        layout_form = QFormLayout(layout_group)
+        layout_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        layout_form.setHorizontalSpacing(10)
+        layout_form.setVerticalSpacing(6)
+
+        self.grid_cols_spin = QSpinBox()
+        self.grid_cols_spin.setRange(1, 10)
+        self.grid_cols_spin.setValue(settings.grid_ncols)
+        self.grid_cols_spin.valueChanged.connect(self._update_summary_text)
+        self.letter_portrait_check = QCheckBox("Use letter portrait")
+        self.letter_portrait_check.setChecked(settings.use_letter_portrait)
+        self.letter_portrait_check.stateChanged.connect(self._update_summary_text)
+
+        layout_form.addRow(QLabel("Grid columns"), self.grid_cols_spin)
+        layout_form.addRow(QLabel(""), self.letter_portrait_check)
+
+        self.summary_box = QTextEdit()
+        self.summary_box.setReadOnly(True)
+        self.summary_box.setMinimumHeight(110)
+
+        layout.addWidget(harmonics_group)
+        layout.addWidget(snr_group)
+        layout.addWidget(layout_group)
+        layout.addWidget(QLabel("Effective parameters summary"))
+        layout.addWidget(self.summary_box)
+        layout.addStretch(1)
+        self._toggle_fdr_alpha()
+        self._update_summary_text()
+
+    def _build_bottom_panel(self, parent_layout: QVBoxLayout) -> None:
+        panel = QWidget()
+        layout = QVBoxLayout(panel)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
+        row = QWidget()
+        row_layout = QHBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(6)
+        self.run_btn = QPushButton("Run")
+        self.run_btn.clicked.connect(self._start_run)
+        self.progress = QProgressBar()
+        self.progress.setValue(0)
+        self.status_label = QLabel("Ready.")
+        self.status_label.setStyleSheet("color: #666;")
+        row_layout.addWidget(self.run_btn)
+        row_layout.addWidget(self.progress, 1)
+        row_layout.addWidget(self.status_label)
+
+        log_row = QWidget()
+        log_layout = QHBoxLayout(log_row)
+        log_layout.setContentsMargins(0, 0, 0, 0)
+        log_layout.setSpacing(6)
+        self.toggle_log_btn = QPushButton("Show log")
+        self.toggle_log_btn.setCheckable(True)
+        self.toggle_log_btn.toggled.connect(self._toggle_log_panel)
+        self.copy_log_btn = QPushButton("Copy log")
+        self.copy_log_btn.clicked.connect(self._copy_log)
+        self.open_output_btn = QPushButton("Open output folder")
+        self.open_output_btn.clicked.connect(self._open_output_folder)
+        log_layout.addWidget(self.toggle_log_btn)
+        log_layout.addWidget(self.copy_log_btn)
+        log_layout.addWidget(self.open_output_btn)
+        log_layout.addStretch(1)
+
+        self.log_box = QPlainTextEdit()
+        self.log_box.setReadOnly(True)
+        self.log_box.setVisible(False)
+        self.log_box.setMinimumHeight(140)
+
+        layout.addWidget(row)
+        layout.addWidget(log_row)
+        layout.addWidget(self.log_box)
+        parent_layout.addWidget(panel)
+
+    def _apply_groupbox_title_style(self, group: QGroupBox) -> None:
+        font = group.font()
+        font.setBold(True)
+        group.setFont(font)
+
+    def _apply_button_styling(self) -> None:
+        for btn in self.findChildren(QPushButton):
+            btn.setFixedHeight(28)
+            btn.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.toggle_log_btn.setFixedHeight(26)
+
+    def _apply_button_icons(self) -> None:
+        style = QApplication.instance().style()
+        self.input_root_btn.setIcon(style.standardIcon(QStyle.SP_DirOpenIcon))
+        self.refresh_btn.setIcon(style.standardIcon(QStyle.SP_BrowserReload))
+        self.output_root_btn.setIcon(style.standardIcon(QStyle.SP_DirOpenIcon))
+        self.output_root_open_btn.setIcon(style.standardIcon(QStyle.SP_DialogOpenButton))
+        self.autofill_btn.setIcon(style.standardIcon(QStyle.SP_ArrowRight))
+        self.run_btn.setIcon(style.standardIcon(QStyle.SP_MediaPlay))
+        self.toggle_log_btn.setIcon(style.standardIcon(QStyle.SP_FileDialogInfoView))
+        self.copy_log_btn.setIcon(style.standardIcon(QStyle.SP_DialogSaveButton))
+        self.open_output_btn.setIcon(style.standardIcon(QStyle.SP_DirOpenIcon))
+
+    def _set_default_input_root(self) -> None:
+        if self.input_root_edit.text().strip():
+            return
+        if self._project_root:
+            candidate = self._project_root / "1 - Excel Data Files"
+            if candidate.exists():
+                self.input_root_edit.setText(str(candidate))
+
+    def _browse_input_root(self) -> None:
+        start_dir = self._default_browse_dir()
+        folder = QFileDialog.getExistingDirectory(self, "Select Excel root folder", str(start_dir))
+        if folder:
+            self.input_root_edit.setText(folder)
+            self._last_dir = Path(folder)
+            self._refresh_conditions()
+
+    def _browse_output_root(self) -> None:
+        start_dir = self._default_browse_dir()
+        folder = QFileDialog.getExistingDirectory(self, "Select output folder", str(start_dir))
+        if folder:
+            self.output_root_edit.setText(folder)
+            self._last_dir = Path(folder)
+            self._update_run_state()
+
+    def _default_browse_dir(self) -> Path:
+        if self._last_dir and self._last_dir.exists():
+            return self._last_dir
+        if self._project_root:
+            candidate = self._project_root / "1 - Excel Data Files"
+            if candidate.exists():
+                return candidate
+        return Path.home()
+
+    def _refresh_conditions(self) -> None:
+        root_text = self.input_root_edit.text().strip()
+        self._conditions = discover_conditions(Path(root_text)) if root_text else []
+        with self._block_signals(self.conditions_list):
+            self.conditions_list.clear()
+            for cond in self._conditions:
+                item = QListWidgetItem(f"{cond.name} ({len(cond.files)})")
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+                item.setCheckState(Qt.Checked)
+                self.conditions_list.addItem(item)
+        self._populate_output_table()
+        self._update_condition_summary()
+        self._populate_participants()
+        self._update_run_state()
+
+    def _populate_output_table(self) -> None:
+        self.output_table.setRowCount(len(self._conditions))
+        for row, cond in enumerate(self._conditions):
+            name_item = QTableWidgetItem(cond.name)
+            name_item.setFlags(name_item.flags() & ~Qt.ItemIsEditable)
+            stem_item = QTableWidgetItem(
+                sanitize_filename_stem(f"{cond.name}_individual_detectability_grid")
+            )
+            self.output_table.setItem(row, 0, name_item)
+            self.output_table.setItem(row, 1, stem_item)
+
+    def _autofill_stems(self) -> None:
+        for row in range(self.output_table.rowCount()):
+            cond = self.output_table.item(row, 0)
+            if cond is None:
+                continue
+            stem = sanitize_filename_stem(
+                f"{cond.text()}_individual_detectability_grid"
+            )
+            self.output_table.setItem(row, 1, QTableWidgetItem(stem))
+
+    def _on_condition_check_changed(self, _item: QListWidgetItem) -> None:
+        self._update_condition_summary()
+        self._populate_participants()
+        self._update_run_state()
+
+    def _set_all_conditions(self, checked: bool) -> None:
+        with self._block_signals(self.conditions_list):
+            for i in range(self.conditions_list.count()):
+                item = self.conditions_list.item(i)
+                item.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+        self._update_condition_summary()
+        self._populate_participants()
+        self._update_run_state()
+
+    def _selected_conditions(self) -> list[ConditionInfo]:
+        selected: list[ConditionInfo] = []
+        for idx, cond in enumerate(self._conditions):
+            item = self.conditions_list.item(idx)
+            if item and item.checkState() == Qt.Checked:
+                selected.append(cond)
+        return selected
+
+    def _update_condition_summary(self) -> None:
+        selected = self._selected_conditions()
+        total_files = sum(len(cond.files) for cond in selected)
+        self.conditions_summary.setText(
+            f"Selected conditions: {len(selected)} | Total files: {total_files}"
+        )
+
+    def _populate_participants(self) -> None:
+        selected = self._selected_conditions()
+        files = [f for cond in selected for f in cond.files]
+        participants: list[str] = []
+        for path in files:
+            pid = parse_participant_id(path.stem)
+            if pid and pid not in participants:
+                participants.append(pid)
+        participants.sort(key=lambda p: int(p[1:]) if p[1:].isdigit() else p)
+
+        with self._block_signals(self.participant_table):
+            self.participant_table.setRowCount(len(participants))
+            for row, pid in enumerate(participants):
+                exclude_item = QTableWidgetItem()
+                exclude_item.setFlags(
+                    Qt.ItemIsUserCheckable | Qt.ItemIsEnabled | Qt.ItemIsSelectable
+                )
+                exclude_item.setCheckState(Qt.Unchecked)
+                pid_item = QTableWidgetItem(pid)
+                pid_item.setFlags(pid_item.flags() & ~Qt.ItemIsEditable)
+                self.participant_table.setItem(row, 0, exclude_item)
+                self.participant_table.setItem(row, 1, pid_item)
+        self._apply_participant_filter()
+
+    def _apply_participant_filter(self) -> None:
+        search = self.participant_search.text().strip().lower()
+        only_excluded = self.show_excluded_check.isChecked()
+        excluded = 0
+        total = self.participant_table.rowCount()
+        for row in range(total):
+            pid_item = self.participant_table.item(row, 1)
+            exclude_item = self.participant_table.item(row, 0)
+            if not pid_item or not exclude_item:
+                continue
+            pid_text = pid_item.text().lower()
+            is_excluded = exclude_item.checkState() == Qt.Checked
+            if is_excluded:
+                excluded += 1
+            visible = True
+            if search and search not in pid_text:
+                visible = False
+            if only_excluded and not is_excluded:
+                visible = False
+            self.participant_table.setRowHidden(row, not visible)
+        included = total - excluded
+        self.participant_summary.setText(
+            f"Excluded: {excluded} | Included: {included} | Total detected: {total}"
+        )
+
+    def _toggle_fdr_alpha(self) -> None:
+        enabled = self.use_bh_fdr_check.isChecked()
+        self.fdr_alpha_spin.setEnabled(enabled)
+        self._update_summary_text()
+
+    def _update_summary_text(self) -> None:
+        settings = self._collect_settings()
+        summary = [
+            f"Harmonics: {', '.join([str(h) for h in settings.oddball_harmonics_hz])}",
+            f"Z threshold: {settings.z_threshold}",
+            f"BH-FDR enabled: {settings.use_bh_fdr}",
+            f"FDR alpha: {settings.fdr_alpha}",
+            f"SNR half window: {settings.half_window_hz}",
+            f"SNR y-limits: {settings.snr_ymin_fixed} to {settings.snr_ymax_fixed}",
+            f"Show 0 Hz tick: {settings.snr_show_mid_xtick}",
+            f"Grid columns: {settings.grid_ncols}",
+            f"Letter portrait: {settings.use_letter_portrait}",
+        ]
+        self.summary_box.setText("\n".join(summary))
+
+    def _collect_settings(self) -> DetectabilitySettings:
+        harmonics = self._parse_harmonics(self.harmonics_edit.text())
+        return DetectabilitySettings(
+            oddball_harmonics_hz=harmonics,
+            z_threshold=float(self.z_threshold_spin.value()),
+            use_bh_fdr=self.use_bh_fdr_check.isChecked(),
+            fdr_alpha=float(self.fdr_alpha_spin.value()),
+            half_window_hz=float(self.half_window_spin.value()),
+            snr_ymin_fixed=float(self.snr_ymin_spin.value()),
+            snr_ymax_fixed=float(self.snr_ymax_spin.value()),
+            snr_show_mid_xtick=self.show_mid_xtick_check.isChecked(),
+            grid_ncols=int(self.grid_cols_spin.value()),
+            use_letter_portrait=self.letter_portrait_check.isChecked(),
+        )
+
+    def _parse_harmonics(self, text: str) -> list[float]:
+        values: list[float] = []
+        for token in text.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                values.append(float(token))
+            except ValueError:
+                continue
+        return values
+
+    def _collect_output_stems(self) -> dict[str, str]:
+        stems: dict[str, str] = {}
+        for row in range(self.output_table.rowCount()):
+            cond_item = self.output_table.item(row, 0)
+            stem_item = self.output_table.item(row, 1)
+            if not cond_item or not stem_item:
+                continue
+            stems[cond_item.text()] = sanitize_filename_stem(stem_item.text())
+        return stems
+
+    def _excluded_participants(self) -> set[str]:
+        excluded: set[str] = set()
+        for row in range(self.participant_table.rowCount()):
+            pid_item = self.participant_table.item(row, 1)
+            exclude_item = self.participant_table.item(row, 0)
+            if pid_item and exclude_item and exclude_item.checkState() == Qt.Checked:
+                excluded.add(pid_item.text())
+        return excluded
+
+    def _update_run_state(self) -> None:
+        ready = bool(self.output_root_edit.text().strip())
+        ready = ready and bool(self._selected_conditions())
+        ready = ready and bool(self._collect_output_stems())
+        self.run_btn.setEnabled(ready and self._thread is None)
+
+    def _toggle_log_panel(self, checked: bool) -> None:
+        self.log_box.setVisible(checked)
+        self.toggle_log_btn.setText("Hide log" if checked else "Show log")
+
+    def _append_log(self, message: str) -> None:
+        self.log_box.appendPlainText(message)
+        self.status_label.setText(message)
+
+    def _copy_log(self) -> None:
+        QApplication.clipboard().setText(self.log_box.toPlainText())
+
+    def _open_output_folder(self) -> None:
+        path = self.output_root_edit.text().strip()
+        if path:
+            QDesktopServices.openUrl(QUrl.fromLocalFile(path))
+
+    def _start_run(self) -> None:
+        if self._thread is not None:
+            return
+        output_root = self.output_root_edit.text().strip()
+        input_root = self.input_root_edit.text().strip()
+        if not input_root:
+            QMessageBox.critical(self, "Error", "Select an Excel root folder.")
+            return
+        if not output_root:
+            QMessageBox.critical(self, "Error", "Select an output folder.")
+            return
+        selected_conditions = self._selected_conditions()
+        if not selected_conditions:
+            QMessageBox.critical(self, "Error", "Select at least one condition.")
+            return
+        settings = self._collect_settings()
+        if not settings.oddball_harmonics_hz:
+            QMessageBox.critical(self, "Error", "Provide at least one harmonic value.")
+            return
+
+        request = RunRequest(
+            input_root=Path(input_root),
+            output_root=Path(output_root),
+            conditions=selected_conditions,
+            output_stems=self._collect_output_stems(),
+            excluded_participants=self._excluded_participants(),
+            settings=settings,
+            export_png=self.export_png_check.isChecked(),
+        )
+        self.log_box.clear()
+        self.progress.setValue(0)
+        self.status_label.setText("Starting...")
+
+        self._thread = QThread()
+        self._worker = IndividualDetectabilityWorker(request)
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.progress.connect(self.progress.setValue)
+        self._worker.status.connect(self.status_label.setText)
+        self._worker.log.connect(self._append_log)
+        self._worker.error.connect(self._on_worker_error)
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.finished.connect(self._thread.quit)
+        self._thread.finished.connect(self._cleanup_worker)
+        self._thread.start()
+        self.run_btn.setEnabled(False)
+
+    def _on_worker_error(self, message: str) -> None:
+        self._append_log(message)
+        QMessageBox.critical(self, "Individual Detectability error", message)
+
+    def _on_worker_finished(self, output_root: str) -> None:
+        self.status_label.setText("Complete.")
+        self.progress.setValue(100)
+        if self.open_on_complete_check.isChecked():
+            QDesktopServices.openUrl(QUrl.fromLocalFile(output_root))
+        self._update_run_state()
+
+    def _cleanup_worker(self) -> None:
+        if self._worker:
+            self._worker.deleteLater()
+        if self._thread:
+            self._thread.deleteLater()
+        self._worker = None
+        self._thread = None
+        self._update_run_state()

--- a/src/Tools/Individual_Detectability/worker.py
+++ b/src/Tools/Individual_Detectability/worker.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import traceback
+from typing import Callable
+
+from PySide6.QtCore import QObject, Signal
+
+from .core import (
+    ConditionInfo,
+    DetectabilitySettings,
+    generate_condition_figure,
+    sanitize_filename_stem,
+)
+
+
+@dataclass(frozen=True)
+class RunRequest:
+    input_root: Path
+    output_root: Path
+    conditions: list[ConditionInfo]
+    output_stems: dict[str, str]
+    excluded_participants: set[str]
+    settings: DetectabilitySettings
+    export_png: bool
+
+
+class IndividualDetectabilityWorker(QObject):
+    progress = Signal(int)
+    status = Signal(str)
+    log = Signal(str)
+    error = Signal(str)
+    finished = Signal(str)
+
+    def __init__(self, request: RunRequest) -> None:
+        super().__init__()
+        self._request = request
+
+    def _emit_log(self, message: str) -> None:
+        self.log.emit(message)
+        self.status.emit(message)
+
+    def run(self) -> None:
+        try:
+            import matplotlib
+
+            matplotlib.use("Agg", force=True)
+            self._run()
+        except Exception:
+            self.error.emit(traceback.format_exc())
+
+    def _run(self) -> None:
+        req = self._request
+        total_conditions = len(req.conditions)
+        if total_conditions == 0:
+            self._emit_log("No conditions selected.")
+            self.finished.emit(str(req.output_root))
+            return
+
+        log_path = req.output_root / "individual_detectability_log.txt"
+        req.output_root.mkdir(parents=True, exist_ok=True)
+        with log_path.open("w", encoding="utf-8") as log_file:
+
+            def write_log(message: str) -> None:
+                log_file.write(message + "\n")
+                log_file.flush()
+                self._emit_log(message)
+
+            self._log_header(write_log, req)
+
+            for idx, condition in enumerate(req.conditions, start=1):
+                write_log(f"Processing condition: {condition.name}")
+                condition_out = req.output_root / sanitize_filename_stem(condition.name)
+                stem = req.output_stems.get(condition.name) or sanitize_filename_stem(
+                    f"{condition.name}_individual_detectability_grid"
+                )
+                processed, total = generate_condition_figure(
+                    condition=condition,
+                    output_dir=condition_out,
+                    output_stem=stem,
+                    excluded=req.excluded_participants,
+                    settings=req.settings,
+                    export_png=req.export_png,
+                    log=write_log,
+                )
+                write_log(
+                    f"Condition {condition.name}: processed {processed} of {total} files."
+                )
+                pct = int(idx / total_conditions * 100)
+                self.progress.emit(pct)
+
+        self.status.emit("Individual detectability export complete.")
+        self.progress.emit(100)
+        self.finished.emit(str(req.output_root))
+
+    @staticmethod
+    def _log_header(log: Callable[[str], None], req: RunRequest) -> None:
+        log("Individual Detectability run")
+        log(f"Input root: {req.input_root}")
+        log(f"Output root: {req.output_root}")
+        log("Selected conditions:")
+        for cond in req.conditions:
+            log(f" - {cond.name} ({len(cond.files)} files)")
+        log(f"Harmonics: {', '.join([str(h) for h in req.settings.oddball_harmonics_hz])}")
+        log(f"Z threshold: {req.settings.z_threshold}")
+        log(f"BH-FDR enabled: {req.settings.use_bh_fdr}")
+        log(f"FDR alpha: {req.settings.fdr_alpha}")
+        log(f"SNR half window: {req.settings.half_window_hz}")
+        log(
+            "SNR y-limits: "
+            f"{req.settings.snr_ymin_fixed} to {req.settings.snr_ymax_fixed}"
+        )
+        log(f"SNR mid xtick: {req.settings.snr_show_mid_xtick}")
+        log(f"Grid columns: {req.settings.grid_ncols}")
+        log(f"Letter portrait: {req.settings.use_letter_portrait}")
+        log(f"Export PNG: {req.export_png}")

--- a/tests/test_individual_detectability_core.py
+++ b/tests/test_individual_detectability_core.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from Tools.Individual_Detectability.core import (
+    discover_conditions,
+    parse_participant_id,
+    render_topomap_svg,
+)
+
+
+def test_parse_participant_id_scp_variants() -> None:
+    assert parse_participant_id("SCP7_condition_Results.xlsx") == "P7"
+    assert parse_participant_id("SCP07_condition_Results.xlsx") == "P7"
+
+
+def test_discover_conditions_with_subfolders(tmp_path: Path) -> None:
+    cond_a = tmp_path / "CondA"
+    cond_b = tmp_path / "CondB"
+    cond_a.mkdir()
+    cond_b.mkdir()
+    (cond_a / "a.xlsx").write_text("data")
+    (cond_b / "b.xlsx").write_text("data")
+
+    conditions = discover_conditions(tmp_path)
+    names = [c.name for c in conditions]
+    assert names == ["CondA", "CondB"]
+    assert all(c.files for c in conditions)
+
+
+def test_discover_conditions_single_root(tmp_path: Path) -> None:
+    (tmp_path / "root.xlsx").write_text("data")
+    conditions = discover_conditions(tmp_path)
+    assert len(conditions) == 1
+    assert conditions[0].path == tmp_path
+
+
+def test_topomap_svg_nonblank(tmp_path: Path) -> None:
+    import pytest
+
+    np = pytest.importorskip("numpy")
+    mne = pytest.importorskip("mne")
+
+    montage = mne.channels.make_standard_montage("biosemi64")
+    electrodes = montage.ch_names
+    z_threshold = 1.64
+    z_values = np.full(len(electrodes), z_threshold)
+    z_values[0] = z_threshold + 1.2
+    z_values[5] = z_threshold + 0.5
+
+    output = tmp_path / "topomap.svg"
+    render_topomap_svg(z_values, electrodes, z_threshold, output)
+    contents = output.read_text(encoding="utf-8")
+    assert output.stat().st_size > 200
+    assert "<svg" in contents
+    assert "path" in contents

--- a/tests/test_individual_detectability_gui_smoke.py
+++ b/tests/test_individual_detectability_gui_smoke.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+QtCore = pytest.importorskip("PySide6.QtCore")
+if not hasattr(QtCore, "QThread"):
+    pytest.skip("PySide6 QtCore missing QThread", allow_module_level=True)
+
+from Tools.Individual_Detectability.main_window import (  # noqa: E402
+    IndividualDetectabilityWindow,
+)
+
+
+def test_individual_detectability_window_smoke(qtbot, tmp_path: Path) -> None:
+    window = IndividualDetectabilityWindow(project_root=str(tmp_path))
+    qtbot.addWidget(window)
+    window.show()
+    qtbot.waitExposed(window)


### PR DESCRIPTION
### Motivation
- Provide a new FPVS Toolbox tool "Individual Detectability" that produces per-participant detectability SVGs from existing Excel exports without recomputing spectral metrics. 
- Integrate the tool into the existing PySide6 app using the same registration and worker patterns as other tools so UI, threading, styling, and logging remain consistent.
- Preserve the critical topomap invariants (finite vector, threshold floor rendered as white) and make the tool configurable from an Advanced tab local to the tool.

### Description
- Added a new tool package under `src/Tools/Individual_Detectability/` containing `core.py` (parsing, file discovery, plotting and file-export logic), `worker.py` (QThread-friendly worker wrapper), `main_window.py` (PySide6 UI with Basic/Advanced tabs), `launcher.py`, and `individual_detectability.py` (entrypoint), plus `__init__.py`.
- Implemented filename PID parsing and sanitization with `parse_participant_id` and `sanitize_filename_stem`, and condition discovery via `discover_conditions` that mirrors existing tools' behavior.
- Ported plotting logic into `core.py` preserving the finite topomap vector rule (non-significant electrodes set exactly to `Z_THRESHOLD`), a white-floor colormap, and fixed SNR y-axis default; topomaps are exported as SVG and optional PNG (600 DPI) when enabled.
- Background processing uses a tool-local worker `IndividualDetectabilityWorker` that forces `matplotlib.use('Agg', force=True)` and runs off the UI thread via `QThread`, emitting `progress`, `status`, `log`, `error`, and `finished` signals; the UI disables Run while active and streams logs into a collapsible panel.
- Integrated the tool into the app by adding a runtime `individual_detectability_icon`, and registering the tool in the left sidebar and the `Tools` menu (using the same launcher pattern as `Ratio Calculator`); retained the existing QSS/theme usage and button/icon conventions.
- Added GUI and core tests under `tests/`: PID parsing, condition discovery, topomap non-blank regression (skipped when optional deps missing), and a GUI smoke test that is skipped when `PySide6` features are unavailable.

### Testing
- Ran the linter with `python -m ruff check .` and all checks passed.
- Ran targeted tests with `python -m pytest tests/test_individual_detectability_core.py tests/test_individual_detectability_gui_smoke.py`, which resulted in `3 passed, 2 skipped` (the topomap regression and GUI smoke tests skip when optional packages like `mne`, `numpy`, or `PySide6` runtime features are not available in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e2b9d840832caebb7f5e86366738)