### PR TITLE
Phase D: Between-group missingness rules, pipeline wiring, and export

### DIFF
--- a/src/Tools/Stats/PySide6/stats_controller.py
+++ b/src/Tools/Stats/PySide6/stats_controller.py
@@ -33,7 +33,7 @@ from .stats_data_loader import (
     scan_lela_phase_folder,
     ScanError,
 )
-from .stats_subjects import canonical_group_and_phase_from_manifest, canonical_group_label
+from .stats_subjects import canonical_group_label
 from Main_App.PySide6_App.Backend.project import EXCEL_SUBFOLDER_NAME, STATS_SUBFOLDER_NAME
 from .stats_run_report import StatsRunReport
 
@@ -139,8 +139,8 @@ SINGLE_PIPELINE_STEPS: Sequence[StepId] = (
 """Default ordered steps for the Single pipeline."""
 
 BETWEEN_PIPELINE_STEPS: Sequence[StepId] = (
-    StepId.BETWEEN_GROUP_ANOVA,
     StepId.BETWEEN_GROUP_MIXED_MODEL,
+    StepId.BETWEEN_GROUP_ANOVA,
     StepId.GROUP_CONTRASTS,
     StepId.HARMONIC_CHECK,
 )
@@ -590,26 +590,6 @@ class StatsController:
             },
         )
         self._view.append_log(self._section_label(pipeline_id), summary)
-
-        if (
-            pipeline_id is PipelineId.BETWEEN
-            and tuple(step_ids) == tuple(BETWEEN_PIPELINE_STEPS)
-        ):
-            try:
-                self._start_between_process_pipeline()
-            except Exception as exc:  # noqa: BLE001
-                logger.exception(
-                    "stats_between_process_start_failed",
-                    exc_info=True,
-                    extra={"pipeline": pipeline_id.name},
-                )
-                self._finalize_pipeline(
-                    pipeline_id,
-                    success=False,
-                    error_message=str(exc),
-                    exports_ran=False,
-                )
-            return
 
         try:
             self._run_next_step(pipeline_id)

