### PR TITLE
Add between-group LMM DV merge diagnostics and key-match blocking

### DIFF
--- a/tests/test_stats_between_group_blocked_payload.py
+++ b/tests/test_stats_between_group_blocked_payload.py
@@ -110,6 +110,6 @@ def test_blocked_lmm_exports_diagnostics_workbook(tmp_path: Path) -> None:
     assert workbook_path.is_file()
 
     with pd.ExcelFile(workbook_path) as workbook:
-        assert {"CountsByStage", "ExcludedParticipants", "ModelInput_Columns", "RemainingRows_Sample"}.issubset(
+        assert {"StageCounts", "ExcludedParticipants", "ModelInput_Columns", "ConditionSets", "KeyMatchStats", "FinalBeforeDropna", "RemainingRows_Sample"}.issubset(
             set(workbook.sheet_names)
         )

--- a/tests/test_stats_between_group_merge_diagnostics.py
+++ b/tests/test_stats_between_group_merge_diagnostics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from Tools.Stats.PySide6 import stats_workers
+from Tools.Stats.PySide6.stats_workers import run_lmm
+
+
+def _base_kwargs(fixed_dv: pd.DataFrame, tmp_path):
+    return {
+        "subjects": ["S1", "S2"],
+        "conditions": ["A"],
+        "conditions_all": ["A"],
+        "subject_data": {},
+        "base_freq": 6.0,
+        "alpha": 0.05,
+        "rois": {"ROI1": ["O1"]},
+        "rois_all": {"ROI1": ["O1"]},
+        "subject_groups": {"S1": "G1", "S2": "G2"},
+        "include_group": True,
+        "fixed_harmonic_dv_table": fixed_dv,
+        "required_conditions": ["A"],
+        "subject_to_group": {"S1": "G1", "S2": "G2"},
+        "results_dir": str(tmp_path),
+    }
+
+
+def test_between_group_lmm_blocks_with_pid_mismatch(tmp_path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["X1", "X2"],
+            "condition": ["A", "A"],
+            "roi": ["ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0],
+            "group": ["G1", "G2"],
+        }
+    )
+
+    payload = run_lmm(lambda _progress: None, lambda _msg: None, **_base_kwargs(fixed_dv, tmp_path))
+
+    assert payload["status"] == "blocked"
+    assert "PID mismatch" in payload["message"]
+    assert payload["merge_match_stats"]["intersection_count"] == 0
+
+
+def test_between_group_lmm_blocks_with_condition_mismatch(tmp_path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["S1", "S2"],
+            "condition": ["B", "B"],
+            "roi": ["ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0],
+            "group": ["G1", "G2"],
+        }
+    )
+
+    payload = run_lmm(lambda _progress: None, lambda _msg: None, **_base_kwargs(fixed_dv, tmp_path))
+
+    assert payload["status"] == "blocked"
+    assert "Selected conditions not found" in payload["message"]
+    assert payload["merge_match_stats"]["intersection_count"] == 0
+
+
+def test_between_group_lmm_merge_success_does_not_block(monkeypatch, tmp_path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["S1", "S2"],
+            "condition": ["A", "A"],
+            "roi": ["ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0],
+            "group": ["G1", "G2"],
+        }
+    )
+
+    monkeypatch.setattr(
+        stats_workers,
+        "run_mixed_effects_model",
+        lambda **_kwargs: pd.DataFrame({"term": ["Intercept"], "pvalue": [0.1]}),
+    )
+
+    payload = run_lmm(lambda _progress: None, lambda _msg: None, **_base_kwargs(fixed_dv, tmp_path))
+
+    assert payload.get("status") != "blocked"
+    assert not payload["mixed_results_df"].empty


### PR DESCRIPTION
### Motivation
- Between-group LMM runs were being blocked with 0 rows after `dropna_dependent_variable` with little visibility into why the DV values were missing for all model rows.
- Need targeted diagnostics that show pre-merge state, DV table contents, and precise merge-key match statistics to classify why there are no DV matches (pid mismatch, condition mismatch, or generic 0 matches).
- Changes must be limited to between-group codepaths and must not alter single-group behavior or legacy stats code.

### Description
- Added between-group-only diagnostic stages into `run_lmm` (gated by `include_group`) to record `before_any_filters`, `before_dv_merge`, `dv_table_overview`, and `after_dv_merge_before_dropna`, while keeping existing `after_dropna_dependent_variable` snapshots.
- Constructed an expected model-key frame (`subject`,`condition`,`roi`) pre-merge, performed a left-merge against the DV table, and computed `dv_non_nan_count` for early detection of zero matches.
- Implemented `_compute_merge_key_stats` to compute key counts, intersection, model-only/dv-only sample keys, PID samples, selected/DV condition sets, and surfaced those stats in the blocked payload as `merge_match_stats` and a `KeyMatchStats` DataFrame.
- Added `_build_condition_sets_df` and included additional diagnostic workbook sheets (`StageCounts`, `ConditionSets`, `KeyMatchStats`, `FinalBeforeDropna`) and wired these into `_build_lmm_blocked_payload` (between-group-only) without altering single-group behavior.
- Classified blocked reasons when `dv_non_nan_count == 0` into three explicit messages: `0 DV matches after merge`, `Selected conditions not found in DV table`, and `PID mismatch between manifest and DV table`.
- Tests: updated the blocked-workbook test expectation and added focused synthetic tests `tests/test_stats_between_group_merge_diagnostics.py` to validate PID-mismatch, condition-mismatch, and successful-merge cases.
- Files changed: `src/Tools/Stats/PySide6/stats_workers.py`, `tests/test_stats_between_group_blocked_payload.py`, and new `tests/test_stats_between_group_merge_diagnostics.py`.

### Testing
- Installed dependencies (`pip install -r requirements.txt`) and validated environment with `python -c "import numpy, pandas, PySide6, psutil; print('deps ok')"` which succeeded.
- Ran the new targeted merge diagnostics tests `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_between_group_merge_diagnostics.py`, which passed (3 passed).
- Ran existing between-group tests `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_between_group_dv_mapping.py tests/test_stats_between_group_blocked_payload.py`, which passed (5 passed).
- Verified a single-group regression gate `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_dv_policy.py::test_stats_dv_policy_fixed_k_snapshot_and_kwargs` to ensure single-group behavior was not affected, which passed.
- Ran `python -m ruff check` on changed files which reported no issues.
- Note: testing focused on the between-group diagnostic path and a single-group gate; a full test-suite run was not performed here (targeted tests and linters passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc8de571c832c827517a03b3ab3c1)