### PR TITLE
Stats: report and export both interaction post-hoc directions by default

### DIFF
--- a/src/Tools/Stats/Legacy/stats_export.py
+++ b/src/Tools/Stats/Legacy/stats_export.py
@@ -92,8 +92,8 @@ def export_posthoc_results_to_excel(results_df, save_path, log_func, factor=""):
             if direction_col:
                 cond_df = results_df[results_df[direction_col] == "condition_within_roi"].copy()
                 roi_df = results_df[results_df[direction_col] == "roi_within_condition"].copy()
-                _auto_format_and_write_excel(writer, cond_df, 'CondWithinROI', log_func)
-                _auto_format_and_write_excel(writer, roi_df, 'ROIWithinCond', log_func)
+                _auto_format_and_write_excel(writer, cond_df, 'Posthoc_ConditionWithinROI', log_func)
+                _auto_format_and_write_excel(writer, roi_df, 'Posthoc_ROIWithinCondition', log_func)
                 _auto_format_and_write_excel(writer, results_df, 'Combined', log_func)
                 # Backward-compatible sheet name used by summary readers.
                 _auto_format_and_write_excel(writer, results_df, 'Post-hoc Results', log_func)

--- a/src/Tools/Stats/PySide6/reporting_summary.py
+++ b/src/Tools/Stats/PySide6/reporting_summary.py
@@ -220,14 +220,14 @@ def _append_posthoc(lines: list[str], posthoc_df: pd.DataFrame | None) -> None:
     p_raw_col = _find_col(posthoc_df, ["p_raw", "p_value", "p"])
     p_adj_col = _find_col(posthoc_df, ["p_fdr_bh", "p_corr", "p_adj"])
     direction_col = _find_col(posthoc_df, ["Direction", "direction"])
-    slice_col = _find_col(posthoc_df, ["Slice", "slice"])
-    factor_col = _find_col(posthoc_df, ["Factor", "factor"])
+    slice_col = _find_col(posthoc_df, ["Stratum", "Slice", "stratum", "slice"])
+    factor_col = _find_col(posthoc_df, ["FactorAnalyzed", "Factor", "factor_analyzed", "factor"])
     for _, row in posthoc_df.iterrows():
         direction = _fmt(row.get(direction_col)) if direction_col else "condition_within_roi"
         slice_val = _fmt(row.get(slice_col)) if slice_col else NOT_AVAILABLE
         factor = _fmt(row.get(factor_col)) if factor_col else NOT_AVAILABLE
         lines.append(
-            f"- [{direction}] slice={slice_val} factor={factor} {_fmt(row.get(label_col or 'Comparison'))}: estimate={_fmt(row.get(estimate_col))}  "
+            f"- [{direction}] stratum={slice_val} factor={factor} {_fmt(row.get(label_col or 'Comparison'))}: estimate={_fmt(row.get(estimate_col))}  "
             f"SE={_fmt(row.get(se_col))}  stat={_fmt(row.get(stat_col))}  "
             f"df={_fmt(row.get(df_col))}  p_raw={_fmt(row.get(p_raw_col))}  p_adj={_fmt(row.get(p_adj_col))}"
         )

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1721,6 +1721,7 @@ def run_posthoc(
     if df_long.empty:
         raise RuntimeError("No valid rows for post-hoc tests after filtering NaNs.")
 
+    requested_direction = kwargs.get("direction", kwargs.get("posthoc_direction", "both"))
     message_cb("Running post-hoc tests…")
     output_text, results_df = run_interaction_posthocs(
         data=df_long,
@@ -1729,7 +1730,7 @@ def run_posthoc(
         condition_col="condition",
         subject_col="subject",
         alpha=alpha,
-        direction="both",
+        direction=requested_direction,
     )
     message_cb("Post-hoc interaction tests completed.")
     return {

--- a/tests/test_stats_reporting_summary_posthoc_direction.py
+++ b/tests/test_stats_reporting_summary_posthoc_direction.py
@@ -40,8 +40,8 @@ def test_reporting_summary_includes_posthoc_direction_and_slice_labels():
         [
             {
                 "Direction": "condition_within_roi",
-                "Slice": "R1",
-                "Factor": "condition",
+                "Stratum": "R1",
+                "FactorAnalyzed": "condition",
                 "Level_A": "C1",
                 "Level_B": "C2",
                 "mean_diff": 1.2,
@@ -51,8 +51,8 @@ def test_reporting_summary_includes_posthoc_direction_and_slice_labels():
             },
             {
                 "Direction": "roi_within_condition",
-                "Slice": "C1",
-                "Factor": "roi",
+                "Stratum": "C1",
+                "FactorAnalyzed": "roi",
                 "Level_A": "R1",
                 "Level_B": "R2",
                 "mean_diff": -0.8,
@@ -72,5 +72,5 @@ def test_reporting_summary_includes_posthoc_direction_and_slice_labels():
 
     assert "Conditions within ROI rows: 1" in summary
     assert "ROIs within condition rows: 1" in summary
-    assert "[condition_within_roi] slice=R1 factor=condition" in summary
-    assert "[roi_within_condition] slice=C1 factor=roi" in summary
+    assert "[condition_within_roi] stratum=R1 factor=condition" in summary
+    assert "[roi_within_condition] stratum=C1 factor=roi" in summary


### PR DESCRIPTION
### Motivation
- Ensure interaction post-hoc reporting shows BOTH simple-effect directions by default: (A) condition-within-ROI and (B) ROI-within-condition, while remaining backward-compatible and not changing RM-ANOVA or LMM computations.

### Description
- posthoc logic: updated `run_interaction_posthocs` to run either direction or `both`, and to tag every result row with `Direction`, `Stratum`, and `FactorAnalyzed` while preserving legacy `Slice`/`Factor`/`ROI`/`Condition` columns; summaries now include separate headings `Simple effects: Condition within ROI` and `Simple effects: ROI within Condition`.
- Worker wiring: `stats_workers.run_posthoc` now forwards a requested `direction` (from `direction`/`posthoc_direction` kwargs) to `run_interaction_posthocs`, defaulting to `both` so behavior is unchanged unless explicitly overridden.
- Exports: `export_posthoc_results_to_excel` now writes deterministic directional sheets named `Posthoc_ConditionWithinROI` and `Posthoc_ROIWithinCondition`, plus a `Combined` sheet and the legacy `Post-hoc Results` sheet for compatibility.
- Reporting summary: updated `reporting_summary` to prefer `Stratum` and `FactorAnalyzed` (falling back to legacy names) and to print `stratum=` in the human-readable summary lines.
- Tests: added/updated unit tests in `tests/test_stats_posthoc_both_directions.py` and `tests/test_stats_reporting_summary_posthoc_direction.py` to validate default `both` behavior, single-direction selection, presence of new metadata columns, export sheet names, and summary rendering.
- Files touched: `src/Tools/Stats/Legacy/posthoc_tests.py`, `src/Tools/Stats/Legacy/stats_export.py`, `src/Tools/Stats/PySide6/stats_workers.py`, `src/Tools/Stats/PySide6/reporting_summary.py`, and tests under `tests/`.

### Testing
- Ran the targeted unit tests with `pytest -q tests/test_stats_posthoc_both_directions.py tests/test_stats_reporting_summary_posthoc_direction.py` and all tests passed (`5 passed`).
- Ran the linter with `ruff check ...` which reported existing `E702` multiple-statements-on-one-line warnings in `posthoc_tests.py` (style issues present in the file prior to this change); these are linter/style findings and not functional test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df3f5a104832c9cfe0a1ffec4eab3)