--- a/src/Tools/Stats/PySide6/stats_missingness.py
+++ b/src/Tools/Stats/PySide6/stats_missingness.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from Tools.Stats.Legacy.stats_export import _auto_format_and_write_excel
+
+
+def _normalize_group(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return text
+
+
+def compute_missingness(
+    dv_table: pd.DataFrame,
+    required_conditions: list[str],
+    subject_to_group: dict[str, str | None],
+) -> list[dict[str, str]]:
+    """Return missing subject×condition cells for mixed-model reporting."""
+    if dv_table is None or dv_table.empty:
+        return []
+
+    required = [str(cond) for cond in required_conditions]
+    if not required:
+        return []
+
+    working = dv_table.copy()
+    if "value" in working.columns:
+        working = working.loc[working["value"].notna()].copy()
+
+    missing_rows: list[dict[str, str]] = []
+    subjects = sorted({str(subject) for subject in working.get("subject", pd.Series(dtype=str)).dropna().tolist()})
+
+    for subject in subjects:
+        subject_rows = working.loc[working["subject"].astype(str) == subject]
+        present = {str(cond) for cond in subject_rows.get("condition", pd.Series(dtype=str)).dropna().tolist()}
+        group_name = _normalize_group(subject_to_group.get(subject))
+        for condition in required:
+            if condition in present:
+                continue
+            missing_rows.append(
+                {
+                    "Subject": subject,
+                    "Group": group_name,
+                    "Condition": condition,
+                    "Status": "Missing",
+                    "Note": "Required condition cell absent; retained for mixed model.",
+                }
+            )
+
+    return missing_rows
+
+
+def compute_complete_case_subjects(
+    dv_table: pd.DataFrame,
+    required_conditions: list[str],
+    subject_to_group: dict[str, str | None],
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Return included complete-case subjects and explicit ANOVA exclusions."""
+    missing_rows = compute_missingness(
+        dv_table=dv_table,
+        required_conditions=required_conditions,
+        subject_to_group=subject_to_group,
+    )
+    missing_map: dict[str, list[str]] = {}
+    for row in missing_rows:
+        missing_map.setdefault(row["Subject"], []).append(row["Condition"])
+
+    subjects = sorted({str(subject) for subject in dv_table.get("subject", pd.Series(dtype=str)).dropna().tolist()})
+    included = [subject for subject in subjects if subject not in missing_map]
+
+    excluded_rows: list[dict[str, str]] = []
+    for subject in sorted(missing_map):
+        missing_conditions = sorted(set(missing_map[subject]))
+        excluded_rows.append(
+            {
+                "Subject": subject,
+                "Group": _normalize_group(subject_to_group.get(subject)),
+                "MissingConditions": ", ".join(missing_conditions),
+                "Reason": "Incomplete required condition cells for between-group ANOVA complete-case rule.",
+            }
+        )
+
+    return included, excluded_rows
+
+
+def build_missingness_export_tables(
+    *,
+    mixed_missing_rows: list[dict[str, str]],
+    anova_excluded_rows: list[dict[str, str]],
+    summary_rows: list[dict[str, Any]] | None = None,
+) -> dict[str, pd.DataFrame]:
+    summary_rows = summary_rows or []
+    return {
+        "ANOVA_ExcludedSubjects": pd.DataFrame(
+            anova_excluded_rows,
+            columns=["Subject", "Group", "MissingConditions", "Reason"],
+        ),
+        "MixedModel_MissingCells": pd.DataFrame(
+            mixed_missing_rows,
+            columns=["Subject", "Group", "Condition", "Status", "Note"],
+        ),
+        "Summary": pd.DataFrame(summary_rows),
+    }
+
+
+def export_missingness_workbook(
+    *,
+    save_path: str | Path,
+    mixed_missing_rows: list[dict[str, str]],
+    anova_excluded_rows: list[dict[str, str]],
+    summary_rows: list[dict[str, Any]] | None,
+    log_func,
+) -> Path:
+    tables = build_missingness_export_tables(
+        mixed_missing_rows=mixed_missing_rows,
+        anova_excluded_rows=anova_excluded_rows,
+        summary_rows=summary_rows,
+    )
+    save_path = Path(save_path)
+    with pd.ExcelWriter(save_path, engine="xlsxwriter") as writer:
+        for sheet_name, table in tables.items():
+            _auto_format_and_write_excel(writer, table, sheet_name, log_func)
+    return save_path

--- a/tests/test_stats_missingness_rules.py
+++ b/tests/test_stats_missingness_rules.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Stats.PySide6.stats_missingness import (
+    build_missingness_export_tables,
+    compute_complete_case_subjects,
+    compute_missingness,
+    export_missingness_workbook,
+)
+
+
+def _synthetic_dv_table() -> pd.DataFrame:
+    rows = [
+        {"subject": "P1", "group": "G1", "condition": "A", "roi": "ROI1", "value": 1.0},
+        {"subject": "P1", "group": "G1", "condition": "B", "roi": "ROI1", "value": 2.0},
+        {"subject": "P2", "group": "G1", "condition": "A", "roi": "ROI1", "value": 1.5},
+        {"subject": "P3", "group": "G2", "condition": "A", "roi": "ROI1", "value": 1.2},
+        {"subject": "P3", "group": "G2", "condition": "B", "roi": "ROI1", "value": 2.3},
+    ]
+    return pd.DataFrame(rows)
+
+
+def test_missingness_rules_complete_case_and_mixed() -> None:
+    dv_table = _synthetic_dv_table()
+    required_conditions = ["A", "B"]
+    subject_to_group = {"P1": "G1", "P2": "G1", "P3": "G2"}
+
+    mixed_missing = compute_missingness(dv_table, required_conditions, subject_to_group)
+    assert len(mixed_missing) == 1
+    assert mixed_missing[0]["Subject"] == "P2"
+    assert mixed_missing[0]["Condition"] == "B"
+
+    included, excluded = compute_complete_case_subjects(
+        dv_table,
+        required_conditions,
+        subject_to_group,
+    )
+    assert included == ["P1", "P3"]
+    assert len(excluded) == 1
+    assert excluded[0]["Subject"] == "P2"
+    assert excluded[0]["MissingConditions"] == "B"
+
+
+def test_missingness_export_tables_schema_and_workbook(tmp_path: Path) -> None:
+    mixed_missing = [
+        {
+            "Subject": "P2",
+            "Group": "G1",
+            "Condition": "B",
+            "Status": "Missing",
+            "Note": "Required condition cell absent; retained for mixed model.",
+        }
+    ]
+    anova_excluded = [
+        {
+            "Subject": "P2",
+            "Group": "G1",
+            "MissingConditions": "B",
+            "Reason": "Incomplete required condition cells for between-group ANOVA complete-case rule.",
+        }
+    ]
+    summary_rows = [{"Metric": "N groups", "Value": 2}]
+
+    tables = build_missingness_export_tables(
+        mixed_missing_rows=mixed_missing,
+        anova_excluded_rows=anova_excluded,
+        summary_rows=summary_rows,
+    )
+
+    assert list(tables["ANOVA_ExcludedSubjects"].columns) == [
+        "Subject",
+        "Group",
+        "MissingConditions",
+        "Reason",
+    ]
+    assert list(tables["MixedModel_MissingCells"].columns) == [
+        "Subject",
+        "Group",
+        "Condition",
+        "Status",
+        "Note",
+    ]
+
+    export_path = export_missingness_workbook(
+        save_path=tmp_path / "missingness.xlsx",
+        mixed_missing_rows=mixed_missing,
+        anova_excluded_rows=anova_excluded,
+        summary_rows=summary_rows,
+        log_func=lambda _msg: None,
+    )
+    assert export_path.exists()
+    sheets = pd.ExcelFile(export_path).sheet_names
+    assert "ANOVA_ExcludedSubjects" in sheets
+    assert "MixedModel_MissingCells" in sheets
+    assert "Summary" in sheets


### PR DESCRIPTION
### Motivation
- Enforce Phase D pipeline order and ensure between-group runs only when prerequisites (multi-group readiness, shared harmonics, fixed-harmonic DV) are available. 
- Make missingness rules explicit and auditable for both the Mixed Model (retain incomplete rows) and ANOVA (complete-case drop with reasons). 
- Provide a stable Excel export of missingness/exclusions using existing Excel styling helpers and make the logic testable without Qt.

### Description
- Added a new helper module `src/Tools/Stats/PySide6/stats_missingness.py` that implements `compute_missingness`, `compute_complete_case_subjects`, `build_missingness_export_tables`, and `export_missingness_workbook` (uses existing `_auto_format_and_write_excel`).
- Wired between-group workers so `run_between_group_anova` and `run_lmm` can consume an optional fixed-harmonic DV table, apply Phase D missingness rules, and return a `missingness` payload (ANOVA exclusions and mixed-model missing cells). 
- Reordered the default between pipeline in `StatsController` to run the Mixed Model before ANOVA and removed the process fast-path to preserve the strict step ordering. 
- Updated UI/controller (`stats_main_window.py`) to hard-stop the between run with non-blocking status/log messages if prerequisites are missing, aggregate worker `missingness` payloads into `_between_missingness_payload`, export `Missingness and Exclusions.xlsx`, and append a concise post-run summary line.

### Testing
- Ran gated Phase A/B/C + Phase D tests: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_multigroup_scan.py tests/test_stats_shared_harmonics.py tests/test_stats_fixed_harmonics_dv.py tests/test_stats_missingness_rules.py`, all tests passed (13 passed).
- Ran full collection: `QT_QPA_PLATFORM=offscreen python -m pytest -q --collect-only`, collection succeeded (204 items collected).
- Ran linter: `python -m ruff check` on modified files (specified files) and fixed issues; linter returned no errors.
- Added `tests/test_stats_missingness_rules.py` with synthetic DV fixtures validating that ANOVA complete-case exclusions are derived, mixed-model retains incomplete rows and records missing cells, and the export workbook schema is correct; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b54ce5f18832c96289afb60784fac)