### PR TITLE
Handle blocked between-group mixed-model inputs and fix error logging crash

### DIFF
--- a/src/Tools/Stats/PySide6/stats_controller.py
+++ b/src/Tools/Stats/PySide6/stats_controller.py
@@ -1060,6 +1060,27 @@ class StatsController:
                 },
             )
 
+            if isinstance(payload, dict) and str(payload.get("status", "")).lower() == "blocked":
+                blocked_message = str(payload.get("message") or "Analysis blocked.")
+                self._view.append_log(
+                    self._section_label(pipeline_id),
+                    format_step_event(
+                        pipeline_id,
+                        step_id,
+                        event="blocked",
+                        message=blocked_message,
+                    ),
+                    level="warning",
+                )
+                state.results[step_id] = payload
+                self._finalize_pipeline(
+                    pipeline_id,
+                    success=False,
+                    error_message=blocked_message,
+                    exports_ran=False,
+                )
+                return
+
             try:
                 handler(payload)
                 state.results[step_id] = payload if isinstance(payload, dict) else {"result": payload}

--- a/tests/test_stats_between_group_blocked_payload.py
+++ b/tests/test_stats_between_group_blocked_payload.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from PySide6.QtCore import QThreadPool
+
+from Tools.Stats.PySide6.stats_core import PipelineId, PipelineStep, StepId
+from Tools.Stats.PySide6.stats_main_window import StatsWindow
+from Tools.Stats.PySide6.stats_workers import run_lmm
+
+
+def test_stats_window_error_slot_does_not_raise_keyerror(qtbot, monkeypatch, tmp_path: Path) -> None:
+    window = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(window)
+
+    monkeypatch.setattr(QThreadPool, "start", lambda self, worker: worker.run(), raising=False)
+
+    def failing_worker(*_args, **_kwargs):
+        raise RuntimeError("synthetic worker failure")
+
+    error_messages: list[str] = []
+    step = PipelineStep(
+        id=StepId.RM_ANOVA,
+        name="RM-ANOVA",
+        worker_fn=failing_worker,
+        kwargs={},
+        handler=lambda _payload: None,
+    )
+
+    window.start_step_worker(
+        PipelineId.SINGLE,
+        step,
+        finished_cb=lambda *_args: None,
+        error_cb=lambda _pid, _sid, message: error_messages.append(message),
+    )
+
+    assert error_messages
+    assert "synthetic worker failure" in error_messages[0]
+
+
+def test_run_lmm_returns_blocked_payload_when_rows_drop_to_zero(tmp_path: Path) -> None:
+    diagnostics: list[str] = []
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["S1", "S2"],
+            "condition": ["A", "A"],
+            "roi": ["ROI1", "ROI1"],
+            "dv_value": [float("nan"), float("nan")],
+            "group": ["G1", "G2"],
+        }
+    )
+
+    payload = run_lmm(
+        lambda _progress: None,
+        diagnostics.append,
+        subjects=["S1", "S2"],
+        conditions=["A"],
+        conditions_all=["A"],
+        subject_data={},
+        base_freq=6.0,
+        alpha=0.05,
+        rois={"ROI1": ["O1"]},
+        rois_all={"ROI1": ["O1"]},
+        subject_groups={"S1": "G1", "S2": "G2"},
+        include_group=True,
+        fixed_harmonic_dv_table=fixed_dv,
+        required_conditions=["A"],
+        subject_to_group={"S1": "G1", "S2": "G2"},
+        results_dir=str(tmp_path),
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["blocked_stage"] == "dropna_dependent_variable"
+    assert payload["mixed_results_df"].empty
+    assert any("dependent_variable_column" in line for line in diagnostics)
+
+
+def test_blocked_lmm_exports_diagnostics_workbook(tmp_path: Path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["S1", "S2"],
+            "condition": ["A", "A"],
+            "roi": ["ROI1", "ROI1"],
+            "dv_value": [float("nan"), float("nan")],
+            "group": ["G1", "G2"],
+        }
+    )
+
+    payload = run_lmm(
+        lambda _progress: None,
+        lambda _msg: None,
+        subjects=["S1", "S2"],
+        conditions=["A"],
+        conditions_all=["A"],
+        subject_data={},
+        base_freq=6.0,
+        alpha=0.05,
+        rois={"ROI1": ["O1"]},
+        rois_all={"ROI1": ["O1"]},
+        subject_groups={"S1": "G1", "S2": "G2"},
+        include_group=True,
+        fixed_harmonic_dv_table=fixed_dv,
+        required_conditions=["A"],
+        subject_to_group={"S1": "G1", "S2": "G2"},
+        results_dir=str(tmp_path),
+    )
+
+    workbook_path = Path(payload["diagnostics_workbook"])
+    assert workbook_path.is_file()
+
+    with pd.ExcelFile(workbook_path) as workbook:
+        assert {"CountsByStage", "ExcludedParticipants", "RemainingRows_Sample"}.issubset(
+            set(workbook.sheet_names)
+        )


