### PR TITLE
Fix LMM p-value underflow, record optimizer, and restore Mixed Model GUI summary

### DIFF
--- a/src/Tools/Stats/PySide6/stats_export_formatting.py
+++ b/src/Tools/Stats/PySide6/stats_export_formatting.py
@@ -128,6 +128,7 @@ def apply_lmm_number_formats_and_metadata(
                         continue
                     if not math.isfinite(numeric):
                         continue
+                    cell.value = numeric
                     cell.number_format = SCIENTIFIC_FMT if (numeric != 0.0 and abs(numeric) < SCIENTIFIC_P_THRESHOLD) else DEFAULT_P_FMT
 
         attrs = lmm_df.attrs if isinstance(lmm_df, pd.DataFrame) else {}
@@ -151,7 +152,10 @@ def apply_lmm_number_formats_and_metadata(
                         numeric = float(cell.value)
                     except Exception:
                         continue
-                    if math.isfinite(numeric) and numeric != 0.0 and abs(numeric) < SCIENTIFIC_P_THRESHOLD:
+                    if not math.isfinite(numeric):
+                        continue
+                    cell.value = numeric
+                    if numeric != 0.0 and abs(numeric) < SCIENTIFIC_P_THRESHOLD:
                         cell.number_format = SCIENTIFIC_FMT
                     else:
                         cell.number_format = DEFAULT_P_FMT

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -86,6 +86,7 @@ from Tools.Stats.PySide6.lmm_reporting import (
     build_lmm_text_report,
     ensure_lmm_effect_columns,
     infer_lmm_diagnostics,
+    repair_lmm_pvalues_from_z,
 )
 
 logger = logging.getLogger("Tools.Stats")
@@ -1627,6 +1628,7 @@ def run_lmm(
         method=method_requested,
         return_model=True,
     )
+    mixed_results_df = repair_lmm_pvalues_from_z(mixed_results_df)
     mixed_results_df = ensure_lmm_effect_columns(mixed_results_df)
     formula_lhs = f"{dv_col} ~ "
     formula_rhs = formula_fixed_terms[0]

--- a/tests/test_lmm_reporting_exports.py
+++ b/tests/test_lmm_reporting_exports.py
@@ -7,11 +7,11 @@ import sys
 
 import openpyxl
 import pandas as pd
-from scipy.stats import norm
 
 ROOT = Path(__file__).resolve().parents[1]
 REPORT_PATH = ROOT / "src" / "Tools" / "Stats" / "PySide6" / "lmm_reporting.py"
 FORMAT_PATH = ROOT / "src" / "Tools" / "Stats" / "PySide6" / "stats_export_formatting.py"
+SUMMARY_PATH = ROOT / "src" / "Tools" / "Stats" / "PySide6" / "summary_utils.py"
 
 
 def _load_module(path: Path, name: str):
@@ -26,6 +26,7 @@ def _load_module(path: Path, name: str):
 
 lmm_reporting = _load_module(REPORT_PATH, "lmm_reporting_under_test")
 export_formatting = _load_module(FORMAT_PATH, "lmm_export_formatting_under_test")
+summary_utils = _load_module(SUMMARY_PATH, "lmm_summary_utils_under_test")
 
 
 def test_humanize_effect_labels() -> None:
@@ -38,10 +39,68 @@ def test_humanize_effect_labels() -> None:
     assert "Condition×Roi:" in label
 
 
-def test_wald_p_not_zero_underflow() -> None:
-    p_value = float(2.0 * norm.sf(10.0))
-    assert p_value > 0.0
-    assert p_value != 0.0
+def test_wald_p_underflow_fixed() -> None:
+    p_10248 = lmm_reporting.compute_two_sided_wald_p(10.248)
+    p_12643 = lmm_reporting.compute_two_sided_wald_p(12.643)
+    assert p_10248 > 0.0
+    assert p_10248 < 1e-10
+    assert p_12643 > 0.0
+
+
+def test_optimizer_recorded_in_attrs() -> None:
+    import numpy as np
+    import statsmodels.formula.api as smf
+
+    rng = np.random.default_rng(7)
+    subject_effect = {f"S{i}": float(rng.normal(0.0, 0.4)) for i in range(12)}
+    rows = []
+    for subject in subject_effect:
+        for condition in ("A", "B"):
+            for roi in ("R1", "R2"):
+                rows.append(
+                    {
+                        "subject": subject,
+                        "condition": condition,
+                        "roi": roi,
+                        "value": (
+                            1.0
+                            + subject_effect[subject]
+                            + (0.5 if condition == "B" else -0.5)
+                            + (0.25 if roi == "R2" else -0.25)
+                            + float(rng.normal(0.0, 0.15))
+                        ),
+                    }
+                )
+    df = pd.DataFrame(rows)
+    model = smf.mixedlm(
+        "value ~ C(condition, Sum) * C(roi, Sum)",
+        df,
+        groups=df["subject"],
+        re_formula="1",
+    ).fit(reml=True, method="powell", maxiter=1000, full_output=True)
+
+    lmm_df = pd.DataFrame({"Effect": ["Intercept"], "Note": [""]})
+    converged, singular, optimizer, warnings = lmm_reporting.infer_lmm_diagnostics(lmm_df, model)
+    lmm_reporting.attach_lmm_run_metadata(
+        table=lmm_df,
+        formula="value ~ C(condition, Sum) * C(roi, Sum)",
+        fixed_effects=["C(condition, Sum) * C(roi, Sum)"],
+        contrast_map={"condition": "Sum", "roi": "Sum"},
+        method_requested="reml",
+        method_used="REML",
+        re_formula_requested="1",
+        re_formula_used="1",
+        backed_off_random_slopes=False,
+        converged=converged,
+        singular=singular,
+        optimizer_used=optimizer,
+        fit_warnings=warnings,
+        rows_input=len(df),
+        rows_used=len(df),
+        subjects_used=df["subject"].nunique(),
+        lrt_table=None,
+    )
+    assert lmm_df.attrs["lmm_optimizer_used"] in {"lbfgs", "powell"}
 
 
 def test_lmm_attrs_populated() -> None:
@@ -133,3 +192,20 @@ def test_lmm_text_report_written_to_stats_results_dir(tmp_path: Path) -> None:
 
     assert report_path.exists()
     assert report_path.parent == stats_dir
+
+
+def test_gui_summary_no_placeholder() -> None:
+    lmm_df = pd.DataFrame(
+        {
+            "Effect (readable)": ["Intercept (grand mean)", "Condition: Demo (Sum-coded)"],
+            "Coef.": [0.3, 0.2],
+            "P>|z|": [1.21e-24, 0.0049],
+        }
+    )
+    frames = summary_utils.StatsSummaryFrames(mixed_model_terms=lmm_df)
+    config = summary_utils.SummaryConfig(alpha=0.05)
+    summary = summary_utils.build_summary_from_frames(frames=frames, config=config)
+    assert "no summary is available" not in summary.lower()
+    assert "Wald z-tests (normal approximation)" in summary
+
+


### PR DESCRIPTION
### Motivation
- Prevent Wald p-values from numerically underflowing to exact `0.0` for very large |Z| so tiny but nonzero p-values are preserved for reporting and Excel exports.
- Ensure the optimizer actually used by `statsmodels.MixedLM` is recorded and propagated into LMM metadata for export and diagnostics instead of showing "NOT AVAILABLE".
- Replace the placeholder mixed-model GUI summary with a coefficient-driven summary that reports Wald inference and formats tiny p-values for readability.

### Description
- Added a stable tail p-value helper `compute_two_sided_wald_p` (uses `2 * norm.sf(|z|)` with an `erfc` fallback) and a `repair_lmm_pvalues_from_z` step that recomputes `P>|z|` from `Z` before downstream reporting; changes in `src/Tools/Stats/PySide6/lmm_reporting.py` and pipeline wiring in `src/Tools/Stats/PySide6/stats_workers.py`.
- Improved optimizer inference by inspecting `model.hist` and other fit-history attributes and ensuring `lmm_optimizer_used` is always populated, with metadata attached via `attach_lmm_run_metadata`; changes in `src/Tools/Stats/PySide6/lmm_reporting.py`.
- Ensure Excel export writes p-values as numeric floats and applies scientific number formatting for `0 < p < 0.001` for both the "Mixed Model" and optional "LRT" sheets; changes in `src/Tools/Stats/PySide6/stats_export_formatting.py`.
- Restore and improve the mixed-model summary builder to emit real, coefficient-based bullets including the inference type and scientific formatting rules (prefer `Effect (readable)` when available); changes in `src/Tools/Stats/PySide6/summary_utils.py`.
- Tests added/updated in `tests/test_lmm_reporting_exports.py` to cover underflow-safe p-values, optimizer-recording in attrs, GUI summary no-placeholder behavior, and Excel scientific p formatting.

### Testing
- Ran `ruff` checks on modified modules (`src/Tools/Stats/PySide6/*.py`) and reported no lint issues (passed).
- Ran the focused test module `pytest -q tests/test_lmm_reporting_exports.py` which completed successfully with `7 passed`.
- Performed the LMM pipeline integration in `stats_workers` to recompute p-values and attach metadata and validated exports by executing the added unit tests that exercise Excel formatting and text-summary generation (all assertions passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e3c4b8c54832cabbb0faca8b14bb1)