### PR TITLE
Restore backward-compatible QcExclusionReport.excluded_pids accessor

### DIFF
--- a/tests/test_stats_qc_exclusion_report_compat.py
+++ b/tests/test_stats_qc_exclusion_report_compat.py
@@ -1,0 +1,59 @@
+from Tools.Stats.PySide6.stats_qc_exclusion import (
+    QcExclusionReport,
+    QcExclusionSummary,
+    QcParticipantReport,
+)
+
+
+def _summary() -> QcExclusionSummary:
+    return QcExclusionSummary(
+        n_subjects_before=0,
+        n_subjects_flagged=0,
+        n_subjects_after=0,
+        warn_threshold=6.0,
+        critical_threshold=10.0,
+        warn_abs_floor_sumabs=5.0,
+        critical_abs_floor_sumabs=10.0,
+        warn_abs_floor_maxabs=1.0,
+        critical_abs_floor_maxabs=2.0,
+    )
+
+
+def test_qc_exclusion_report_compat_excluded_pids_empty() -> None:
+    report = QcExclusionReport(
+        summary=_summary(),
+        participants=[],
+        screened_conditions=[],
+        screened_rois=[],
+    )
+
+    assert hasattr(report, "excluded_pids") is True
+    assert report.excluded_pids == set()
+
+
+def test_qc_exclusion_report_compat_excluded_pids_non_empty() -> None:
+    participant = QcParticipantReport(
+        participant_id="P01",
+        reasons=[],
+        n_violations=0,
+        worst_value=0.0,
+        worst_condition="",
+        worst_roi="",
+        worst_metric="",
+        robust_center=0.0,
+        robust_spread=0.0,
+        robust_score=0.0,
+        threshold_used=0.0,
+        trigger_harmonic_hz=None,
+        roi_mean_bca_at_trigger=None,
+        violations=[],
+    )
+    report = QcExclusionReport(
+        summary=_summary(),
+        participants=[participant],
+        screened_conditions=["CondA"],
+        screened_rois=["ROI1"],
+    )
+
+    assert hasattr(report, "excluded_pids") is True
+    assert report.excluded_pids == {"P01"}


### PR DESCRIPTION
### Motivation
- A recent regression caused `AttributeError: 'QcExclusionReport' object has no attribute 'excluded_pids'` in single-group and between-group pipelines; callers expect a stable `excluded_pids` API. 
- The goal is API compatibility only: provide a read-only accessor that returns `set[str]` without changing exclusion logic or outputs.

### Description
- Added a backward-compatible `@property def excluded_pids(self) -> set[str]` to `QcExclusionReport` that conservatively extracts IDs using the fallback order: `excluded_subjects`/`excluded_participants`/`excluded_ids` → `exclusions` (dict keys or list entries) → `participants[*].participant_id`, returning an empty `set()` as a safe default. 
- The accessor is read-only and does not modify existing fields or QC behavior. 
- Removed an unused `Tuple` import to satisfy linting. 
- Added regression tests `tests/test_stats_qc_exclusion_report_compat.py` that verify the `excluded_pids` attribute exists and returns correct sets for empty and non-empty report shapes. 
- Files changed: `src/Tools/Stats/PySide6/stats_qc_exclusion.py`, `tests/test_stats_qc_exclusion_report_compat.py`.

### Testing
- Installed Python deps and verified runtime: `python -m pip install -r requirements.txt` and `python -c "import numpy, pandas, PySide6, psutil; print('deps ok')"` (succeeded). 
- Linted changed files with `python -m ruff check src/Tools/Stats/PySide6/stats_qc_exclusion.py tests/test_stats_qc_exclusion_report_compat.py` (passed). 
- Ran collection and unit tests: `QT_QPA_PLATFORM=offscreen python -m pytest -q --collect-only` (collected successfully). 
- Ran the new regression tests: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_qc_exclusion_report_compat.py` (2 passed). 
- Ran the requested stats test subset: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_multigroup_scan.py tests/test_stats_shared_harmonics.py tests/test_stats_shared_harmonics_pooled_roi_z.py tests/test_stats_fixed_harmonics_dv.py tests/test_stats_missingness_rules.py tests/test_stats_n_group_contrasts.py` (23 passed). 
- Note: a long-running smoke invocation for `tests/test_stats_pipeline_smoke.py::test_single_pipeline_completes_and_logs` timed out in this environment after the configured 180s limit and did not complete; this does not indicate the API change alters exclusion logic (the regression-specific unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc019d7a4832caf532e904585b434)