### PR TITLE
Add "FFT and neighbors" debug worksheet to legacy Excel export

### DIFF
--- a/src/Main_App/Legacy_App/post_process.py
+++ b/src/Main_App/Legacy_App/post_process.py
@@ -7,10 +7,12 @@ import gc
 import mne
 import re
 from config import TARGET_FREQUENCIES, DEFAULT_ELECTRODE_NAMES_64  # Ensure these are correct
-from typing import List, Any
+from typing import List, Any, Dict
 from Tools.Stats.Legacy.full_snr import compute_full_snr
 from Tools.Stats.Legacy.noise_utils import compute_noise_stats_for_bin
 
+
+from Main_App.Legacy_App.post_process_excel import build_fft_neighbors_rows, write_results_workbook
 
 def post_process(app: Any, condition_labels_present: List[str]) -> None:
     """
@@ -128,6 +130,7 @@ def post_process(app: Any, condition_labels_present: List[str]) -> None:
         # --- Metrics Calculation (largely unchanged) ---
         accum = {"fft": None, "snr": None, "z": None, "bca": None}
         full_snr_accum = None
+        fft_neighbors_rows: List[Dict[str, Any]] = []
         valid_data_count = 0
         final_num_channels = 0
         final_electrode_names_ordered = []
@@ -220,6 +223,22 @@ def post_process(app: Any, condition_labels_present: List[str]) -> None:
                 fft_full_spectrum = np.fft.fft(avg_data_uv, axis=1)
                 fft_amplitudes = (
                     np.abs(fft_full_spectrum[:, :num_fft_bins]) / num_times * 2
+                )
+
+                source_file_name = os.path.basename(app.data_paths[0]) if app.data_paths else pid
+                fft_neighbors_rows.extend(
+                    build_fft_neighbors_rows(
+                        file_name=source_file_name,
+                        condition_label=cond_label_from_keys,
+                        condition_id=cond_label_from_keys,
+                        repetition_index=str(data_idx + 1),
+                        electrode_names=ordered_electrode_names_for_df,
+                        fft_amplitudes=fft_amplitudes,
+                        freqs=fft_frequencies,
+                        fs=sfreq,
+                        n_samples=num_times,
+                        target_freq=1.2,
+                    )
                 )
 
                 # Full-spectrum SNR (uses shared noise logic via compute_full_snr)
@@ -368,30 +387,35 @@ def post_process(app: Any, condition_labels_present: List[str]) -> None:
                     0, "Electrode", dataframes_to_save[df_name_iter].index
                 )
 
+            neighbor_columns = [
+                "file_name",
+                "condition_label",
+                "condition_id",
+                "repetition_index",
+                "channel_or_roi",
+                "target",
+                "fs",
+                "N",
+                "T_sec",
+                "df_hz",
+                "k0",
+                "f_bin_hz",
+                *[f"amp_m{i}" for i in range(11, 0, -1)],
+                *[f"amp_p{i}" for i in range(1, 12)],
+                "warning",
+            ]
+            fft_neighbors_df = pd.DataFrame(fft_neighbors_rows)
+            if fft_neighbors_df.empty:
+                fft_neighbors_df = pd.DataFrame(columns=neighbor_columns)
+            else:
+                fft_neighbors_df = fft_neighbors_df.reindex(columns=neighbor_columns)
+
             try:
-                with pd.ExcelWriter(full_excel_path, engine="xlsxwriter") as writer:
-                    workbook = writer.book
-                    center_fmt = workbook.add_format(
-                        {"align": "center", "valign": "vcenter"}
-                    )
-                    for sheet_name, df_to_write in dataframes_to_save.items():
-                        df_to_write.to_excel(
-                            writer, sheet_name=sheet_name, index=False
-                        )
-                        worksheet = writer.sheets[sheet_name]
-                        for col_idx, header_name in enumerate(df_to_write.columns):
-                            max_len = max(
-                                len(str(header_name)),
-                                df_to_write[header_name]
-                                .astype(str)
-                                .map(len)
-                                .max()
-                                if not df_to_write[header_name].empty
-                                else 0,
-                            )
-                            worksheet.set_column(
-                                col_idx, col_idx, max_len + 4, center_fmt
-                            )
+                write_results_workbook(
+                    full_excel_path=full_excel_path,
+                    dataframes_to_save=dataframes_to_save,
+                    fft_neighbors_df=fft_neighbors_df,
+                )
                 app.log(f"Successfully saved Excel: {excel_filename}")
                 any_results_saved = True
             except Exception as write_err:

--- a/src/Main_App/Legacy_App/post_process_excel.py
+++ b/src/Main_App/Legacy_App/post_process_excel.py
@@ -1,0 +1,101 @@
+import numpy as np
+import pandas as pd
+from typing import Any, Dict, List, Optional
+
+
+NEIGHBOR_OFFSETS = [*range(-11, 0), *range(1, 12)]
+
+
+def build_fft_neighbors_rows(
+    *,
+    file_name: str,
+    condition_label: str,
+    condition_id: str,
+    repetition_index: str,
+    electrode_names: List[str],
+    fft_amplitudes: np.ndarray,
+    freqs: np.ndarray,
+    fs: float,
+    n_samples: int,
+    target_freq: float = 1.2,
+) -> List[Dict[str, Any]]:
+    """Build per-channel FFT neighbor rows (±11 bins, excluding center bin)."""
+    rows: List[Dict[str, Any]] = []
+    if len(freqs) == 0:
+        return rows
+
+    k0 = int(round(target_freq * n_samples / fs))
+    if not (0 <= k0 < len(freqs)):
+        k0 = int(np.argmin(np.abs(freqs - target_freq)))
+    f_bin_hz = float(freqs[k0]) if 0 <= k0 < len(freqs) else np.nan
+
+    for chan_idx, channel_name in enumerate(electrode_names):
+        row: Dict[str, Any] = {
+            "file_name": file_name,
+            "condition_label": condition_label,
+            "condition_id": condition_id,
+            "repetition_index": repetition_index,
+            "channel_or_roi": channel_name,
+            "target": "1.2Hz",
+            "fs": float(fs),
+            "N": int(n_samples),
+            "T_sec": float(n_samples / fs) if fs else np.nan,
+            "df_hz": float(fs / n_samples) if n_samples else np.nan,
+            "k0": int(k0),
+            "f_bin_hz": f_bin_hz,
+            "warning": "",
+        }
+        out_of_bounds = []
+        for offset in NEIGHBOR_OFFSETS:
+            col_name = f"amp_m{abs(offset)}" if offset < 0 else f"amp_p{offset}"
+            neighbor_idx = k0 + offset
+            if 0 <= neighbor_idx < len(freqs):
+                row[col_name] = float(fft_amplitudes[chan_idx, neighbor_idx])
+            else:
+                row[col_name] = np.nan
+                out_of_bounds.append(offset)
+        if out_of_bounds:
+            row["warning"] = (
+                "neighbor bins out of range: "
+                + ",".join(str(offset) for offset in out_of_bounds)
+            )
+        rows.append(row)
+    return rows
+
+
+def write_results_workbook(
+    full_excel_path: str,
+    dataframes_to_save: Dict[str, pd.DataFrame],
+    fft_neighbors_df: Optional[pd.DataFrame] = None,
+) -> None:
+    """Write results workbook with consistent formatting and optional debug sheet."""
+    with pd.ExcelWriter(full_excel_path, engine="xlsxwriter") as writer:
+        workbook = writer.book
+        center_fmt = workbook.add_format({"align": "center", "valign": "vcenter"})
+
+        for sheet_name, df_to_write in dataframes_to_save.items():
+            df_to_write.to_excel(writer, sheet_name=sheet_name, index=False)
+            worksheet = writer.sheets[sheet_name]
+            worksheet.freeze_panes(1, 0)
+            for col_idx, header_name in enumerate(df_to_write.columns):
+                max_len = max(
+                    len(str(header_name)),
+                    df_to_write[header_name].astype(str).map(len).max()
+                    if not df_to_write[header_name].empty
+                    else 0,
+                )
+                worksheet.set_column(col_idx, col_idx, max_len + 4, center_fmt)
+
+        if fft_neighbors_df is not None and not fft_neighbors_df.empty:
+            sheet_name = "FFT and neighbors"
+            fft_neighbors_df.to_excel(writer, sheet_name=sheet_name, index=False)
+            worksheet = writer.sheets[sheet_name]
+            worksheet.freeze_panes(1, 0)
+            for col_idx, header_name in enumerate(fft_neighbors_df.columns):
+                max_len = max(
+                    len(str(header_name)),
+                    fft_neighbors_df[header_name].astype(str).map(len).max()
+                    if not fft_neighbors_df[header_name].empty
+                    else 0,
+                )
+                worksheet.set_column(col_idx, col_idx, max_len + 4, center_fmt)

--- a/tests/test_fft_neighbors_sheet.py
+++ b/tests/test_fft_neighbors_sheet.py
@@ -1,0 +1,72 @@
+import pytest
+from Main_App.Legacy_App.post_process_excel import (
+    build_fft_neighbors_rows,
+    write_results_workbook,
+)
+
+np = pytest.importorskip('numpy')
+pd = pytest.importorskip('pandas')
+load_workbook = pytest.importorskip('openpyxl').load_workbook
+
+
+def test_fft_neighbors_sheet_written_with_expected_columns(tmp_path):
+    fs = 12.0
+    n_samples = 120
+    freqs = np.fft.rfftfreq(n_samples, d=1.0 / fs)
+    fft_amplitudes = np.arange(2 * len(freqs), dtype=float).reshape(2, len(freqs))
+
+    rows = build_fft_neighbors_rows(
+        file_name="demo.bdf",
+        condition_label="Condition A",
+        condition_id="Condition A",
+        repetition_index="1",
+        electrode_names=["Oz", "POz"],
+        fft_amplitudes=fft_amplitudes,
+        freqs=freqs,
+        fs=fs,
+        n_samples=n_samples,
+        target_freq=1.2,
+    )
+
+    neighbor_columns = [
+        "file_name",
+        "condition_label",
+        "condition_id",
+        "repetition_index",
+        "channel_or_roi",
+        "target",
+        "fs",
+        "N",
+        "T_sec",
+        "df_hz",
+        "k0",
+        "f_bin_hz",
+        *[f"amp_m{i}" for i in range(11, 0, -1)],
+        *[f"amp_p{i}" for i in range(1, 12)],
+        "warning",
+    ]
+
+    neighbors_df = pd.DataFrame(rows).reindex(columns=neighbor_columns)
+    workbook_path = tmp_path / "result.xlsx"
+
+    write_results_workbook(
+        str(workbook_path),
+        {"FFT Amplitude (uV)": pd.DataFrame({"Electrode": ["Oz"], "1.2000_Hz": [1.0]})},
+        neighbors_df,
+    )
+
+    wb = load_workbook(workbook_path)
+    assert "FFT and neighbors" in wb.sheetnames
+
+    ws = wb["FFT and neighbors"]
+    header = [cell.value for cell in ws[1]]
+
+    expected_neighbor_cols = [
+        *[f"amp_m{i}" for i in range(11, 0, -1)],
+        *[f"amp_p{i}" for i in range(1, 12)],
+    ]
+
+    for col_name in expected_neighbor_cols:
+        assert col_name in header
+    assert len([c for c in header if c.startswith("amp_")]) == 22
+    assert "amp_0" not in header


### PR DESCRIPTION
### Motivation
- Provide a per-file, per-channel debugging sheet to inspect ±11 FFT bins around the 1.2 Hz oddball (bin-lock / leakage investigation) without changing any existing outputs or processing order. 
- Export enough metadata (fs, N, T_sec, df_hz, k0, bin center) so consumers can interpret the neighbor amplitudes unambiguously.
- Keep the change additive and non-invasive: reuse already-computed FFT amplitudes and append a new sheet during the existing Excel write step.

### Description
- Added a new helper module `src/Main_App/Legacy_App/post_process_excel.py` which provides `build_fft_neighbors_rows(...)` (builds one row per file/condition/rep/channel with columns `file_name, condition_label, condition_id, repetition_index, channel_or_roi, target, fs, N, T_sec, df_hz, k0, f_bin_hz, amp_m11..amp_m1, amp_p1..amp_p11, warning`) and `write_results_workbook(...)` (centralized Excel writer that applies center alignment, auto-width padding, and freezes the top row). 
- Integrated the neighbor-row capture into the existing legacy pipeline at the point where FFT amplitudes are already computed in `src/Main_App/Legacy_App/post_process.py` so there is no FFT recomputation and the processing order is preserved. 
- Implemented oddball bin logic: primary `k0 = int(round(target_freq * N / fs))` with fallback to `argmin(|freqs - target_freq|)`; both `k0` and `freqs[k0]` are exported; out-of-range neighbor indices are written as `NaN` and flagged in the `warning` field. 
- Added `tests/test_fft_neighbors_sheet.py` which constructs a minimal FFT amplitude/freq fixture, invokes the writer, and asserts that the workbook contains the exact 22 neighbor amplitude columns (`amp_m11..amp_m1`, `amp_p1..amp_p11`) and that `amp_0` is not present.

### Testing
- Ran lint/typing checks via `ruff check` on the modified files and found no issues (PASS).
- Ran the new pytest: `pytest -q tests/test_fft_neighbors_sheet.py` and it passed (1 test, 1 passed) (PASS).
- Verified syntax/bytecode with `python -m py_compile` on changed files (PASS).
- PowerShell (`pwsh`) was not available in the environment, so I executed a Python equivalent of the requested `Select-String` audit; sample matches returned (first block):
  - `src/Main_App/Legacy_App/post_process.py	365	f"WARN [fft_crop] bin_mismatch cond={cond_label_from_keys} target={target_freq} argmin={target_bin_index} exact={exact_k}`
  - `src/Main_App/Legacy_App/fft_crop_utils.py	39	def compute_fft_crop_from_events(`
  - `src/Main_App/Legacy_App/processing_utils.py	270	fft_crop_debug_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt,`
- Verification gates: imports and compilation (PASS), processing order unchanged (PASS), existing sheet schemas unchanged (PASS), new sheet present with correct columns (covered by unit test PASS), Excel styling applied via the centralized writer (PASS), no hard-coded user paths (PASS), SourceLocalization untouched (PASS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c0869e14832c9cfe800df061492c)