### PR TITLE
Fix RM-ANOVA tiny p-value export/display formatting

### DIFF
--- a/src/Tools/Stats/PySide6/reporting_summary.py
+++ b/src/Tools/Stats/PySide6/reporting_summary.py
@@ -183,14 +183,14 @@ def build_rm_anova_text_report(
             [
                 f"Effect: {_fmt(row.get('Effect'))}",
                 f"  F={_fmt(row.get('F Value'))} df1={_fmt(row.get('Num DF'))} df2={_fmt(row.get('Den DF'))}",
-                f"  p_uncorrected={_fmt(p_unc)}",
+                f"  p_uncorrected={fmt_p(p_unc)}",
                 f"  epsilon (GG)={_fmt(eps)}",
                 f"  W (Mauchly)={_fmt(w)}",
-                f"  p (Mauchly)={_fmt(p_spher)}",
+                f"  p (Mauchly)={fmt_p(p_spher)}",
                 f"  Sphericity (bool)={_fmt(s_bool)}",
-                f"  Pr > F (GG)={_fmt(p_gg_val)}",
-                f"  Pr > F (HF)={_fmt(p_hf_val)}",
-                f"  p_reported={_fmt(p_reported)} ({p_label})",
+                f"  Pr > F (GG)={fmt_p(p_gg_val)}",
+                f"  Pr > F (HF)={fmt_p(p_hf_val)}",
+                f"  p_reported={fmt_p(p_reported)} ({p_label})",
                 "",
             ]
         )
@@ -227,6 +227,20 @@ def _fmt(value: Any) -> str:
     if isinstance(value, float):
         return f"{value:.6g}"
     return str(value)
+
+
+def fmt_p(value: Any) -> str:
+    if value is None:
+        return NOT_AVAILABLE
+    try:
+        numeric = float(value)
+    except Exception:
+        return str(value)
+    if not math.isfinite(numeric):
+        return NOT_AVAILABLE
+    if numeric != 0.0 and abs(numeric) < 0.001:
+        return f"{numeric:.3e}"
+    return f"{numeric:.6g}"
 
 
 def _finite_value(row: pd.Series, col: str) -> float | None:
@@ -301,11 +315,11 @@ def _append_anova(lines: list[str], context: ReportingSummaryContext, anova_df: 
                 f"- {effect}:",
                 f"  - df1 (uncorrected): {_fmt(row.get('Num DF'))}   df2 (uncorrected): {_fmt(row.get('Den DF'))}",
                 f"  - F: {_fmt(row.get('F Value'))}",
-                f"  - p_reported: {_fmt(p_reported)} ({p_label})",
-                f"  - p_uncorrected: {_fmt(p_uncorrected)}",
+                f"  - p_reported: {fmt_p(p_reported)} ({p_label})",
+                f"  - p_uncorrected: {fmt_p(p_uncorrected)}",
                 f"  - epsilon (GG): {_fmt(epsilon_gg)}",
                 f"  - W (Mauchly): {_fmt(mauchly_w)}",
-                f"  - p (Mauchly): {_fmt(mauchly_p)}",
+                f"  - p (Mauchly): {fmt_p(mauchly_p)}",
                 f"  - Sphericity (bool): {_fmt(sphericity_bool)}",
                 f"  - effect size (if already computed): {_fmt(row.get('partial eta squared'))}",
             ]

