### PR TITLE
Fix Stats tool landscape layout and Multi-Group summary clipping

### DIFF
--- a/tests/test_stats_multigroup_layout_visibility.py
+++ b/tests/test_stats_multigroup_layout_visibility.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("PySide6.QtWidgets")
+from PySide6.QtWidgets import QAbstractScrollArea, QGroupBox, QPlainTextEdit
+
+from Tools.Stats.PySide6.stats_ui_pyside6 import StatsWindow
+
+
+@pytest.fixture(autouse=True)
+def _stub_default_loader(monkeypatch):
+    monkeypatch.setattr(StatsWindow, "_load_default_data_folder", lambda self: None, raising=False)
+
+
+@pytest.mark.qt
+def test_multigroup_scan_summary_controls_visible_at_startup(qtbot, tmp_path):
+    window = StatsWindow(project_dir=str(tmp_path))
+    qtbot.addWidget(window)
+    window.show()
+    qtbot.wait(100)
+
+    summary_group = next(
+        box for box in window.findChildren(QGroupBox) if box.title() == "Multi-Group Scan Summary"
+    )
+    assert summary_group.isVisible()
+    assert summary_group.height() > 0
+
+    assert window.compute_shared_harmonics_btn.isVisible()
+    assert window.compute_shared_harmonics_btn.height() > 20
+    assert window.compute_fixed_harmonic_dv_btn.isVisible()
+    assert window.compute_fixed_harmonic_dv_btn.height() > 20
+    assert window.multi_group_issue_toggle_btn.isVisible()
+
+    issues = window.multi_group_issue_text
+    assert isinstance(issues, QPlainTextEdit)
+    assert isinstance(issues, QAbstractScrollArea)
+    assert issues.isVisible()
+    assert issues.minimumHeight() >= 70
+    assert issues.maximumHeight() <= 140


### PR DESCRIPTION
### Motivation
- The Stats UI was vertically cramped and the "Multi-Group Scan Summary" could be clipped at startup while horizontal space was unused, so a landscape-first layout is needed to surface key summary controls without resizing. 
- Changes are layout-only and must preserve all existing controls and statistical behavior.

### Description
- Increased default and minimum window sizes to a landscape-friendly startup (`resize(1400, 820)`, `setMinimumSize(1180, 760)`).
- Consolidated the top data row so the Data Folder path + Browse/Copy + "Open Results Folder" + "Analysis Info" share a full-width row.
- Reorganized the main area into three horizontal columns via a `QSplitter` (`stats_top_splitter`) with 1:2:2 stretch, mapping: Column 1 = Included Conditions, Column 2 = Summed BCA definition (+ previews/manual exclusions), Column 3 = Multi-Group Scan Summary (top) + Analysis Controls (below) + status/export/ROI.
- Reduced vertical pressure on the Multi-Group Scan Summary by tightening `QFormLayout` spacing, bounding the Issues widget with a minimum and maximum height and enabling scrollbars, and ensuring compute buttons and "Show details" are visible at startup.
- Adjusted splitter stretch factors and sizes so the main content receives most vertical space and the Summary/Log tabs do not steal height.
- Files changed: `src/Tools/Stats/PySide6/stats_main_window.py` and new test `tests/test_stats_multigroup_layout_visibility.py`.

### Testing
- Added a pytest-qt layout sanity test `tests/test_stats_multigroup_layout_visibility.py` which instantiates `StatsWindow`, shows it, and asserts visibility/height constraints for the Multi-Group summary controls and Issues widget.
- Ran `python -m ruff check` on the touched files and it passed.
- Attempted GUI test collection and execution (`QT_QPA_PLATFORM=offscreen python -m pytest -q --collect-only` and targeted pytest runs), but collection/execution were blocked or skipped in this environment due to missing or partial runtime dependencies (incomplete `PySide6` runtime and missing scientific packages such as `numpy`/`pandas`), so the new UI test was skipped here; the test is present and should run in a full PySide6/pytest-qt environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ddc3b6bc8832ca1a3468892fcf168)