### PR TITLE
Add per-group QC/Context workbook export for fixed-harmonic DV and Phase-F regression smoke tests

### DIFF
--- a/src/Tools/Stats/PySide6/stats_qc_reports.py
+++ b/src/Tools/Stats/PySide6/stats_qc_reports.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.Legacy.stats_export import _auto_format_and_write_excel
+
+
+QC_SUMMARY_COLUMNS: tuple[str, ...] = (
+    "Group",
+    "N_subjects",
+    "N_rows",
+    "DV_missing_rows",
+    "DV_missing_harmonics_count",
+    "N_conditions",
+    "N_rois",
+)
+
+QC_DISTRIBUTION_COLUMNS: tuple[str, ...] = (
+    "Group",
+    "ROI",
+    "mean",
+    "sd",
+    "median",
+    "IQR",
+    "min",
+    "max",
+    "n_nonmissing",
+)
+
+QC_SUBJECT_LEVEL_COLUMNS: tuple[str, ...] = (
+    "Group",
+    "Subject",
+    "Condition",
+    "ROI",
+    "DV_value",
+    "Flags",
+)
+
+
+def _normalize_group(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _coerce_fixed_dv_table(dv_table: pd.DataFrame) -> pd.DataFrame:
+    if not isinstance(dv_table, pd.DataFrame) or dv_table.empty:
+        return pd.DataFrame(columns=["subject", "condition", "roi", "value"])
+
+    table = dv_table.copy()
+    if "value" not in table.columns and "dv_value" in table.columns:
+        table = table.rename(columns={"dv_value": "value"})
+
+    for col in ("subject", "condition", "roi"):
+        if col not in table.columns:
+            table[col] = ""
+
+    table["subject"] = table["subject"].astype(str)
+    table["condition"] = table["condition"].astype(str)
+    table["roi"] = table["roi"].astype(str)
+    table["value"] = pd.to_numeric(table.get("value"), errors="coerce")
+    return table[["subject", "condition", "roi", "value"]]
+
+
+def build_qc_context_tables(
+    *,
+    dv_table: pd.DataFrame,
+    subject_to_group: dict[str, str | None],
+    missing_harmonics_rows: list[dict[str, object]] | None = None,
+    flagged_pid_map: dict[str, list[str]] | None = None,
+) -> dict[str, pd.DataFrame]:
+    """Build stable QC/context report tables from the fixed-harmonic DV table."""
+
+    fixed = _coerce_fixed_dv_table(dv_table)
+    flagged_pid_map = flagged_pid_map or {}
+    missing_harmonics_rows = missing_harmonics_rows or []
+
+    if fixed.empty:
+        return {
+            "Summary": pd.DataFrame(columns=QC_SUMMARY_COLUMNS),
+            "DV_Distribution": pd.DataFrame(columns=QC_DISTRIBUTION_COLUMNS),
+            "Subject_Level": pd.DataFrame(columns=QC_SUBJECT_LEVEL_COLUMNS),
+        }
+
+    fixed = fixed.copy()
+    fixed["Group"] = fixed["subject"].map(lambda pid: _normalize_group(subject_to_group.get(str(pid))))
+    fixed["Flags"] = fixed["subject"].map(lambda pid: "; ".join(flagged_pid_map.get(str(pid), [])))
+
+    missing_by_group: dict[str, int] = {}
+    for row in missing_harmonics_rows:
+        subject = str(row.get("subject", ""))
+        group = _normalize_group(subject_to_group.get(subject))
+        missing_by_group[group] = missing_by_group.get(group, 0) + 1
+
+    summary_rows: list[dict[str, object]] = []
+    for group, group_df in fixed.groupby("Group", dropna=False):
+        group_name = _normalize_group(group)
+        summary_rows.append(
+            {
+                "Group": group_name,
+                "N_subjects": int(group_df["subject"].nunique()),
+                "N_rows": int(len(group_df)),
+                "DV_missing_rows": int(group_df["value"].isna().sum()),
+                "DV_missing_harmonics_count": int(missing_by_group.get(group_name, 0)),
+                "N_conditions": int(group_df["condition"].nunique()),
+                "N_rois": int(group_df["roi"].nunique()),
+            }
+        )
+    summary_df = pd.DataFrame(summary_rows).sort_values(["Group"], kind="stable")
+    summary_df = summary_df.reindex(columns=QC_SUMMARY_COLUMNS)
+
+    dist_rows: list[dict[str, object]] = []
+    grouped = fixed.groupby(["Group", "roi"], dropna=False)
+    for (group, roi), slice_df in grouped:
+        values = pd.to_numeric(slice_df["value"], errors="coerce").dropna()
+        iqr = float(values.quantile(0.75) - values.quantile(0.25)) if not values.empty else np.nan
+        dist_rows.append(
+            {
+                "Group": _normalize_group(group),
+                "ROI": str(roi),
+                "mean": float(values.mean()) if not values.empty else np.nan,
+                "sd": float(values.std(ddof=1)) if len(values) > 1 else np.nan,
+                "median": float(values.median()) if not values.empty else np.nan,
+                "IQR": iqr,
+                "min": float(values.min()) if not values.empty else np.nan,
+                "max": float(values.max()) if not values.empty else np.nan,
+                "n_nonmissing": int(values.size),
+            }
+        )
+    distribution_df = pd.DataFrame(dist_rows).sort_values(["Group", "ROI"], kind="stable")
+    distribution_df = distribution_df.reindex(columns=QC_DISTRIBUTION_COLUMNS)
+
+    subject_level_df = fixed.rename(
+        columns={
+            "subject": "Subject",
+            "condition": "Condition",
+            "roi": "ROI",
+            "value": "DV_value",
+        }
+    )[["Group", "Subject", "Condition", "ROI", "DV_value", "Flags"]]
+    subject_level_df = subject_level_df.sort_values(
+        ["Group", "Subject", "Condition", "ROI"], kind="stable"
+    )
+
+    return {
+        "Summary": summary_df,
+        "DV_Distribution": distribution_df,
+        "Subject_Level": subject_level_df,
+    }
+
+
+def export_qc_context_workbook(
+    *,
+    save_path: str | Path,
+    dv_table: pd.DataFrame,
+    subject_to_group: dict[str, str | None],
+    missing_harmonics_rows: list[dict[str, object]] | None,
+    flagged_pid_map: dict[str, list[str]] | None,
+    log_func,
+) -> Path:
+    tables = build_qc_context_tables(
+        dv_table=dv_table,
+        subject_to_group=subject_to_group,
+        missing_harmonics_rows=missing_harmonics_rows,
+        flagged_pid_map=flagged_pid_map,
+    )
+
+    save_path = Path(save_path)
+    with pd.ExcelWriter(save_path, engine="xlsxwriter") as writer:
+        for sheet_name, table in tables.items():
+            _auto_format_and_write_excel(writer, table, sheet_name, log_func)
+    return save_path

--- a/tests/test_stats_multigroup_e2e_smoke.py
+++ b/tests/test_stats_multigroup_e2e_smoke.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Stats.Legacy.group_contrasts import compute_group_contrasts
+from Tools.Stats.PySide6.dv_policies import compute_fixed_harmonic_dv_table
+from Tools.Stats.PySide6.stats_group_contrasts import normalize_group_contrasts_table
+from Tools.Stats.PySide6.stats_missingness import compute_complete_case_subjects, compute_missingness
+from Tools.Stats.PySide6.stats_workers import run_between_group_anova, run_lmm
+
+
+def _write_bca_excel(path: Path, value_a: float, value_b: float) -> None:
+    df = pd.DataFrame(
+        {
+            "1.2000_Hz": [value_a, value_a + 0.1],
+            "2.4000_Hz": [value_b, value_b + 0.1],
+            "3.6000_Hz": [999.0, 999.0],
+        },
+        index=["O1", "O2"],
+    )
+    df.index.name = "Electrode"
+    with pd.ExcelWriter(path) as writer:
+        df.to_excel(writer, sheet_name="BCA (uV)")
+
+
+def _build_fixed_dv_payload(tmp_path: Path) -> tuple[pd.DataFrame, dict[str, str]]:
+    groups = {
+        "P1": "G1",
+        "P2": "G1",
+        "P3": "G1",
+        "P4": "G2",
+        "P5": "G2",
+        "P6": "G2",
+        "P7": "G3",
+        "P8": "G3",
+        "P9": "G3",
+    }
+    subject_data: dict[str, dict[str, str]] = {}
+    for idx, pid in enumerate(groups, start=1):
+        subject_data[pid] = {}
+        for cond in ("A", "B"):
+            if pid == "P3" and cond == "B":
+                continue
+            excel_path = tmp_path / f"{pid}_{cond}.xlsx"
+            _write_bca_excel(excel_path, value_a=0.5 * idx, value_b=0.8 * idx)
+            subject_data[pid][cond] = str(excel_path)
+
+    payload = compute_fixed_harmonic_dv_table(
+        subjects=list(groups.keys()),
+        conditions=["A", "B"],
+        subject_data=subject_data,
+        rois={"ROI1": ["O1", "O2"]},
+        harmonics_by_roi={"ROI1": [1.2, 2.4]},
+        log_func=lambda _msg: None,
+    )
+    dv_df = payload["dv_df"].copy()
+    dv_df["group"] = dv_df["subject"].map(groups)
+    return dv_df, groups
+
+
+def test_multigroup_end_to_end_smoke_with_fixed_dv(tmp_path: Path) -> None:
+    dv_df, groups = _build_fixed_dv_payload(tmp_path)
+    dv_df = dv_df.loc[~((dv_df["subject"] == "P3") & (dv_df["condition"] == "B"))].copy()
+
+    missing = compute_missingness(dv_df, ["A", "B"], groups)
+    assert any(row["Subject"] == "P3" and row["Condition"] == "B" for row in missing)
+
+    included, excluded = compute_complete_case_subjects(dv_df, ["A", "B"], groups)
+    assert "P3" not in included
+    assert any(row["Subject"] == "P3" for row in excluded)
+
+    mixed_payload = run_lmm(
+        lambda _progress: None,
+        lambda _message: None,
+        subjects=sorted(groups),
+        conditions=["A", "B"],
+        conditions_all=["A", "B"],
+        subject_data={},
+        base_freq=6.0,
+        alpha=0.05,
+        rois={"ROI1": ["O1", "O2"]},
+        rois_all={"ROI1": ["O1", "O2"]},
+        include_group=True,
+        subject_groups=groups,
+        subject_to_group=groups,
+        fixed_harmonic_dv_table=dv_df,
+        required_conditions=["A", "B"],
+    )
+    assert "mixed_results_df" in mixed_payload
+    assert mixed_payload["missingness"]["mixed_model_subject_count"] >= 8
+
+    anova_payload = run_between_group_anova(
+        lambda _progress: None,
+        lambda _message: None,
+        subjects=sorted(groups),
+        conditions=["A", "B"],
+        conditions_all=["A", "B"],
+        subject_data={},
+        base_freq=6.0,
+        rois={"ROI1": ["O1", "O2"]},
+        rois_all={"ROI1": ["O1", "O2"]},
+        subject_groups=groups,
+        subject_to_group=groups,
+        fixed_harmonic_dv_table=dv_df,
+        required_conditions=["A", "B"],
+    )
+    assert any(row["Subject"] == "P3" for row in anova_payload["missingness"]["anova_excluded_subjects"])
+
+    normalized = normalize_group_contrasts_table(
+        compute_group_contrasts(
+            dv_df.rename(columns={"dv_value": "value"}),
+            subject_col="subject",
+            group_col="group",
+            condition_col="condition",
+            roi_col="roi",
+            dv_col="value",
+        )
+    )
+    assert {"G1", "G2", "G3"}.issuperset(set(normalized["GroupA"]))
+    assert len(normalized) >= 3
+
+
+def test_single_group_fixed_dv_regression_schema_stable(tmp_path: Path) -> None:
+    dv_df, groups = _build_fixed_dv_payload(tmp_path)
+    single_df = dv_df[dv_df["subject"].isin(["P1", "P2", "P3"])].copy()
+
+    payload = run_lmm(
+        lambda _progress: None,
+        lambda _message: None,
+        subjects=["P1", "P2", "P3"],
+        conditions=["A", "B"],
+        conditions_all=["A", "B"],
+        subject_data={},
+        base_freq=6.0,
+        alpha=0.05,
+        rois={"ROI1": ["O1", "O2"]},
+        rois_all={"ROI1": ["O1", "O2"]},
+        include_group=False,
+        subject_groups={pid: groups[pid] for pid in ["P1", "P2", "P3"]},
+        fixed_harmonic_dv_table=single_df,
+    )
+
+    assert set(["subject", "condition", "roi", "dv_value"]).issubset(single_df.columns)
+    assert "missingness" in payload
+    assert payload["missingness"] == {}
+    assert "mixed_results_df" in payload

--- a/tests/test_stats_qc_reports.py
+++ b/tests/test_stats_qc_reports.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Stats.PySide6.stats_qc_reports import (
+    QC_DISTRIBUTION_COLUMNS,
+    QC_SUBJECT_LEVEL_COLUMNS,
+    QC_SUMMARY_COLUMNS,
+    build_qc_context_tables,
+    export_qc_context_workbook,
+)
+
+
+def _fixed_dv_df() -> pd.DataFrame:
+    rows = [
+        {"subject": "P1", "condition": "A", "roi": "ROI1", "dv_value": 1.0},
+        {"subject": "P1", "condition": "B", "roi": "ROI1", "dv_value": 2.0},
+        {"subject": "P2", "condition": "A", "roi": "ROI1", "dv_value": 3.0},
+        {"subject": "P2", "condition": "B", "roi": "ROI1", "dv_value": None},
+        {"subject": "P3", "condition": "A", "roi": "ROI1", "dv_value": 4.0},
+        {"subject": "P3", "condition": "B", "roi": "ROI1", "dv_value": 5.0},
+    ]
+    return pd.DataFrame(rows)
+
+
+def test_build_qc_context_tables_schema_and_stats() -> None:
+    dv_df = _fixed_dv_df()
+    subject_to_group = {"P1": "G1", "P2": "G1", "P3": "G2"}
+    missing_harmonics = [
+        {"subject": "P2", "condition": "B", "roi": "ROI1", "missing_hz": [2.4]},
+        {"subject": "P3", "condition": "A", "roi": "ROI1", "missing_hz": [2.4]},
+    ]
+
+    tables = build_qc_context_tables(
+        dv_table=dv_df,
+        subject_to_group=subject_to_group,
+        missing_harmonics_rows=missing_harmonics,
+        flagged_pid_map={"P2": ["DV_NONFINITE"]},
+    )
+
+    assert list(tables["Summary"].columns) == list(QC_SUMMARY_COLUMNS)
+    assert list(tables["DV_Distribution"].columns) == list(QC_DISTRIBUTION_COLUMNS)
+    assert list(tables["Subject_Level"].columns) == list(QC_SUBJECT_LEVEL_COLUMNS)
+
+    summary = tables["Summary"].set_index("Group")
+    assert int(summary.loc["G1", "N_subjects"]) == 2
+    assert int(summary.loc["G1", "DV_missing_rows"]) == 1
+    assert int(summary.loc["G1", "DV_missing_harmonics_count"]) == 1
+    assert int(summary.loc["G2", "DV_missing_harmonics_count"]) == 1
+
+    dist = tables["DV_Distribution"]
+    g1 = dist[(dist["Group"] == "G1") & (dist["ROI"] == "ROI1")].iloc[0]
+    assert int(g1["n_nonmissing"]) == 3
+    assert float(g1["median"]) == 2.0
+
+    subject_level = tables["Subject_Level"]
+    flagged_row = subject_level[(subject_level["Subject"] == "P2") & (subject_level["Condition"] == "A")].iloc[0]
+    assert flagged_row["Flags"] == "DV_NONFINITE"
+
+
+def test_export_qc_context_workbook(tmp_path: Path) -> None:
+    dv_df = _fixed_dv_df()
+    export_path = export_qc_context_workbook(
+        save_path=tmp_path / "QC_Context_ByGroup.xlsx",
+        dv_table=dv_df,
+        subject_to_group={"P1": "G1", "P2": "G1", "P3": "G2"},
+        missing_harmonics_rows=[],
+        flagged_pid_map={},
+        log_func=lambda _msg: None,
+    )
+
+    assert export_path.exists()
+    sheets = pd.ExcelFile(export_path).sheet_names
+    assert sheets == ["Summary", "DV_Distribution", "Subject_Level"]


### PR DESCRIPTION
### Motivation
- Provide auditable, stable QC/context reports per group that reuse the fixed-harmonic DV table from Phase C without re-deriving harmonics or changing DV computation.
- Expose a minimal read-only UI export so downstream reporting can consume a `QC_Context_ByGroup.xlsx` workbook alongside existing exports.

### Description
- Add `src/Tools/Stats/PySide6/stats_qc_reports.py` implementing `build_qc_context_tables` and `export_qc_context_workbook` to produce `Summary`, `DV_Distribution`, and `Subject_Level` tables from a fixed-harmonic DV table and optional flagged/missing metadata.
- Wire a UI export path in `src/Tools/Stats/PySide6/stats_main_window.py` by importing `export_qc_context_workbook`, enabling an advanced action `Export QC Context (By Group)`, adding `_export_qc_context_by_group` and `on_export_qc_context_by_group`, and including the QC workbook in the between-group export bundle while gating the button on fixed-DV availability.
- Add tests: `tests/test_stats_qc_reports.py` verifies table schemas, statistics and workbook sheets, and `tests/test_stats_multigroup_e2e_smoke.py` provides a Phase F end-to-end smoke that exercises fixed-DV → missingness → mixed model → between-group ANOVA → contrasts; a single-group regression check is included.
- Reuse existing Excel auto-format helpers (`_auto_format_and_write_excel`) and do not modify any files under `Tools/Stats/Legacy/**`.

### Testing
- Preflight steps executed successfully: `python -m pip install -U pip`, `python -m pip install -r requirements.txt`, and `python -c "import numpy, pandas, PySide6, psutil; print('deps ok')"` returned `deps ok`.
- Prior-phase gating tests were run and passed: `tests/test_stats_multigroup_scan.py`, `tests/test_stats_shared_harmonics.py`, `tests/test_stats_fixed_harmonics_dv.py`, `tests/test_stats_missingness_rules.py`, and `tests/test_stats_n_group_contrasts.py` (all passed).
- Phase F tests were run and passed: `tests/test_stats_qc_reports.py` and `tests/test_stats_multigroup_e2e_smoke.py` (both passed).
- Baseline checks run: `pytest --collect-only` completed and `ruff` was executed against the changed files with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5cc95d2c832cb3ce885161233d9e)