### PR TITLE
Enforce on-bin FFT crop length for 55-anchored segments

### DIFF
--- a/src/Main_App/Legacy_App/fft_crop_utils.py
+++ b/src/Main_App/Legacy_App/fft_crop_utils.py
@@ -27,13 +27,22 @@ class CropResult:
     warnings: list[str] = field(default_factory=list)
 
 
-def _compute_n_step(fs: float) -> Tuple[Optional[int], Optional[str]]:
+ODDBALL_FREQ = Fraction(6, 5)
+
+
+def compute_onbin_step(fs: float, f_oddball: Fraction = ODDBALL_FREQ) -> Tuple[Optional[int], Optional[int], Optional[str]]:
     fs_i = int(round(fs))
     if abs(fs - fs_i) >= 1e-6:
-        return None, f"non_integer_fs:{fs}"
-    frac = Fraction(6, 5)
-    den_fs = frac.denominator * fs_i
-    return den_fs // gcd(frac.numerator, den_fs), None
+        return None, None, f"non_integer_fs:{fs}"
+    den_fs = f_oddball.denominator * fs_i
+    n_step = den_fs // gcd(f_oddball.numerator, den_fs)
+    return fs_i, n_step, None
+
+
+def compute_onbin_N(available_samples: int, N_step: int) -> int:
+    if available_samples <= 0 or N_step <= 0:
+        return 0
+    return (available_samples // N_step) * N_step
 
 
 def compute_fft_crop_from_events(
@@ -51,7 +60,7 @@ def compute_fft_crop_from_events(
         run_warnings.append("empty_events")
         return results, None, run_warnings
 
-    n_step, step_err = _compute_n_step(fs)
+    _, n_step, step_err = compute_onbin_step(fs=fs)
     if step_err:
         run_warnings.append(step_err)
 
@@ -103,7 +112,7 @@ def compute_fft_crop_from_events(
             n_samples = 0
             crop_start = onset_sample
         else:
-            n_samples = (available // n_step) * n_step
+            n_samples = compute_onbin_N(available_samples=available, N_step=n_step)
             crop_start = first55
             if n_samples <= 0:
                 fallback = True

--- a/src/Main_App/Legacy_App/processing_utils.py
+++ b/src/Main_App/Legacy_App/processing_utils.py
@@ -23,7 +23,7 @@ from Tools.SourceLocalization.logging_utils import QueueLogHandler
 from Main_App.Legacy_App.post_process import post_process as _external_post_process
 from Main_App.Legacy_App.eeg_preprocessing import perform_preprocessing
 from Main_App.Legacy_App.load_utils import load_eeg_file
-from Main_App.Legacy_App.fft_crop_utils import compute_fft_crop_from_events
+from Main_App.Legacy_App.fft_crop_utils import compute_fft_crop_from_events, compute_onbin_step, ODDBALL_FREQ
 
 
 def _sanitize_folder_name(label: str) -> str:
@@ -489,6 +489,11 @@ class ProcessingMixin:
                                     if not crop.fallback and crop.n_samples > 0:
                                         n_common = crop.n_samples if n_common is None else min(n_common, crop.n_samples)
 
+                                if n_common is not None and n_step is not None:
+                                    n_common = (n_common // n_step) * n_step
+                                    if n_common <= 0:
+                                        n_common = None
+
                                 if n_common_by_label.get(lbl) is None and n_common is not None:
                                     n_common_by_label[lbl] = n_common
 
@@ -521,6 +526,30 @@ class ProcessingMixin:
                                     df_hz = sfreq / n_used if n_used > 0 else 0.0
                                     k = (1.2 * n_used / sfreq) if sfreq > 0 else 0.0
                                     k_is_int = abs(k - round(k)) < 1e-9
+                                    _, n_step_check, step_err = compute_onbin_step(fs=sfreq, f_oddball=ODDBALL_FREQ)
+                                    f_bin_hz = (sfreq / n_used) * round(k) if n_used > 0 and sfreq > 0 else 0.0
+                                    if not use_fallback:
+                                        if n_step_check is None or n_used % n_step_check != 0:
+                                            raise ValueError(
+                                                f"FFT crop enforcement failed for {f_name}/{lbl}: N={n_used}, N_step={n_step_check}"
+                                            )
+                                        fs_i = int(round(sfreq))
+                                        if (ODDBALL_FREQ.numerator * n_used) % (ODDBALL_FREQ.denominator * fs_i) != 0:
+                                            raise ValueError(
+                                                f"FFT bin-lock failed for {f_name}/{lbl}: N={n_used}, fs_i={fs_i}"
+                                            )
+                                        fft_crop_log(
+                                            "INFO",
+                                            f"FFT_CROP_ACTIVE file={f_name} condition={lbl} rep={rep_key[1]} fs={sfreq:.6f} "
+                                            f"N_step={n_step_check} N={n_used} N%N_step={n_used % n_step_check} "
+                                            f"k={k:.8f} f_bin={f_bin_hz:.12f}",
+                                        )
+                                    else:
+                                        fft_crop_log(
+                                            "WARN",
+                                            f"FFT_CROP_FALLBACK file={f_name} condition={lbl} rep={rep_key[1]} reason={fallback_reason or step_err or 'unknown'} "
+                                            f"N={n_used} k={k:.8f} f_bin={f_bin_hz:.12f}",
+                                        )
                                     fft_crop_log(
                                         "INFO" if not use_fallback else "WARN",
                                         f"file={f_name} condition={lbl} rep={rep_key[1]} block=({crop.block_start_sample},{crop.block_end_sample}) "

--- a/src/Main_App/Legacy_App/test_fft_onbin.py
+++ b/src/Main_App/Legacy_App/test_fft_onbin.py
@@ -1,0 +1,66 @@
+from fractions import Fraction
+
+import numpy as np
+
+from Main_App.Legacy_App.fft_crop_utils import compute_onbin_N, compute_onbin_step
+from Main_App.Legacy_App.post_process_excel import build_fft_neighbors_rows
+
+
+def test_compute_onbin_step_fs_256_and_divisible_n():
+    fs_i, n_step, err = compute_onbin_step(256.0, Fraction(6, 5))
+    assert err is None
+    assert fs_i == 256
+    assert n_step == 640
+
+    available_samples = 32257
+    n = compute_onbin_N(available_samples, n_step)
+    assert n % 640 == 0
+
+
+def test_compute_onbin_step_fs_512_and_divisible_n():
+    fs_i, n_step, err = compute_onbin_step(512.0, Fraction(6, 5))
+    assert err is None
+    assert fs_i == 512
+    assert n_step == 1280
+
+    n = compute_onbin_N(9999, n_step)
+    assert n % n_step == 0
+
+
+def test_compute_onbin_n_smaller_than_step_returns_zero():
+    _, n_step, err = compute_onbin_step(256.0, Fraction(6, 5))
+    assert err is None
+    n = compute_onbin_N(available_samples=n_step - 1, N_step=n_step)
+    assert n == 0
+
+
+def test_compute_onbin_n_stop_exclusive_no_plus_one():
+    _, n_step, err = compute_onbin_step(256.0, Fraction(6, 5))
+    assert err is None
+    n = compute_onbin_N(available_samples=n_step, N_step=n_step)
+    assert n == n_step
+
+
+def test_fft_neighbors_sheet_metadata_uses_enforced_n_and_df():
+    fs = 256.0
+    n_samples = 640
+    freqs = np.fft.rfftfreq(n_samples, d=1.0 / fs)
+    fft_amplitudes = np.ones((1, len(freqs)))
+
+    rows = build_fft_neighbors_rows(
+        file_name="demo.fif",
+        condition_label="cond",
+        condition_id="1",
+        repetition_index="1",
+        electrode_names=["Oz"],
+        fft_amplitudes=fft_amplitudes,
+        freqs=freqs,
+        fs=fs,
+        n_samples=n_samples,
+        target_freq=1.2,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["N"] == n_samples
+    assert row["df_hz"] == fs / n_samples


### PR DESCRIPTION
### Motivation
- Ensure FFT segment length `N` is exactly on-bin when 55-anchored cropping is available so target 1.2 Hz lands on an FFT bin (e.g., fs=256 → `N_step=640`).
- Avoid MNE epoch endpoint-inclusive sample-count issues by using stop-exclusive sample indexing and only trimming (never extending) to the nearest `N_step` multiple.
- Preserve legacy fallback behavior when `fs` is non-integer or 55-run info is insufficient and add explicit logging when fallback occurs.

### Description
- Added pure helpers in `fft_crop_utils.py`: `compute_onbin_step(fs, f_oddball=Fraction(6,5))` which returns `(fs_i, N_step, err)` and `compute_onbin_N(available_samples, N_step)` which computes `N = floor(available / N_step) * N_step`.
- Wired the 55-crop computation in `compute_fft_crop_from_events` to use these helpers and to compute `available = last55 - first55` with stop-exclusive semantics, storing results in `CropResult.n_samples`.
- In the worker path (`processing_utils.py`) enforced a common per-condition `n_common` to be a multiple of `N_step`, extracted segments via `raw.get_data(start, stop)` (stop exclusive), and added strict checks that non-fallback rows satisfy divisibility and the exact bin-lock condition `(6*N) % (5*fs_i) == 0`.
- Added consistent logging lines for both active enforcement (`FFT_CROP_ACTIVE ...`) and fallback cases (`FFT_CROP_FALLBACK ...`) that include `file`, `fs`, `N_step`, `N`, `k`, and `f_bin` diagnostics.
- Added unit tests `src/Main_App/Legacy_App/test_fft_onbin.py` covering `fs=256` and `fs=512` `N_step` math, small-available fallback (`N=0`), stop-exclusive behavior (no `+1`), and FFT-neighbors metadata (`N` and `df_hz=fs/N`).

### Testing
- Ran unit tests with `PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q src/Main_App/Legacy_App/test_fft_onbin.py` and observed all tests passing (`5 passed`).
- Linted/checked changed modules with `PYTHONPATH=src ruff check ...` and observed no issues (`All checks passed`).
- Note: an initial `pytest` invocation in this container failed due to the `pytest-qt` plugin auto-loading (missing `libGL.so.1`), which was resolved by disabling plugin autoload with `PYTEST_DISABLE_PLUGIN_AUTOLOAD` and setting `PYTHONPATH=src` for test collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ef083580832ca640059117bc2b63)