### PR TITLE
Phase E: add stable N-group pairwise contrasts export

### DIFF
--- a/src/Tools/Stats/PySide6/stats_group_contrasts.py
+++ b/src/Tools/Stats/PySide6/stats_group_contrasts.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.Legacy.stats_export import _auto_format_and_write_excel
+
+PAIRWISE_CONTRAST_COLUMNS: tuple[str, ...] = (
+    "ModelType",
+    "ROI",
+    "Condition",
+    "GroupA",
+    "GroupB",
+    "Estimate",
+    "SE",
+    "TestStat",
+    "DF",
+    "P",
+    "P_corrected",
+    "Method",
+)
+
+
+def normalize_group_contrasts_table(results_df: pd.DataFrame) -> pd.DataFrame:
+    """Return a stable, export-friendly pairwise-contrasts table.
+
+    Preserves existing legacy columns and prepends the normalized schema used by
+    between-group exports.
+    """
+
+    if not isinstance(results_df, pd.DataFrame):
+        return pd.DataFrame(columns=PAIRWISE_CONTRAST_COLUMNS)
+
+    if results_df.empty:
+        return pd.DataFrame(columns=PAIRWISE_CONTRAST_COLUMNS)
+
+    df = results_df.copy()
+
+    if "condition" not in df.columns:
+        df["condition"] = ""
+    if "roi" not in df.columns:
+        df["roi"] = ""
+
+    corrected_source = "p_fdr_bh" if "p_fdr_bh" in df.columns else "p_value"
+    method = "fdr_bh" if corrected_source == "p_fdr_bh" else "none"
+
+    normalized = pd.DataFrame(
+        {
+            "ModelType": "Welch_ttest",
+            "ROI": df["roi"],
+            "Condition": df["condition"],
+            "GroupA": df.get("group_1", ""),
+            "GroupB": df.get("group_2", ""),
+            "Estimate": df.get("difference", np.nan),
+            "SE": np.nan,
+            "TestStat": df.get("t_stat", np.nan),
+            "DF": np.nan,
+            "P": df.get("p_value", np.nan),
+            "P_corrected": df.get(corrected_source, np.nan),
+            "Method": method,
+        }
+    )
+
+    normalized["ROI"] = normalized["ROI"].astype(str)
+    normalized["Condition"] = normalized["Condition"].astype(str)
+    normalized["GroupA"] = normalized["GroupA"].astype(str)
+    normalized["GroupB"] = normalized["GroupB"].astype(str)
+
+    normalized = normalized.sort_values(
+        by=["ROI", "Condition", "GroupA", "GroupB"],
+        kind="mergesort",
+    ).reset_index(drop=True)
+
+    legacy_sorted = df.sort_values(
+        by=["roi", "condition", "group_1", "group_2"],
+        kind="mergesort",
+    ).reset_index(drop=True)
+
+    out = pd.concat([normalized, legacy_sorted], axis=1)
+    ordered_columns = list(PAIRWISE_CONTRAST_COLUMNS) + [
+        col for col in out.columns if col not in PAIRWISE_CONTRAST_COLUMNS
+    ]
+    return out.loc[:, ordered_columns]
+
+
+def export_group_contrasts_workbook(results_df: pd.DataFrame, save_path: str | Path, log_func) -> bool:
+    if results_df is None or not isinstance(results_df, pd.DataFrame) or results_df.empty:
+        raise ValueError("No Group Contrasts results data available to export.")
+
+    export_table = normalize_group_contrasts_table(results_df)
+    with pd.ExcelWriter(Path(save_path), engine="xlsxwriter") as writer:
+        _auto_format_and_write_excel(writer, export_table, "Pairwise_Contrasts", log_func)
+    return True

--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -91,6 +91,7 @@ from Tools.Stats.PySide6.stats_data_loader import (
 )
 from Tools.Stats.PySide6.stats_logging import format_log_line, format_section_header
 from Tools.Stats.PySide6.stats_missingness import export_missingness_workbook
