### PR TITLE
Add between-group DV merge diagnostics and normalize merge keys

### DIFF
--- a/tests/test_stats_between_group_dv_merge_keys.py
+++ b/tests/test_stats_between_group_dv_merge_keys.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from Tools.Stats.PySide6.stats_workers import LMM_DIAGNOSTIC_WORKBOOK, run_lmm
+
+
+def _base_kwargs(results_dir: Path | None = None) -> dict:
+    kwargs = {
+        "subjects": ["P1", "P2"],
+        "conditions": ["Face", "House"],
+        "conditions_all": ["Face", "House"],
+        "subject_data": {},
+        "base_freq": 6.0,
+        "alpha": 0.05,
+        "rois": {"ROI1": ["O1"]},
+        "rois_all": {"ROI1": ["O1"]},
+        "subject_groups": {"P1": "G1", "P2": "G2"},
+        "include_group": True,
+        "required_conditions": ["Face", "House"],
+        "subject_to_group": {"P1": "G1", "P2": "G2"},
+    }
+    if results_dir is not None:
+        kwargs["results_dir"] = str(results_dir)
+    return kwargs
+
+
+def test_between_group_pid_mismatch_reports_precise_reason_and_writes_diagnostics(tmp_path: Path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["P100", "P100", "P200", "P200"],
+            "condition": ["Face", "House", "Face", "House"],
+            "roi": ["ROI1", "ROI1", "ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+    payload = run_lmm(
+        lambda _progress: None,
+        lambda _msg: None,
+        fixed_harmonic_dv_table=fixed_dv,
+        **_base_kwargs(results_dir=tmp_path),
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["blocked_reason"] == "DV merge produced 0 matches: PID mismatch"
+
+    workbook_path = tmp_path / LMM_DIAGNOSTIC_WORKBOOK
+    assert workbook_path.is_file()
+    with pd.ExcelFile(workbook_path) as workbook:
+        assert {"StageCounts", "ConditionSets", "KeyMatchStats", "DVColumnAudit", "FinalBeforeDropna"}.issubset(
+            set(workbook.sheet_names)
+        )
+
+
+def test_between_group_condition_mismatch_reports_precise_reason(tmp_path: Path) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["P1", "P1", "P2", "P2"],
+            "condition": ["Car", "Chair", "Car", "Chair"],
+            "roi": ["ROI1", "ROI1", "ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+    payload = run_lmm(
+        lambda _progress: None,
+        lambda _msg: None,
+        fixed_harmonic_dv_table=fixed_dv,
+        **_base_kwargs(results_dir=tmp_path),
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["blocked_reason"] == "DV merge produced 0 matches: condition mismatch"
+
+
+def test_between_group_successful_merge_logs_non_nan_before_dropna_and_does_not_block(monkeypatch) -> None:
+    fixed_dv = pd.DataFrame(
+        {
+            "subject": ["P1", "P1", "P2", "P2"],
+            "condition": ["Face", "House", "Face", "House"],
+            "roi": ["ROI1", "ROI1", "ROI1", "ROI1"],
+            "dv_value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+    logs: list[str] = []
+    captured: dict[str, object] = {}
+
+    def _fake_mixed_effects_model(*, data, dv_col, group_col, fixed_effects):
+        captured["dv_col"] = dv_col
+        captured["rows"] = len(data)
+        return pd.DataFrame({"Effect": ["condition"], "P-Value": [0.04]})
+
+    monkeypatch.setattr("Tools.Stats.PySide6.stats_workers.run_mixed_effects_model", _fake_mixed_effects_model)
+
+    kwargs = _base_kwargs()
+    kwargs["subjects"] = ["P1BCF", "P2CGL"]
+    kwargs["subject_groups"] = {"P1BCF": "G1", "P2CGL": "G2"}
+    kwargs["subject_to_group"] = {"P1BCF": "G1", "P2CGL": "G2"}
+
+    payload = run_lmm(
+        lambda _progress: None,
+        logs.append,
+        fixed_harmonic_dv_table=fixed_dv,
+        **kwargs,
+    )
+
+    assert payload.get("status") != "blocked"
+    assert captured["dv_col"] == "value"
+    assert captured["rows"] == 4
+    assert any("stage=after_merge_before_dropna" in line and "non_nan_count=4" in line for line in logs)


### PR DESCRIPTION
### Motivation
- Diagnose and surface why between-group mixed models can be blocked with "0 rows after dropna_dependent_variable" by adding pre-dropna diagnostics around the DV merge step. 
- Provide a precise, actionable blocked reason when dependent-variable mapping yields zero matches (PID/condition/ROI/composite key). 
- Apply a minimal between-group-only fix to key matching (PID canonicalization / condition/ROI normalization) without changing single-group codepaths or legacy modules.

### Description
- Emit LMM diagnostics at `before_dv_merge`, `dv_table_overview`, and `after_merge_before_dropna` including shapes, unique counts, sample keys, candidate DV columns, DV dtype, non-null counts and sample DV values. 
- Add `DVColumnAudit` and richer `KeyMatchStats` (including ROI intersections and samples) and export them into `BetweenGroup_ModelInput_Diagnostics.xlsx` along with an enriched `FinalBeforeDropna` sheet using existing Excel formatting helpers. 
- Implement `_build_dv_column_audit_df` and `_normalize_between_group_merge_keys` to canonicalize `subject` via `canonical_subject_id`, normalize `condition` via `strip().casefold()`, and normalize `roi` via `strip()` and use these only for the between-group merge path. 
- Replace the generic block message with precise reasons: `PID mismatch`, `condition mismatch`, `ROI mismatch`, or `composite key mismatch` when zero matches are found. 
- Ensure post-merge participant filtering uses the same canonical PID logic to avoid dropping valid matches. 
- Add targeted tests in `tests/test_stats_between_group_dv_merge_keys.py` covering PID mismatch (and workbook export), condition mismatch, and a successful canonicalized merge that proceeds to the mixed-model call.

### Testing
- Ran a representative single-group stats test collection: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_shared_harmonics.py tests/test_stats_fixed_harmonics_dv.py tests/test_stats_missingness_rules.py tests/test_stats_n_group_contrasts.py` and all 13 tests passed. 
- Executed the new between-group focused tests: `QT_QPA_PLATFORM=offscreen python -m pytest -q tests/test_stats_between_group_dv_merge_keys.py` and all 3 tests passed (including verification that the diagnostics workbook was written). 
- Ran an outlier exclusion check `python -m pytest -q tests/test_stats_outlier_exclusion.py` which passed, and performed `python -m ruff check src/Tools/Stats/PySide6/stats_workers.py tests/test_stats_between_group_dv_merge_keys.py` which reported no issues. 

No single-group pipeline codepaths were modified and `Tools/Stats/Legacy/**` was not changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bce264a70832c8c2357bbb3f2209e)