### PR TITLE
RM-ANOVA: include GG epsilon, Mauchly sphericity fields, corrected p-values and text report export

### DIFF
--- a/tests/test_rm_anova_reporting.py
+++ b/tests/test_rm_anova_reporting.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import datetime
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+pd = pytest.importorskip("pandas")
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RM_ANOVA_MODULE_PATH = ROOT / "src" / "Tools" / "Stats" / "Legacy" / "repeated_m_anova.py"
+REPORTING_MODULE_PATH = ROOT / "src" / "Tools" / "Stats" / "PySide6" / "reporting_summary.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load module at {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rm_mod = _load_module(RM_ANOVA_MODULE_PATH, "rm_anova_legacy_mod")
+report_mod = _load_module(REPORTING_MODULE_PATH, "rm_anova_report_mod")
+
+
+def test_tidy_from_pingouin_maps_eps_and_sphericity_fields():
+    pg_df = pd.DataFrame(
+        [
+            {
+                "Source": "condition",
+                "ddof1": 1,
+                "ddof2": 19,
+                "F": 5.2,
+                "p-unc": 0.03,
+                "eps": 0.81,
+                "p-GG-corr": 0.041,
+                "W-spher": 0.92,
+                "p-spher": 0.12,
+                "sphericity": True,
+            }
+        ]
+    )
+    out = rm_mod._tidy_from_pingouin(pg_df)
+    for col in [
+        "epsilon (GG)",
+        "Pr > F (GG)",
+        "W (Mauchly)",
+        "p (Mauchly)",
+        "Sphericity (bool)",
+    ]:
+        assert col in out.columns
+
+
+def test_pingouin_success_prefers_corrected_p_for_reported_value():
+    anova_df = pd.DataFrame(
+        [
+            {
+                "Effect": "condition",
+                "F Value": 4.3,
+                "Num DF": 1,
+                "Den DF": 10,
+                "Pr > F": 0.07,
+                "Pr > F (GG)": 0.049,
+            }
+        ]
+    )
+    anova_df.attrs["rm_anova_backend"] = "pingouin"
+
+    text = report_mod.build_rm_anova_text_report(
+        anova_df=anova_df,
+        generated_local=datetime(2025, 1, 1, 12, 0, 0),
+        project_name="Demo",
+    )
+
+    assert "p_reported=0.049 (GG corrected)" in text
+    assert "p_uncorrected=0.07" in text
+
+
+def test_statsmodels_fallback_marks_correction_and_sphericity_not_available():
+    anova_df = pd.DataFrame(
+        [
+            {
+                "Effect": "condition",
+                "F Value": 4.3,
+                "Num DF": 1,
+                "Den DF": 10,
+                "Pr > F": 0.07,
+            }
+        ]
+    )
+    anova_df.attrs["rm_anova_backend"] = "statsmodels"
+
+    text = report_mod.build_rm_anova_text_report(
+        anova_df=anova_df,
+        generated_local=datetime(2025, 1, 1, 12, 0, 0),
+        project_name="Demo",
+    )
+
+    assert "RM-ANOVA backend: statsmodels" in text
+    assert "epsilon (GG)=NOT AVAILABLE (statsmodels fallback)" in text
+    assert "W (Mauchly)=NOT AVAILABLE (statsmodels fallback)" in text
+    assert "Pr > F (GG)=NOT AVAILABLE (statsmodels fallback)" in text
+
+
+def test_rm_anova_report_export_path_writes_to_results_folder(tmp_path):
+    generated = datetime(2025, 1, 2, 3, 4, 5)
+    results_dir = tmp_path / "Statistical Analysis Results"
+    report_path = report_mod.build_rm_anova_report_path(results_dir, generated)
+
+    anova_df = pd.DataFrame([{"Effect": "condition", "F Value": 2.1, "Num DF": 1, "Den DF": 8, "Pr > F": 0.1}])
+    anova_df.attrs["rm_anova_backend"] = "statsmodels"
+
+    text = report_mod.build_rm_anova_text_report(
+        anova_df=anova_df,
+        generated_local=generated,
+        project_name="Demo",
+    )
+    report_path.write_text(text, encoding="utf-8")
+
+    assert report_path.exists()
+    assert "RM_ANOVA_Report_2025-01-02_030405.txt" == report_path.name
+    content = report_path.read_text(encoding="utf-8")
+    assert "Timestamp (local): 2025-01-02 03:04:05" in content
+    assert "RM-ANOVA backend: statsmodels" in content


### PR DESCRIPTION
### Motivation
- Improve RM-ANOVA reporting to surface Greenhouse–Geisser (GG) correction outputs and sphericity diagnostics when Pingouin provides them. 
- Prefer corrected p-values in human-facing reports while preserving existing stats pipeline and statsmodels fallback semantics. 
- Emit a per-run human-readable text report into the project results folder (same resolved stats results location) and make exports non-blocking. 

### Description
- Extended `_tidy_from_pingouin()` to map Pingouin fields into the standardized table including `eps` → `epsilon (GG)`, `p-GG-corr` → `Pr > F (GG)`, `W-spher` → `W (Mauchly)`, `p-spher` → `p (Mauchly)`, and `sphericity` → `Sphericity (bool)` when present, and preserved HF/un-corrected mappings. (src/Tools/Stats/Legacy/repeated_m_anova.py)
- When Pingouin is available, attempt `pg.rm_anova(..., detailed=True, correction=True)` and fall back to the older signature on `TypeError`, recording backend and whether correction outputs were available in the returned DataFrame `attrs`. (src/Tools/Stats/Legacy/repeated_m_anova.py)
- When falling back to statsmodels, attach explicit attributes marking that correction and sphericity outputs are unavailable and, if Pingouin previously raised, attach a short diagnostics block (exception type/message, df shape and subject/condition/roi counts, DV non-finite counts) to `attrs` for downstream reporting. (src/Tools/Stats/Legacy/repeated_m_anova.py)
- Added text-report helpers `build_rm_anova_text_report()` and `build_rm_anova_report_path()` to generate `RM_ANOVA_Report_YYYY-MM-DD_HHMMSS.txt` files, choose `p_reported` with precedence GG → HF → uncorrected, always include `p_uncorrected` for transparency, and explicitly print "NOT AVAILABLE (statsmodels fallback)" or "NOT AVAILABLE (pingouin output)" per field when appropriate. (src/Tools/Stats/PySide6/reporting_summary.py)
- Wired automatic non-blocking export of the RM-ANOVA text report into the existing worker flow using the resolved `results_dir` and logged export successes/fallback diagnostics to `message_cb` and structured logger on failures. (src/Tools/Stats/PySide6/stats_workers.py)
- Added unit/integration tests exercising Pingouin field mapping, corrected-p selection, statsmodels fallback messaging, and report path/export behavior. (tests/test_rm_anova_reporting.py)

### Testing
- Ran style/type checks with `ruff` on modified files which passed. 
- Verified Python syntax by running `python -m py_compile` on changed modules which passed. 
- Executed the new RM-ANOVA reporting tests via `pytest`; the new test module was skipped in this environment because `pandas` is not installed here (`pytest.importorskip("pandas")`).
- Ran two existing reporting-summary smoke tests where one passed and one failed in this environment due to a pandas stub incompatibility when real `pandas` is unavailable, which is environment-specific and not caused by the changes above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0e13eeb8832c993d80b259e46748)