### PR TITLE
Fix BASELINE_VS_ZERO StatsRunReport missing final_modeled_pids

### DIFF
--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1995,6 +1995,7 @@ def run_baseline_vs_zero(
             qc_report=qc_report,
             dv_report=exclusion_report,
             required_exclusions=required_exclusions,
+            final_modeled_pids=sorted(df_long["subject"].unique().tolist()),
         ),
     }
 


### PR DESCRIPTION
### Motivation
- `StatsRunReport` is a frozen dataclass whose fields are required and include `final_modeled_pids`, so omitting that argument causes a constructor-time error in the BASELINE_VS_ZERO pipeline.  
- The BASELINE_VS_ZERO worker built a `run_report` payload that did not include `final_modeled_pids`, causing the observed crash when the run report was constructed.

### Description
- Added `final_modeled_pids=sorted(df_long["subject"].unique().tolist())` to the BASELINE_VS_ZERO `StatsRunReport` construction so it matches other stats steps that report modeled subject IDs.  
- Touched file: `src/Tools/Stats/PySide6/stats_workers.py`.  
- Unified diff:  
```diff
diff --git a/src/Tools/Stats/PySide6/stats_workers.py b/src/Tools/Stats/PySide6/stats_workers.py
index 16bf6b5..2d3b391 100644
--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1995,6 +1995,7 @@ def run_baseline_vs_zero(
             qc_report=qc_report,
             dv_report=exclusion_report,
             required_exclusions=required_exclusions,
+            final_modeled_pids=sorted(df_long["subject"].unique().tolist()),
         ),
     }
```
- Reasoning: `final_modeled_pids` is derived from the post-filter `df_long` (the same source used by RM_ANOVA/MIXED_MODEL and other workers), ensuring consistent behavior and preventing missing-argument errors.

### Testing
- Ran `python -m pytest -q` which failed to run in this environment due to a test bootstrap `PySide6.__spec__ is None` import issue (environmental, pre-existing).  
- Ran `ruff check .` and it passed (`All checks passed!`).  
- Ran `mypy src --strict` which reported many pre-existing typing errors across the repo unrelated to this change (mypy failures are not caused by this small fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997307e247c832ca7a9b2afeecb49a0)