### PR DESCRIPTION
### Motivation
- Prevent a KeyError in the worker error path where logging used a reserved LogRecord key (`message`) and crashed UI error handling.
- Diagnose and make actionable the failure path where the between-group mixed model ends up with 0 valid rows after filtering (NaNs / exclusions) so the pipeline doesn't crash with an unhelpful exception.
- Provide clear stage-by-stage diagnostics to identify which filtering step zeroed the data and allow export of that diagnostic information.
- Keep single-group behavior and Legacy code untouched while preferring safe, informative handling over changing statistical logic.

### Description
- Renamed the reserved logging extra key in `StatsWindow._on_error` from `"message"` to `"error_message"` to avoid overwriting `LogRecord.message` and triggering `KeyError` during `logger.error` calls (file: `src/Tools/Stats/PySide6/stats_main_window.py`).
- Enhanced `run_lmm` (file: `src/Tools/Stats/PySide6/stats_workers.py`) with structured LMM diagnostics: dependent variable column audit (`value` vs `dv_value`), stage snapshots (`initial_dv_rows`, `after_group_condition_roi_filters`, `after_manual_exclusions`, `after_qc_screen`, `after_outlier_exclusions`, `after_dropna_dependent_variable`, `after_dropna_group`), and logging of unique groups/conditions/ROIs and per-stage row/subject/group counts.
- Added participant exclusion tracking (manual, QC, outlier/non-finite) and changed the failing `df_long.empty` branch into a safe, structured blocked result by returning a payload with `"status": "blocked"`, `"blocked_stage"`, `"stage_counts"`, `"excluded_participants"`, and an empty `mixed_results_df` instead of raising an exception.
- Export of a blocked-only diagnostics workbook `BetweenGroup_ModelInput_Diagnostics.xlsx` is performed when blocked and `results_dir` is provided, using the existing helper `_auto_format_and_write_excel` with sheets `CountsByStage`, `ExcludedParticipants`, and `RemainingRows_Sample` (file: `src/Tools/Stats/PySide6/stats_workers.py`).
- Thread-safety / orchestration changes: the controller now recognizes a `payload` with `status == "blocked"` and treats it as a handled (blocked) outcome, appending a warning log and finalizing the pipeline cleanly instead of relying on a worker exception (file: `src/Tools/Stats/PySide6/stats_controller.py`).
- UI changes: when a pipeline finishes with a blocked outcome the UI shows a non-modal status/log warning instead of attempting to show a blocking error dialog (file: `src/Tools/Stats/PySide6/stats_main_window.py`).
- Passed `results_dir` into the between-group mixed-model worker kwargs so blocked diagnostics can be saved to the project stats output area (file: `src/Tools/Stats/PySide6/stats_main_window.py`).
- Added unit tests in `tests/test_stats_between_group_blocked_payload.py` to verify: (1) the worker error slot logging path does not raise `KeyError`, (2) `run_lmm` returns a blocked payload when all rows drop out, and (3) the blocked diagnostics workbook is created with expected sheet names.

### Testing
- Ran linter checks with `ruff` on the modified files and the new test file using `python -m ruff check ...`; all checks passed.
- Attempted to run the GUI/Qt-backed pytest suites (including `tests/test_stats_between_group_blocked_payload.py` and other stats tests) using `QT_QPA_PLATFORM=offscreen`, but execution in this environment failed during test collection with `ImportError: libGL.so.1: cannot open shared object file: No such file or directory` while importing `PySide6`, so the PySide6-dependent tests could not be executed here.
- The added test module is included and runnable in an environment with PySide6 and required system libraries; the tests assert blocked payload structure and workbook creation when run under a proper test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb8d09fa4832c92d21db079d7583c)