+from Tools.Stats.PySide6.stats_group_contrasts import export_group_contrasts_workbook
 from Tools.Stats.PySide6.stats_workers import StatsWorker
 from Tools.Stats.PySide6 import stats_workers as stats_worker_funcs
 from Tools.Stats.PySide6.dv_policies import (
@@ -1330,7 +1331,7 @@ class StatsWindow(QMainWindow):
             "harmonic": (export_harmonic_results_to_excel, HARMONIC_XLS),
             "anova_between": (export_rm_anova_results_to_excel, ANOVA_BETWEEN_XLS),
             "lmm_between": (export_mixed_model_results_to_excel, LMM_BETWEEN_XLS),
-            "group_contrasts": (export_posthoc_results_to_excel, GROUP_CONTRAST_XLS),
+            "group_contrasts": (export_group_contrasts_workbook, GROUP_CONTRAST_XLS),
         }
         func, fname = mapping[kind]
 

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -50,6 +50,7 @@ from Tools.Stats.PySide6.dv_policies import (
     prepare_summed_bca_data,
 )
 from Tools.Stats.PySide6.dv_variants import compute_dv_variants_payload
+from Tools.Stats.PySide6.stats_group_contrasts import normalize_group_contrasts_table
 from Tools.Stats.PySide6.stats_missingness import compute_complete_case_subjects, compute_missingness
 from Tools.Stats.PySide6.shared_harmonics import (
     DEFAULT_Z_THRESH,
@@ -1272,6 +1273,7 @@ def run_group_contrasts(
         roi_col="roi",
         dv_col="value",
     )
+    results_df = normalize_group_contrasts_table(results_df)
     return {
         "results_df": results_df,
         "output_text": "",

--- a/tests/test_stats_n_group_contrasts.py
+++ b/tests/test_stats_n_group_contrasts.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Stats.Legacy.group_contrasts import compute_group_contrasts
+from Tools.Stats.PySide6.stats_group_contrasts import (
+    PAIRWISE_CONTRAST_COLUMNS,
+    export_group_contrasts_workbook,
+    normalize_group_contrasts_table,
+)
+
+
+def _build_long_df(groups: tuple[str, ...]) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for condition in ("Cond1",):
+        for roi in ("ROI1",):
+            for group_idx, group in enumerate(groups):
+                for subject_offset, value in enumerate((1.0 + group_idx, 2.0 + group_idx)):
+                    rows.append(
+                        {
+                            "subject": f"{group}_S{subject_offset+1}",
+                            "group": group,
+                            "condition": condition,
+                            "roi": roi,
+                            "value": value,
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def test_n3_generates_all_pairs_stable_order_and_schema() -> None:
+    data = _build_long_df(("A", "B", "C"))
+    raw = compute_group_contrasts(
+        data,
+        subject_col="subject",
+        group_col="group",
+        condition_col="condition",
+        roi_col="roi",
+        dv_col="value",
+    )
+
+    normalized = normalize_group_contrasts_table(raw)
+
+    assert len(normalized) == 3
+    assert normalized.loc[:, "GroupA"].tolist() == ["A", "A", "B"]
+    assert normalized.loc[:, "GroupB"].tolist() == ["B", "C", "C"]
+    assert list(normalized.columns[: len(PAIRWISE_CONTRAST_COLUMNS)]) == list(PAIRWISE_CONTRAST_COLUMNS)
+
+
+def test_correction_column_present_and_populated() -> None:
+    data = _build_long_df(("A", "B", "C"))
+    raw = compute_group_contrasts(
+        data,
+        subject_col="subject",
+        group_col="group",
+        condition_col="condition",
+        roi_col="roi",
+        dv_col="value",
+    )
+
+    normalized = normalize_group_contrasts_table(raw)
+
+    assert "P_corrected" in normalized.columns
+    assert normalized["P_corrected"].notna().all()
+    assert (normalized["Method"] == "fdr_bh").all()
+
+
+def test_two_group_case_matches_pre_phase_e_values() -> None:
+    data = _build_long_df(("A", "B"))
+    raw = compute_group_contrasts(
+        data,
+        subject_col="subject",
+        group_col="group",
+        condition_col="condition",
+        roi_col="roi",
+        dv_col="value",
+    )
+    normalized = normalize_group_contrasts_table(raw)
+
+    assert len(normalized) == 1
+    assert normalized.loc[0, "GroupA"] == raw.loc[0, "group_1"]
+    assert normalized.loc[0, "GroupB"] == raw.loc[0, "group_2"]
+    assert normalized.loc[0, "Estimate"] == raw.loc[0, "difference"]
+    assert normalized.loc[0, "TestStat"] == raw.loc[0, "t_stat"]
+    assert normalized.loc[0, "P"] == raw.loc[0, "p_value"]
+    assert normalized.loc[0, "P_corrected"] == raw.loc[0, "p_fdr_bh"]
+
+
+def test_export_uses_pairwise_contrasts_sheet(tmp_path: Path) -> None:
+    data = _build_long_df(("A", "B", "C"))
+    raw = compute_group_contrasts(
+        data,
+        subject_col="subject",
+        group_col="group",
+        condition_col="condition",
+        roi_col="roi",
+        dv_col="value",
+    )
+    save_path = tmp_path / "Group Contrasts.xlsx"
+
+    export_group_contrasts_workbook(raw, save_path, log_func=lambda _msg: None)
+
+    xls = pd.ExcelFile(save_path)
+    assert "Pairwise_Contrasts" in xls.sheet_names
+    exported = pd.read_excel(save_path, sheet_name="Pairwise_Contrasts")
+    assert list(exported.columns[: len(PAIRWISE_CONTRAST_COLUMNS)]) == list(PAIRWISE_CONTRAST_COLUMNS)


### PR DESCRIPTION
### Motivation
- Support N-group between-group contrasts (all unordered pairs) and provide a stable, deterministic export schema for downstream tools. 
- Preserve existing contrast computation and correction behavior (do not refit models or change the repo's correction method). 
- Provide a stable Excel sheet (`Pairwise_Contrasts`) and keep legacy fields for backward compatibility.

### Description
- Added `src/Tools/Stats/PySide6/stats_group_contrasts.py` which provides `normalize_group_contrasts_table` and `export_group_contrasts_workbook` to produce a deterministic schema with columns `ModelType | ROI | Condition | GroupA | GroupB | Estimate | SE | TestStat | DF | P | P_corrected | Method` and reuse existing Excel formatting helpers. 
- Normalized group-contrast tables are produced inside the worker pipeline by calling `normalize_group_contrasts_table` before results are returned (`src/Tools/Stats/PySide6/stats_workers.py`). 
- Updated export plumbing to use the dedicated workbook exporter for `group_contrasts`, ensuring the `Pairwise_Contrasts` sheet is written (`src/Tools/Stats/PySide6/stats_main_window.py`). 
- Added unit tests `tests/test_stats_n_group_contrasts.py` to validate N=3 pair generation/order, presence of corrected p-values and `P_corrected` column, deterministic schema, two-group parity with legacy values, and correct sheet naming.

### Testing
- Ran prior-phase gated tests with `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_multigroup_scan.py tests/test_stats_shared_harmonics.py tests/test_stats_fixed_harmonics_dv.py tests/test_stats_missingness_rules.py` and all tests passed (`13 passed`).
- Ran Phase E tests with `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_n_group_contrasts.py` and they passed (`4 passed`).
- Ran a baseline collection with `QT_QPA_PLATFORM=offscreen python -m pytest -q --collect-only` which collected the test suite successfully (`208 tests collected`).
- Ran linter with `ruff` on changed files and it reported no issues (`ruff check` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b59ff3784832c98c727813815a842)