### PR TITLE
Fix between-group mixed model DV column mapping and blocked diagnostics

### DIFF
--- a/tests/test_stats_between_group_blocked_payload.py
+++ b/tests/test_stats_between_group_blocked_payload.py
@@ -71,7 +71,7 @@ def test_run_lmm_returns_blocked_payload_when_rows_drop_to_zero(tmp_path: Path) 
     )
 
     assert payload["status"] == "blocked"
-    assert payload["blocked_stage"] == "dropna_dependent_variable"
+    assert payload["blocked_stage"] in {"dropna_dependent_variable", "between_group_dv_mapping"}
     assert payload["mixed_results_df"].empty
     assert any("dependent_variable_column" in line for line in diagnostics)
 
@@ -110,6 +110,6 @@ def test_blocked_lmm_exports_diagnostics_workbook(tmp_path: Path) -> None:
     assert workbook_path.is_file()
 
     with pd.ExcelFile(workbook_path) as workbook:
-        assert {"CountsByStage", "ExcludedParticipants", "RemainingRows_Sample"}.issubset(
+        assert {"CountsByStage", "ExcludedParticipants", "ModelInput_Columns", "RemainingRows_Sample"}.issubset(
             set(workbook.sheet_names)
         )

--- a/tests/test_stats_between_group_dv_mapping.py
+++ b/tests/test_stats_between_group_dv_mapping.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Stats.PySide6.stats_workers import run_lmm
+
+
+def test_between_group_lmm_maps_dv_value_to_value_and_does_not_block(monkeypatch) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["S1", "S1", "S2", "S2"],
+            "condition": ["A", "B", "A", "B"],
+            "roi": ["ROI1", "ROI1", "ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0, 3.0, 4.0],
+            "group": ["G1", "G1", "G2", "G2"],
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_mixed_effects_model(*, data, dv_col, group_col, fixed_effects):
+        captured["dv_col"] = dv_col
+        captured["data"] = data.copy()
+        return pd.DataFrame({"Effect": ["condition"], "P-Value": [0.04]})
+
+    monkeypatch.setattr("Tools.Stats.PySide6.stats_workers.run_mixed_effects_model", _fake_mixed_effects_model)
+
+    payload = run_lmm(
+        lambda _progress: None,
+        lambda _msg: None,
+        subjects=["S1", "S2"],
+        conditions=["A", "B"],
+        conditions_all=["A", "B"],
+        subject_data={},
+        base_freq=6.0,
+        alpha=0.05,
+        rois={"ROI1": ["O1"]},
+        rois_all={"ROI1": ["O1"]},
+        subject_groups={"S1": "G1", "S2": "G2"},
+        include_group=True,
+        fixed_harmonic_dv_table=fixed_dv,
+        required_conditions=["A", "B"],
+        subject_to_group={"S1": "G1", "S2": "G2"},
+    )
+
+    assert payload.get("status") != "blocked"
+    assert captured["dv_col"] == "value"
+    model_input = captured["data"]
+    assert model_input["value"].tolist() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_between_group_lmm_blocks_when_all_candidate_dv_columns_are_nan(tmp_path: Path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["S1", "S2"],
+            "condition": ["A", "A"],
+            "roi": ["ROI1", "ROI1"],
+            "dv_value": [float("nan"), float("nan")],
+            "dv": [float("nan"), float("nan")],
+            "SummedBCA": [float("nan"), float("nan")],
+            "bca_sum": [float("nan"), float("nan")],
+            "group": ["G1", "G2"],
+        }
+    )
+
+    payload = run_lmm(
+        lambda _progress: None,
+        lambda _msg: None,
+        subjects=["S1", "S2"],
+        conditions=["A"],
+        conditions_all=["A"],
+        subject_data={},
+        base_freq=6.0,
+        alpha=0.05,
+        rois={"ROI1": ["O1"]},
+        rois_all={"ROI1": ["O1"]},
+        subject_groups={"S1": "G1", "S2": "G2"},
+        include_group=True,
+        fixed_harmonic_dv_table=fixed_dv,
+        required_conditions=["A"],
+        subject_to_group={"S1": "G1", "S2": "G2"},
+        results_dir=str(tmp_path),
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["blocked_stage"] == "between_group_dv_mapping"
+    assert "tried columns" in payload["message"]


### PR DESCRIPTION
### Motivation

- The between-group mixed-model path was dropping all rows because the dependent-variable column used by the model sometimes did not match the fixed-harmonic DV table schema, causing `dropna_dependent_variable` to block analyses.
- The fix must be limited to between-group code paths and must not alter single-group behavior or change statistical logic.

### Description

- Added a between-group-only DV mapping helper `_map_between_group_model_dv_column` that deterministically maps known upstream columns to a canonical model column `value` by selecting the candidate with the highest non-NaN count from the priority list `['dv_value', 'value', 'dv', 'SummedBCA', 'bca_sum']` and coercing to float.
- Integrated the mapping into the between-group branch of `run_lmm` so single-group flows remain unchanged, and added a guarded block that returns a blocked payload with a clear reason when mapping yields an all-NaN `value` column.
- Improved between-group diagnostics: added INFO diagnostics that report `df.columns`, selected DV source, tried columns, DV non-NaN fraction, and a 3-row preview of DV-related columns; enhanced blocked diagnostics workbook export to include a `ModelInput_Columns` sheet (non-NaN fractions and counts) and the `RemainingRows_Sample` sheet.
- Files changed: `src/Tools/Stats/PySide6/stats_workers.py` and tests updated/added: `tests/test_stats_between_group_blocked_payload.py` (expectations adjusted) and new `tests/test_stats_between_group_dv_mapping.py` (positive and negative cases).

### Testing

- Ran test collection with `QT_QPA_PLATFORM=offscreen python -m pytest -q --collect-only` which successfully collected the suite.
- Ran a subset of single-group stats tests with `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_shared_harmonics.py tests/test_stats_fixed_harmonics_dv.py tests/test_stats_missingness_rules.py tests/test_stats_n_group_contrasts.py` and all 13 tests passed.
- Executed the new mapping tests with `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_between_group_dv_mapping.py` and both tests passed, and executed the between-group blocked diagnostics tests with `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_between_group_blocked_payload.py::test_run_lmm_returns_blocked_payload_when_rows_drop_to_zero tests/test_stats_between_group_blocked_payload.py::test_blocked_lmm_exports_diagnostics_workbook` which both passed.
- Ran `python -m ruff check src/Tools/Stats/PySide6/stats_workers.py tests/test_stats_between_group_dv_mapping.py tests/test_stats_between_group_blocked_payload.py` and linting reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc5f9302c832cb399103dabcaeba2)