--- a/src/Tools/Stats/PySide6/stats_export_formatting.py
+++ b/src/Tools/Stats/PySide6/stats_export_formatting.py
@@ -1,0 +1,93 @@
+"""Formatting helpers for Stats Excel exports.
+
+This module applies output-only formatting adjustments after legacy exports.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+
+import openpyxl
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+RM_ANOVA_P_COLUMNS: tuple[str, ...] = ("Pr > F", "Pr > F (GG)", "Pr > F (HF)")
+SCIENTIFIC_P_THRESHOLD = 0.001
+SCIENTIFIC_FMT = "0.00E+00"
+DEFAULT_P_FMT = "0.0000"
+
+
+def log_rm_anova_p_minima(anova_df: pd.DataFrame) -> None:
+    """Emit diagnostic stats confirming whether tiny p-values are real zeros or display artifacts."""
+
+    def _series_metrics(column: str) -> tuple[float | None, bool]:
+        if column not in anova_df.columns:
+            return None, False
+        numeric = pd.to_numeric(anova_df[column], errors="coerce")
+        exact_zero = bool((numeric == 0.0).fillna(False).any())
+        positives = numeric[(numeric > 0.0) & numeric.notna()]
+        if positives.empty:
+            return None, exact_zero
+        return float(positives.min()), exact_zero
+
+    min_p_unc, any_exact_zero_unc = _series_metrics("Pr > F")
+    min_p_gg, any_exact_zero_gg = _series_metrics("Pr > F (GG)")
+    logger.info(
+        "rm_anova_p_min",
+        extra={
+            "min_p_unc": min_p_unc,
+            "min_p_gg": min_p_gg,
+            "any_exact_zero_unc": any_exact_zero_unc,
+            "any_exact_zero_gg": any_exact_zero_gg,
+        },
+    )
+
+
+def apply_rm_anova_pvalue_number_formats(
+    workbook_path: str | Path,
+    *,
+    sheet_name: str = "RM-ANOVA Table",
+) -> None:
+    """Apply scientific formatting for tiny RM-ANOVA p-values in Excel output."""
+
+    path = Path(workbook_path)
+    workbook = openpyxl.load_workbook(path)
+    try:
+        if sheet_name not in workbook.sheetnames:
+            logger.info(
+                "rm_anova_sheet_not_found_for_formatting",
+                extra={"sheet_name": sheet_name, "path": str(path)},
+            )
+            return
+        worksheet = workbook[sheet_name]
+        headers = {
+            str(cell.value).strip(): idx
+            for idx, cell in enumerate(worksheet[1], start=1)
+            if isinstance(cell.value, str)
+        }
+        target_indices = [headers[col] for col in RM_ANOVA_P_COLUMNS if col in headers]
+        if not target_indices:
+            return
+        for row_idx in range(2, worksheet.max_row + 1):
+            for col_idx in target_indices:
+                cell = worksheet.cell(row=row_idx, column=col_idx)
+                value = cell.value
+                if isinstance(value, bool) or value is None:
+                    continue
+                try:
+                    numeric = float(value)
+                except Exception:
+                    continue
+                if not math.isfinite(numeric):
+                    continue
+                if numeric != 0.0 and abs(numeric) < SCIENTIFIC_P_THRESHOLD:
+                    cell.number_format = SCIENTIFIC_FMT
+                else:
+                    cell.number_format = DEFAULT_P_FMT
+    finally:
+        workbook.save(path)
+        workbook.close()
+

--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -93,6 +93,10 @@ from Tools.Stats.PySide6.stats_data_loader import (
 from Tools.Stats.PySide6.stats_logging import format_log_line, format_section_header
 from Tools.Stats.PySide6.stats_missingness import export_missingness_workbook
 from Tools.Stats.PySide6.stats_group_contrasts import export_group_contrasts_workbook
+from Tools.Stats.PySide6.stats_export_formatting import (
+    apply_rm_anova_pvalue_number_formats,
+    log_rm_anova_p_minima,
+)
 from Tools.Stats.PySide6.stats_qc_reports import export_qc_context_workbook
 from Tools.Stats.PySide6.stats_workers import StatsWorker
 from Tools.Stats.PySide6 import stats_workers as stats_worker_funcs
@@ -1422,6 +1426,9 @@ class StatsWindow(QMainWindow):
         if data is None:
             return []
 
+        if kind in {"anova", "anova_between"} and isinstance(data, pd.DataFrame):
+            log_rm_anova_p_minima(data)
+
         path = safe_export_call(
             func,
             data,
@@ -1429,6 +1436,8 @@ class StatsWindow(QMainWindow):
             fname,
             log_func=self._set_status,
         )
+        if kind in {"anova", "anova_between"}:
+            apply_rm_anova_pvalue_number_formats(path)
         return [path]
 
     def _write_dv_metadata(self, out_dir: str, pipeline_id: PipelineId) -> None:

--- a/src/Tools/Stats/PySide6/summary_utils.py
+++ b/src/Tools/Stats/PySide6/summary_utils.py
@@ -201,6 +201,12 @@ def build_summary_frames_from_results(
     return frames
 
 
+def _fmt_p(value: float) -> str:
+    if value != 0.0 and abs(value) < 0.001:
+        return f"{value:.3e}"
+    return f"{value:.6g}"
+
+
 def format_rm_anova_summary(df: pd.DataFrame, alpha: float) -> str:
     out = []
     p_candidates = ["Pr > F", "p-value", "p_value", "p", "P", "pvalue"]
@@ -252,9 +258,9 @@ def format_rm_anova_summary(df: pd.DataFrame, alpha: float) -> str:
             continue
 
         if np.isfinite(p_val) and p_val < alpha:
-            out.append(f"  - Significant {tag} (p = {p_val:.4g}).")
+            out.append(f"  - Significant {tag} (p = {_fmt_p(p_val)}).")
         elif np.isfinite(p_val):
-            out.append(f"  - No significant {tag} (p = {p_val:.4g}).")
+            out.append(f"  - No significant {tag} (p = {_fmt_p(p_val)}).")
         else:
             out.append(f"  - {tag.capitalize()}: p-value unavailable.")
     if not out:
@@ -362,7 +368,7 @@ def _summarize_rm_anova(anova_terms: Optional[pd.DataFrame], cfg: SummaryConfig)
             continue
         p_value, p_label = selected
         if p_value < cfg.alpha:
-            bullets.append(f"- Significant effect of {effect} (p = {p_value:.4g}, {p_label}).")
+            bullets.append(f"- Significant effect of {effect} (p = {_fmt_p(p_value)}, {p_label}).")
     return bullets
 
 

--- a/tests/test_rm_anova_pvalue_formatting.py
+++ b/tests/test_rm_anova_pvalue_formatting.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import openpyxl
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORT_MODULE_PATH = ROOT / "src" / "Tools" / "Stats" / "Legacy" / "stats_export.py"
+REPORTING_MODULE_PATH = ROOT / "src" / "Tools" / "Stats" / "PySide6" / "reporting_summary.py"
+FORMAT_MODULE_PATH = ROOT / "src" / "Tools" / "Stats" / "PySide6" / "stats_export_formatting.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Failed to load module at {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+stats_export = _load_module(EXPORT_MODULE_PATH, "stats_export_under_test")
+reporting_summary = _load_module(REPORTING_MODULE_PATH, "reporting_summary_under_test")
+export_formatting = _load_module(FORMAT_MODULE_PATH, "stats_export_formatting_under_test")
+
+
+def test_rm_anova_excel_preserves_small_p_values(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "Effect": "condition",
+                "Num DF": 1,
+                "Den DF": 19,
+                "F Value": 34.2,
+                "Pr > F": 3.23e-08,
+                "Pr > F (GG)": 3.23e-08,
+                "epsilon (GG)": 0.77,
+            }
+        ]
+    )
+    out = tmp_path / "RM-ANOVA Results.xlsx"
+
+    stats_export.export_rm_anova_results_to_excel(df, out, lambda _msg: None)
+    export_formatting.apply_rm_anova_pvalue_number_formats(out)
+
+    wb = openpyxl.load_workbook(out, data_only=False)
+    ws = wb["RM-ANOVA Table"]
+    header_map = {str(cell.value): i for i, cell in enumerate(ws[1], start=1)}
+
+    p_cell = ws.cell(row=2, column=header_map["Pr > F"])
+    gg_cell = ws.cell(row=2, column=header_map["Pr > F (GG)"])
+
+    assert float(p_cell.value) == 3.23e-08
+    assert float(gg_cell.value) == 3.23e-08
+    assert float(p_cell.value) != 0.0
+    assert p_cell.number_format == "0.00E+00"
+    assert gg_cell.number_format == "0.00E+00"
+
+    wb.close()
+
+
+def test_fmt_p_scientific_threshold() -> None:
+    assert "e-" in reporting_summary.fmt_p(3.23e-08)
+    assert "e" not in reporting_summary.fmt_p(0.0014).lower()
+    assert reporting_summary.fmt_p(0.0) == "0"


### PR DESCRIPTION
### Motivation
- Users observed RM-ANOVA p-values displayed as `0.0000` in Excel while the GUI showed tiny scientific p-values, so the change verifies whether underlying numeric p-values are true zeros and ensures exports/reporting display scientific notation for `p < 0.001` without changing any computations.

### Description
- Added an output-only helper module `src/Tools/Stats/PySide6/stats_export_formatting.py` that logs RM-ANOVA p-value diagnostics (`log_rm_anova_p_minima`) and post-processes Excel workbooks to set per-cell `number_format` to scientific (`0.00E+00`) for `0 < |p| < 0.001` while preserving numeric values (`apply_rm_anova_pvalue_number_formats`).
- Wired diagnostics + post-formatting into the export flow in `src/Tools/Stats/PySide6/stats_main_window.py` so both `anova` and `anova_between` exports run the checks and then apply Excel formatting after the writer returns (no change to computation order, no UI blocking).
- Introduced `fmt_p()` in `src/Tools/Stats/PySide6/reporting_summary.py` and used it to format `Pr > F`, `Pr > F (GG/HF)`, Mauchly p, and the reported p in the RM-ANOVA text report so GUI/text reports use scientific notation for p < 0.001.
- Updated plain-language summary formatting in `src/Tools/Stats/PySide6/summary_utils.py` to use the same threshold formatting for summary bullets.
- Added tests `tests/test_rm_anova_pvalue_formatting.py` that (1) write a tiny-p-value RM-ANOVA DataFrame through the existing Excel writer and assert the stored cell numeric value is preserved and the cell `number_format` is scientific, and (2) validate `fmt_p()` behavior for thresholds.
- No changes were made to statistical computation code and no files under `src/Tools/Stats/Legacy/**` or `src/Tools/SourceLocalization/**` were modified.

### Testing
- Ran linter checks with `ruff` on affected modules and they passed successfully for the modified files.
- Ran the new + related unit tests with `pytest` including `tests/test_rm_anova_pvalue_formatting.py`, `tests/test_rm_anova_reporting.py`, and `tests/test_summary_utils_posthoc_directions.py`, and the targeted tests passed (all assertions in those test files passed).
- During iteration an unrelated import issue surfaced in the test environment (missing GUI bindings), but tests were adapted to load the minimal modules and final automated test runs passed for the added tests and the related RM-ANOVA reporting tests.

Files changed:
- `src/Tools/Stats/PySide6/stats_export_formatting.py` (new)
- `src/Tools/Stats/PySide6/stats_main_window.py` (export wiring)
- `src/Tools/Stats/PySide6/reporting_summary.py` (added `fmt_p()` and used it in RM-ANOVA text report)
- `src/Tools/Stats/PySide6/summary_utils.py` (summary formatting)
- `tests/test_rm_anova_pvalue_formatting.py` (new pytest)

All changes are output/reporting-only and preserve numeric values in Excel (no string coercion), keep report files under the existing Stats results folder, and avoid prints or UI-thread blocking.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1817b744832c912257c64ebac37d)