### PR TITLE
Add Fixed-harmonics-by-ROI DV policy, worker, UI plumbing and tests

### DIFF
--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -42,8 +42,10 @@ from Tools.Stats.Legacy.stats_analysis import (
     SUMMED_BCA_ODDBALL_EVERY_N_DEFAULT,
 )
 from Tools.Stats.PySide6.dv_policies import (
+    FIXED_SHARED_POLICY_NAME,
     ROSSION_POLICY_NAME,
     build_rossion_preview_payload,
+    compute_fixed_harmonic_dv_table,
     normalize_dv_policy,
     prepare_summed_bca_data,
 )
@@ -1293,6 +1295,40 @@ def run_shared_harmonics_worker(
         "selection_rule": "two_consecutive_z_gt_thresh",
     }
 
+
+
+def run_fixed_harmonic_dv_worker(
+    progress_cb,
+    message_cb,
+    *,
+    subjects,
+    conditions,
+    subject_data,
+    rois,
+    harmonics_by_roi,
+):
+    message_cb("Computing fixed-harmonic DV table from shared harmonics…")
+    progress_cb(10)
+
+    payload = compute_fixed_harmonic_dv_table(
+        subjects=list(subjects),
+        conditions=list(conditions),
+        subject_data=subject_data,
+        rois=rois,
+        harmonics_by_roi=harmonics_by_roi,
+        log_func=message_cb,
+    )
+    progress_cb(100)
+    message_cb("Fixed-harmonic DV table ready.")
+    return {
+        "dv_table": payload["dv_df"],
+        "harmonics_by_roi": payload["harmonics_by_roi"],
+        "missing_harmonics": payload["missing_harmonics"],
+        "dv_policy": {
+            "name": FIXED_SHARED_POLICY_NAME,
+            "harmonics_by_roi": payload["harmonics_by_roi"],
+        },
+    }
 
 def run_harmonic_check(
     progress_cb,

--- a/tests/test_stats_fixed_harmonics_dv.py
+++ b/tests/test_stats_fixed_harmonics_dv.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.PySide6.dv_policies import compute_fixed_harmonic_dv_table
+
+
+def _write_bca_excel(path: Path, rows: dict[str, dict[str, float]]) -> None:
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "Electrode"
+    with pd.ExcelWriter(path) as writer:
+        df.to_excel(writer, sheet_name="BCA (uV)")
+
+
+def test_fixed_harmonic_uses_existing_frequency_matching(tmp_path: Path) -> None:
+    file_path = tmp_path / "P1_CondA.xlsx"
+    _write_bca_excel(
+        file_path,
+        {
+            "O1": {"1.2000_Hz": 1.0, "2.4000_Hz": 2.5, "3.6000_Hz": 99.0},
+            "O2": {"1.2000_Hz": 2.0, "2.4000_Hz": 3.5, "3.6000_Hz": 99.0},
+        },
+    )
+
+    payload = compute_fixed_harmonic_dv_table(
+        subjects=["P1"],
+        conditions=["CondA"],
+        subject_data={"P1": {"CondA": str(file_path)}},
+        rois={"Occipital": ["O1", "O2"]},
+        harmonics_by_roi={"Occipital": [1.2, 2.4]},
+        log_func=lambda _msg: None,
+    )
+
+    out = payload["dv_df"]
+    assert out.shape[0] == 1
+    assert np.isclose(float(out.loc[0, "dv_value"]), 4.5)
+
+
+def test_fixed_harmonic_missing_column_returns_nan_and_reports(tmp_path: Path) -> None:
+    file_path = tmp_path / "P1_CondA.xlsx"
+    _write_bca_excel(
+        file_path,
+        {
+            "O1": {"1.2000_Hz": 1.0, "2.4000_Hz": 2.0},
+            "O2": {"1.2000_Hz": 1.5, "2.4000_Hz": 2.5},
+        },
+    )
+
+    payload = compute_fixed_harmonic_dv_table(
+        subjects=["P1"],
+        conditions=["CondA"],
+        subject_data={"P1": {"CondA": str(file_path)}},
+        rois={"Occipital": ["O1", "O2"]},
+        harmonics_by_roi={"Occipital": [1.2, 4.8]},
+        log_func=lambda _msg: None,
+    )
+
+    out = payload["dv_df"]
+    assert np.isnan(float(out.loc[0, "dv_value"]))
+    missing = payload["missing_harmonics"]
+    assert len(missing) == 1
+    assert missing[0]["missing_hz"] == [4.8]
+
+
+def test_fixed_harmonic_deterministic_ordering(tmp_path: Path) -> None:
+    file_path = tmp_path / "P1_CondA.xlsx"
+    _write_bca_excel(
+        file_path,
+        {
+            "O1": {"1.2000_Hz": 1.0, "2.4000_Hz": 2.0},
+            "O2": {"1.2000_Hz": 3.0, "2.4000_Hz": 4.0},
+        },
+    )
+    common_kwargs = dict(
+        subjects=["P1"],
+        conditions=["CondA"],
+        subject_data={"P1": {"CondA": str(file_path)}},
+        rois={"Occipital": ["O1", "O2"]},
+        log_func=lambda _msg: None,
+    )
+
+    p1 = compute_fixed_harmonic_dv_table(
+        harmonics_by_roi={"Occipital": [1.2, 2.4]},
+        **common_kwargs,
+    )
+    p2 = compute_fixed_harmonic_dv_table(
+        harmonics_by_roi={"Occipital": [2.4, 1.2]},
+        **common_kwargs,
+    )
+
+    assert list(p1["dv_df"].columns) == ["subject", "condition", "roi", "dv_value"]
+    pd.testing.assert_frame_equal(p1["dv_df"], p2["dv_df"])


### PR DESCRIPTION
### Motivation
- Implement Phase C DV policy to compute Summed BCA DV per ROI using an explicit `harmonics_by_roi` mapping produced by shared-harmonics (Phase B) without re-deriving harmonics per subject/group.
- Ensure the fixed-harmonics code reuses the repo's existing frequency-column matching and explicitly records/logs missing harmonic columns to avoid silent corruption.

### Description
- Added a new fixed-shared DV policy name `FIXED_SHARED_POLICY_NAME` and wired `prepare_summed_bca_data` to accept a `harmonics_by_roi` payload and route to a new fixed-harmonic data path in `src/Tools/Stats/PySide6/dv_policies.py`.
- Implemented pure-function API `compute_fixed_harmonic_dv_table(...)` and support routines (`_prepare_fixed_harmonics_by_roi_bca_data`, `_aggregate_bca_sum_harmonics_fixed`, `_normalize_harmonics_by_roi`) that reuse `_match_freq_column` for frequency-column matching and return both DV table and `missing_harmonics` metadata.
- Added a non-UI worker `run_fixed_harmonic_dv_worker` (signals-compatible) in `src/Tools/Stats/PySide6/stats_workers.py` and UI/controller plumbing in `src/Tools/Stats/PySide6/stats_main_window.py` to: pass shared harmonics into between-group DV payloads, add a read-only status summary, add a `Compute Fixed-harmonic DV` button, and disable it until shared harmonics are available.
- Implemented explicit missing-column behavior: when a requested harmonic column is absent the per-subject/condition/ROI DV is `NaN`, the missing Hz are recorded in returned metadata, and a structured warning with `subject/condition/ROI/missing_hz/file_path` is emitted via `log_func`.
- Files changed: `src/Tools/Stats/PySide6/dv_policies.py`, `src/Tools/Stats/PySide6/stats_workers.py`, `src/Tools/Stats/PySide6/stats_main_window.py`, and added tests `tests/test_stats_fixed_harmonics_dv.py`.

### Testing
- Updated environment and deps: `python -m pip install -U pip` and `python -m pip install -r requirements.txt` and verified `python -c "import numpy, pandas, PySide6, psutil; print('deps ok')"` (succeeded).
- Ran the Phase A/B tests and the new Phase C tests: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_multigroup_scan.py tests/test_stats_shared_harmonics.py tests/test_stats_fixed_harmonics_dv.py` and all tests passed.
- Ran focused Phase C test: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_fixed_harmonics_dv.py` and it passed.
- Ran repository test discovery: `QT_QPA_PLATFORM=offscreen python -m pytest -q --collect-only` (collect-only succeeded) and static checks: `python -m ruff check` on modified files (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b51892288832cb6d519c53c43e527)