### PR TITLE
Between-group shared harmonics: pooled ROI-Z (Van der Donck) selection

### DIFF
--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1354,11 +1354,16 @@ def run_shared_harmonics_worker(
 
     return {
         "harmonics_by_roi": result.harmonics_by_roi,
+        "strict_intersection_harmonics_by_roi": result.strict_intersection_harmonics_by_roi,
         "exclude_harmonic1_applied": result.exclude_harmonic1_applied,
         "z_thresh": result.z_thresh,
         "conditions_used": result.conditions_used,
         "condition_harmonics_by_roi": result.condition_harmonics_by_roi,
         "mean_z_by_condition": result.mean_z_by_condition,
+        "pooled_mean_z_table": result.pooled_mean_z_table,
+        "z_sheet_used": result.z_sheet_used,
+        "condition_combination_rule_used": result.condition_combination_rule_used,
+        "diagnostics": result.diagnostics,
         "export_path": str(exported_path),
         "selection_rule": "two_consecutive_z_gt_thresh",
     }

--- a/tests/test_stats_shared_harmonics_pooled_roi_z.py
+++ b/tests/test_stats_shared_harmonics_pooled_roi_z.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from Tools.Stats.Legacy.stats_analysis import _match_freq_column
+from Tools.Stats.PySide6.shared_harmonics import (
+    CONDITION_COMBINATION_RULE,
+    compute_shared_harmonics,
+)
+
+
+def _write_z_workbook(path: Path, *, sheet_name: str, rows: dict[str, dict[str, float]]) -> None:
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "Electrode"
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        df.to_excel(writer, sheet_name=sheet_name)
+
+
+def _build_subject_data(tmp_path: Path, values: dict[str, dict[str, dict[str, dict[str, float]]]]) -> tuple[list[str], dict[str, dict[str, str]]]:
+    subject_data: dict[str, dict[str, str]] = {}
+    subjects = sorted(values.keys())
+    for subject, cond_map in values.items():
+        subject_data[subject] = {}
+        for condition, z_rows in cond_map.items():
+            workbook = tmp_path / f"{subject}_{condition}.xlsx"
+            _write_z_workbook(workbook, sheet_name="Z Scores", rows=z_rows)
+            subject_data[subject][condition] = str(workbook)
+    return subjects, subject_data
+
+
+def _run_compute(subjects, subject_data, *, conditions: list[str]):
+    return compute_shared_harmonics(
+        subjects=subjects,
+        conditions=conditions,
+        subject_data=subject_data,
+        base_freq=6.0,
+        rois={"Occ": ["O1", "O2"]},
+        exclude_harmonic1=False,
+        z_threshold=1.64,
+        log_func=lambda _msg: None,
+    )
+
+
+def test_pooled_roi_z_non_empty_two_consecutive(tmp_path: Path) -> None:
+    values = {
+        "G1S1": {
+            "Face": {"O1": {"1.2000_Hz": 2.1, "2.4000_Hz": 2.2, "3.6000_Hz": 0.4}, "O2": {"1.2000_Hz": 2.0, "2.4000_Hz": 2.1, "3.6000_Hz": 0.3}},
+        },
+        "G2S1": {
+            "Face": {"O1": {"1.2000_Hz": 2.0, "2.4000_Hz": 2.0, "3.6000_Hz": 0.2}, "O2": {"1.2000_Hz": 1.9, "2.4000_Hz": 1.9, "3.6000_Hz": 0.1}},
+        },
+    }
+    subjects, subject_data = _build_subject_data(tmp_path, values)
+    result = _run_compute(subjects, subject_data, conditions=["Face"])
+
+    assert result.z_sheet_used == "Z Scores"
+    assert result.harmonics_by_roi["Occ"] == [1.2, 2.4]
+    assert _match_freq_column(result.mean_z_by_condition["Face"].columns, 1.2) is None
+
+
+def test_pooled_roi_z_empty_when_two_consecutive_not_met(tmp_path: Path) -> None:
+    values = {
+        "G1S1": {
+            "Obj": {"O1": {"1.2000_Hz": 2.0, "2.4000_Hz": 1.2, "3.6000_Hz": 1.0}, "O2": {"1.2000_Hz": 1.9, "2.4000_Hz": 1.0, "3.6000_Hz": 0.8}},
+        },
+        "G2S1": {
+            "Obj": {"O1": {"1.2000_Hz": 2.1, "2.4000_Hz": 1.3, "3.6000_Hz": 0.9}, "O2": {"1.2000_Hz": 2.0, "2.4000_Hz": 1.1, "3.6000_Hz": 0.7}},
+        },
+    }
+    subjects, subject_data = _build_subject_data(tmp_path, values)
+    result = _run_compute(subjects, subject_data, conditions=["Obj"])
+
+    assert result.harmonics_by_roi["Occ"] == []
+
+
+def test_pooled_roi_z_all_nan_reports_empty_diagnostics(tmp_path: Path) -> None:
+    nan = float("nan")
+    values = {
+        "G1S1": {
+            "Words": {"O1": {"1.2000_Hz": nan, "2.4000_Hz": nan, "3.6000_Hz": nan}, "O2": {"1.2000_Hz": nan, "2.4000_Hz": nan, "3.6000_Hz": nan}},
+        },
+        "G2S1": {
+            "Words": {"O1": {"1.2000_Hz": nan, "2.4000_Hz": nan, "3.6000_Hz": nan}, "O2": {"1.2000_Hz": nan, "2.4000_Hz": nan, "3.6000_Hz": nan}},
+        },
+    }
+    subjects, subject_data = _build_subject_data(tmp_path, values)
+    result = _run_compute(subjects, subject_data, conditions=["Words"])
+
+    assert result.harmonics_by_roi["Occ"] == []
+    assert result.diagnostics["empty_reasons"]
+    assert any("No finite pooled ROI Z values" in reason for reason in result.diagnostics["empty_reasons"])
+
+
+def test_condition_combination_rule_uses_mean_across_conditions(tmp_path: Path) -> None:
+    values = {
+        "G1S1": {
+            "CondA": {"O1": {"1.2000_Hz": 2.2, "2.4000_Hz": 2.1, "3.6000_Hz": 0.4}, "O2": {"1.2000_Hz": 2.1, "2.4000_Hz": 2.0, "3.6000_Hz": 0.3}},
+            "CondB": {"O1": {"1.2000_Hz": 1.5, "2.4000_Hz": 1.5, "3.6000_Hz": 0.3}, "O2": {"1.2000_Hz": 1.4, "2.4000_Hz": 1.5, "3.6000_Hz": 0.2}},
+        },
+        "G2S1": {
+            "CondA": {"O1": {"1.2000_Hz": 2.2, "2.4000_Hz": 2.2, "3.6000_Hz": 0.5}, "O2": {"1.2000_Hz": 2.0, "2.4000_Hz": 2.1, "3.6000_Hz": 0.4}},
+            "CondB": {"O1": {"1.2000_Hz": 1.5, "2.4000_Hz": 1.5, "3.6000_Hz": 0.2}, "O2": {"1.2000_Hz": 1.4, "2.4000_Hz": 1.5, "3.6000_Hz": 0.2}},
+        },
+    }
+    subjects, subject_data = _build_subject_data(tmp_path, values)
+    result = _run_compute(subjects, subject_data, conditions=["CondA", "CondB"])
+
+    assert result.condition_combination_rule_used == CONDITION_COMBINATION_RULE
+    assert result.harmonics_by_roi["Occ"] == [1.2, 2.4]
+    assert result.strict_intersection_harmonics_by_roi["Occ"] == []
+
+    pooled = result.pooled_mean_z_table.set_index(["roi", "harmonic_hz"])["mean_z"]
+    assert pooled[("Occ", 1.2)] > 1.64
+    assert pooled[("Occ", 2.4)] > 1.64
+    assert np.isfinite(pooled[("Occ", 1.2)])


### PR DESCRIPTION
### Motivation
- Add a between-group shared-harmonics selection that pools participant ROI mean Z scores across all groups to drive harmonic inclusion while preserving existing domain construction and decision rules.
- Keep single-group behavior and all legacy code under `Tools/Stats/Legacy/` untouched as required.

### Description
- Implemented pooled ROI-Z selection in `compute_shared_harmonics` to: build the harmonic domain via the existing helpers, read per-electrode Z sheets (robust resolver preferring the canonical sheet and falling back to `"Z Scores"`), compute participant-level ROI means then pooled ROI mean across participants, and apply the existing two-consecutive significance selector to the pooled vector (condition combination = mean across conditions then two-consecutive selection).
- Added Z-sheet resolution helpers, preserved the existing two-consecutive selection helper (`_select_two_consecutive_significant`), and kept the strict per-condition `intersection` result available as `strict_intersection_harmonics_by_roi` for debugging/comparison while making pooled selection the between-group default.
- Extended metadata & diagnostics exported to `Shared Harmonics Summary.xlsx` (`policy_name = "VANDER_DONCK_POOLED_ROI_Z"`, `z_sheet_used`, `condition_combination_rule_used`, `pooling = "across groups"`, and detailed coverage/empty-reason diagnostics) and surfaced pooled outputs/diagnostics in the worker payload.
- Files changed: `src/Tools/Stats/PySide6/shared_harmonics.py`, `src/Tools/Stats/PySide6/stats_workers.py`; tests added: `tests/test_stats_shared_harmonics_pooled_roi_z.py` (covers non-empty, empty, all-NaN diagnostics, and condition-combination rule lock).

### Testing
- Dependency & lint/compile checks: `python -m pip install -r requirements.txt`, `python -m py_compile src/Tools/Stats/PySide6/shared_harmonics.py src/Tools/Stats/PySide6/stats_workers.py tests/test_stats_shared_harmonics_pooled_roi_z.py`, and `ruff check ...` all succeeded.
- Unit tests run: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_multigroup_scan.py tests/test_stats_shared_harmonics.py tests/test_stats_fixed_harmonics_dv.py tests/test_stats_missingness_rules.py tests/test_stats_n_group_contrasts.py` passed (17 passed), and `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_shared_harmonics.py tests/test_stats_shared_harmonics_pooled_roi_z.py` passed (8 passed), all green.
- Confirmed behavior: single-group harmonic selection unchanged; between-group shared harmonics now use pooled ROI-Z selection and the new metadata/diagnostics are emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb10c2f40832ca5aba686298a44c1)