### PR TITLE
Fix false "No plots were generated" outcome in SNR Plot tool

### DIFF
--- a/tests/test_plot_generator_generation_outcome.py
+++ b/tests/test_plot_generator_generation_outcome.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from PySide6.QtWidgets import QMessageBox
+
+from Tools.Plot_Generator.gui import PlotGeneratorWindow
+from Tools.Plot_Generator.worker import _infer_subject_id_from_path
+
+
+def test_infer_subject_id_is_case_insensitive() -> None:
+    assert _infer_subject_id_from_path(Path("p10.bdf")) == "P10"
+    assert _infer_subject_id_from_path(Path("P01.bdf")) == "P01"
+    assert _infer_subject_id_from_path(Path("=p17.bdf")) == "P17"
+
+
+def test_finish_all_uses_generated_paths(qtbot, monkeypatch) -> None:
+    window = PlotGeneratorWindow()
+    qtbot.addWidget(window)
+
+    called: dict[str, int] = {"question": 0}
+
+    def _fake_question(*_args, **_kwargs):
+        called["question"] += 1
+        return QMessageBox.No
+
+    monkeypatch.setattr(QMessageBox, "question", _fake_question)
+
+    window._generated_paths = ["C:/tmp/plot.png"]
+    window._failed_items = []
+    window._finish_all()
+
+    assert called["question"] == 1
+
+
+def test_finish_all_reports_no_plots_when_generated_paths_empty(qtbot, monkeypatch) -> None:
+    window = PlotGeneratorWindow()
+    qtbot.addWidget(window)
+
+    def _fail_question(*_args, **_kwargs):
+        raise AssertionError("question dialog should not be shown when no plots are generated")
+
+    monkeypatch.setattr(QMessageBox, "question", _fail_question)
+
+    window._generated_paths = []
+    window._failed_items = [{"item": "p10.xlsx", "error": "No frequency columns found"}]
+    window._finish_all()
+
+    assert "No plots were generated" in window.log.toPlainText()


### PR DESCRIPTION
### Motivation
- The UI sometimes showed “No plots were generated” even though plot files existed because the GUI inferred success by scanning the output folder (older code looked for `*.svg`) instead of trusting what the worker actually saved.
- This fragile folder-glob approach produced false negatives (and confusing UX) when file naming/extension patterns differed from the glob used to detect outputs.
- Participant filename case differences (e.g., `p10`, `=p17`) were suspected, so we kept subject-ID parsing case-insensitive and added a regression test to confirm it.

### Description
- Make the worker emit an explicit result payload by changing `_Worker.finished` to emit a `dict` containing `generated_paths` and `failed_items` and accumulate those lists inside the worker (`_record_generated_path`, `_record_failure`).
- Record each successful `savefig(...)` output path in `generated_paths` and record structured failure entries when Excel/ROI/scalp reads fail, without altering plotting math or filenames.
- Add `_on_worker_finished(payload)` in `PlotGeneratorWindow` to accumulate worker-reported `generated_paths`/`failed_items` and log counts, and update `_finish_all()` to decide success using `len(generated_paths) > 0` and to show a partial-success warning when some items failed.
- Clear accumulated state between runs and wire the new finished handler into both single-condition and overlay worker flows; added tests in `tests/test_plot_generator_generation_outcome.py` for case-insensitive ID inference and finish/outcome behavior.

### Testing
- Ran `ruff` on the modified files (`src/Tools/Plot_Generator/gui.py`, `src/Tools/Plot_Generator/worker.py`, `tests/test_plot_generator_generation_outcome.py`) and the targeted check passed for those files.
- Attempted `pytest -q`, but test execution was blocked in this container by a PySide6 import error (`ImportError: libGL.so.1`), so the GUI tests were not executed here.
- Ran `python -m py_compile` on the changed modules and the new test file; compilation succeeded.
- Ran `mypy --strict` repository-wide and observed pre-existing type errors in unrelated legacy modules, so a full strict-type pass across the repo was not achievable in this environment; the changes themselves are confined and maintain the existing threading/signal contracts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3482deb8832c8f3a7c8db08ff2b7)