### PR TITLE
Make Ratio Calculator ROIs dynamic from Settings at runtime

### DIFF
--- a/src/Tools/Ratio_Calculator/gui.py
+++ b/src/Tools/Ratio_Calculator/gui.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import os
 import re
 import sys
+from time import perf_counter
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
+import logging
 
-from PySide6.QtCore import QSignalBlocker, QThread, Qt
+from PySide6.QtCore import QSignalBlocker, QThread, Qt, QTimer
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -35,16 +37,23 @@ from PySide6.QtWidgets import (
     QStyle,
 )
 
-from .constants import RatioCalculatorSettings, ROI_DEFS_DEFAULT
+from .constants import RatioCalculatorSettings
+from .roi_provider import load_ratio_rois
 from .worker import RatioCalculatorWorker
 from .utils import parse_participant_id
 
 PID_PATTERN = re.compile(r"^P\d+$", re.IGNORECASE)
 CUSTOM_CONDITION_OPTION = "Custom path"
+logger = logging.getLogger(__name__)
 
 
 class RatioCalculatorWindow(QWidget):
-    def __init__(self, parent: QWidget | None = None, project_root: str | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        project_root: str | None = None,
+        roi_loader: Callable[[], dict[str, list[str]]] | None = None,
+    ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Ratio Calculator")
         self.resize(980, 760)
@@ -60,6 +69,12 @@ class RatioCalculatorWindow(QWidget):
         self._label_b_dirty = False
         self._run_label_dirty = False
         self._loading_participants = False
+        self._roi_loader = roi_loader or load_ratio_rois
+        self._active_roi_defs: dict[str, list[str]] = {}
+        self._roi_settings_signature: tuple[tuple[str, tuple[str, ...]], ...] = ()
+        self._roi_watch_timer = QTimer(self)
+        self._roi_watch_timer.setInterval(1500)
+        self._roi_watch_timer.timeout.connect(self._sync_rois_if_changed)
 
         main_layout = QVBoxLayout(self)
         self.tabs = QTabWidget()
@@ -79,6 +94,8 @@ class RatioCalculatorWindow(QWidget):
         self._apply_button_icons()
 
         self._refresh_conditions()
+        self._refresh_rois()
+        self._roi_watch_timer.start()
         self._set_default_output()
         self._update_run_state()
 
@@ -289,23 +306,13 @@ class RatioCalculatorWindow(QWidget):
         self.roi_table.verticalHeader().setVisible(False)
         self.roi_table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.roi_table.setSelectionBehavior(QTableWidget.SelectRows)
-        self.roi_table.setRowCount(len(ROI_DEFS_DEFAULT))
+        self.roi_table.setRowCount(0)
         self.roi_table.setAlternatingRowColors(True)
         self.roi_table.setWordWrap(True)
         self.roi_table.setTextElideMode(Qt.ElideRight)
         header = self.roi_table.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.Stretch)
-
-        for row, (roi, electrodes) in enumerate(ROI_DEFS_DEFAULT.items()):
-            roi_item = QTableWidgetItem(roi)
-            roi_item.setFlags(roi_item.flags() & ~Qt.ItemIsEditable)
-            electrodes_text = ", ".join(electrodes)
-            elec_item = QTableWidgetItem(electrodes_text)
-            elec_item.setToolTip(electrodes_text)
-            elec_item.setFlags(elec_item.flags() & ~Qt.ItemIsEditable)
-            self.roi_table.setItem(row, 0, roi_item)
-            self.roi_table.setItem(row, 1, elec_item)
 
         roi_layout.addWidget(self.roi_table)
 
@@ -437,7 +444,58 @@ class RatioCalculatorWindow(QWidget):
                 self.condition_b_combo.setCurrentText(second)
             self._apply_condition_selection(second, is_a=False)
         self._maybe_autoload_participants(force=True)
+        self._refresh_rois()
         self._update_run_state()
+
+    def _rois_signature(self, rois: dict[str, list[str]]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+        return tuple((name, tuple(channels)) for name, channels in rois.items())
+
+    def _refresh_rois(self) -> None:
+        started = perf_counter()
+        try:
+            rois = self._roi_loader()
+        except Exception as exc:
+            elapsed_ms = int((perf_counter() - started) * 1000)
+            logger.exception(
+                "operation=refresh_rois project_root=%s elapsed_ms=%d error=%s",
+                self._project_root,
+                elapsed_ms,
+                exc,
+            )
+            rois = {}
+
+        self._active_roi_defs = rois
+        self._roi_settings_signature = self._rois_signature(rois)
+        self._populate_roi_table(rois)
+        if not rois:
+            self._set_status_message("No valid ROIs found in Settings. Update Settings or click Refresh.")
+        self._update_run_state()
+
+    def _sync_rois_if_changed(self) -> None:
+        try:
+            rois = self._roi_loader()
+        except Exception:
+            return
+        new_signature = self._rois_signature(rois)
+        if new_signature == self._roi_settings_signature:
+            return
+        self._active_roi_defs = rois
+        self._roi_settings_signature = new_signature
+        self._populate_roi_table(rois)
+        self._append_log("ROI settings changed. Table refreshed from Settings.")
+        self._update_run_state()
+
+    def _populate_roi_table(self, rois: dict[str, list[str]]) -> None:
+        self.roi_table.setRowCount(len(rois))
+        for row, (roi, electrodes) in enumerate(rois.items()):
+            roi_item = QTableWidgetItem(roi)
+            roi_item.setFlags(roi_item.flags() & ~Qt.ItemIsEditable)
+            electrodes_text = ", ".join(electrodes)
+            elec_item = QTableWidgetItem(electrodes_text)
+            elec_item.setToolTip(electrodes_text)
+            elec_item.setFlags(elec_item.flags() & ~Qt.ItemIsEditable)
+            self.roi_table.setItem(row, 0, roi_item)
+            self.roi_table.setItem(row, 1, elec_item)
 
     def _populate_condition_combo(self, combo: QComboBox, edit: QLineEdit) -> None:
         current_path = edit.text().strip()
@@ -916,6 +974,9 @@ class RatioCalculatorWindow(QWidget):
         if folders_ready and not self._paired_participants:
             errors.append("Participants are not loaded.")
 
+        if not self._active_roi_defs:
+            errors.append("No valid ROIs are configured in Settings.")
+
         return errors
 
     def _set_validation_errors(self, errors: list[str]) -> None:
@@ -978,6 +1039,16 @@ class RatioCalculatorWindow(QWidget):
             QMessageBox.warning(self, "Missing fields", "Fill out all required fields before running.")
             return
 
+        if not self._active_roi_defs:
+            message = "Cannot run: no valid ROIs are configured in Settings."
+            self._set_status_message(message)
+            logger.warning(
+                "operation=start_run project_root=%s elapsed_ms=0 error=%s",
+                self._project_root,
+                message,
+            )
+            return
+
         ok_out, out_err = self._ensure_output_dir(output_dir)
         if not ok_out:
             QMessageBox.warning(self, "Output folder error", out_err or "Output folder is not usable.")
@@ -1031,7 +1102,7 @@ class RatioCalculatorWindow(QWidget):
             run_label=run_label,
             manual_exclude=manual_list,
             settings=settings,
-            roi_defs=ROI_DEFS_DEFAULT,
+            roi_defs=self._active_roi_defs,
         )
         self._worker.moveToThread(self._thread)
         self._thread.started.connect(self._worker.run)

--- a/src/Tools/Ratio_Calculator/roi_provider.py
+++ b/src/Tools/Ratio_Calculator/roi_provider.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from Main_App import SettingsManager
+
+logger = logging.getLogger(__name__)
+
+
+def load_ratio_rois() -> dict[str, list[str]]:
+    """Load ROI definitions from the shared SettingsManager ROI store.
+
+    This uses the same runtime source the Stats workflow relies on: ``get_roi_pairs``.
+    Invalid rows are dropped (blank ROI names or blank electrodes).
+    """
+
+    try:
+        manager = SettingsManager()
+        get_roi_pairs = getattr(manager, "get_roi_pairs", None)
+        pairs: Iterable[tuple[object, object]]
+        if not callable(get_roi_pairs):
+            return {}
+        raw_pairs = get_roi_pairs() or []
+        if isinstance(raw_pairs, dict):
+            pairs = raw_pairs.items()
+        else:
+            pairs = raw_pairs
+    except Exception:
+        logger.exception("Failed to load ROI pairs from SettingsManager")
+        return {}
+
+    rois: dict[str, list[str]] = {}
+    for raw_name, raw_electrodes in pairs:
+        name = str(raw_name).strip()
+        if not name:
+            continue
+        if not isinstance(raw_electrodes, (list, tuple)):
+            continue
+        electrodes = [str(e).strip() for e in raw_electrodes if str(e).strip()]
+        if not electrodes:
+            continue
+        rois[name] = electrodes
+    return rois
+

--- a/tests/test_ratio_calculator_roi_dynamic.py
+++ b/tests/test_ratio_calculator_roi_dynamic.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ValueError:
+        return False
+
+
+def _table_rows(window) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for row_idx in range(window.roi_table.rowCount()):
+        roi_item = window.roi_table.item(row_idx, 0)
+        elec_item = window.roi_table.item(row_idx, 1)
+        rows.append((roi_item.text() if roi_item else "", elec_item.text() if elec_item else ""))
+    return rows
+
+
+def test_ratio_calculator_uses_runtime_roi_settings_and_refreshes(qtbot):
+    if not _module_available("PySide6") or not _module_available("pytestqt"):
+        pytest.skip("PySide6 or pytest-qt not available")
+
+    from PySide6.QtWidgets import QApplication
+
+    from Tools.Ratio_Calculator.gui import RatioCalculatorWindow
+
+    QApplication.instance() or QApplication([])
+    roi_state = {
+        "Occipital": ["O1", "O2", "Oz"],
+        "Temporal": ["P7", "P8"],
+    }
+
+    def fake_loader() -> dict[str, list[str]]:
+        return {name: list(chans) for name, chans in roi_state.items()}
+
+    window = RatioCalculatorWindow(roi_loader=fake_loader)
+    qtbot.addWidget(window)
+    window.show()
+
+    assert _table_rows(window) == [
+        ("Occipital", "O1, O2, Oz"),
+        ("Temporal", "P7, P8"),
+    ]
+
+    roi_state.clear()
+    roi_state["Parietal"] = ["P3", "P4"]
+    window.refresh_btn.click()
+
+    assert _table_rows(window) == [("Parietal", "P3, P4")]
+
+    roi_state.clear()
+    roi_state["Central"] = ["C3", "C4"]
+    window._sync_rois_if_changed()
+    assert _table_rows(window) == [("Central", "C3, C4")]


### PR DESCRIPTION
### Motivation
- Replace the Ratio Calculator's hard-coded ROI definitions with the same runtime ROI source the Stats tool uses so ROI config in Settings drives both tools.
- Keep the existing UI layout/flows and worker-threaded processing while making the ROI source dynamic and updatable at runtime.
- Surface clear, non-blocking UX when Settings contain no valid ROIs and ensure the worker receives the runtime ROI set instead of a hard-coded default.

### Description
- Added `src/Tools/Ratio_Calculator/roi_provider.py` with `load_ratio_rois()` which reads `SettingsManager.get_roi_pairs()` and returns cleaned ROI -> electrode lists.
- Updated `src/Tools/Ratio_Calculator/gui.py` to accept an injectable `roi_loader`, call it on window open and on Refresh, populate the read-only ROIs table from the returned map, and supply `roi_defs` to the worker from the active runtime ROIs instead of constants.
- Added lightweight runtime sync: a `QTimer` periodically re-queries the ROI loader and refreshes the table when a signature change is detected; Refresh button also re-queries immediately.
- Validation and UX: when no valid ROIs are available the table shows empty state, Run is blocked, and a non-blocking status/log message is shown; ROI load errors are logged with structured context (`operation`, `project_root`, `elapsed_ms`, exception).
- Added `tests/test_ratio_calculator_roi_dynamic.py`, a pytest-qt smoke test that injects a fake ROI loader, verifies the table contents after init, after clicking Refresh, and after simulating a settings-change sync.

### Testing
- Ran targeted pytest for the new test: `python -m pytest tests/test_ratio_calculator_roi_dynamic.py -q` — PASSED (1 test passed).
- Ran full test suite: `python -m pytest -q` — FAILED due to many pre-existing unrelated test failures across the repo (these are not introduced by this change; the new test was run in isolation and passed).
- Ran linter: `ruff check .` — PASSED (no issues in changed files).
- Ran strict mypy: `mypy src --strict` — FAILED due to many pre-existing typing issues elsewhere in the repository (the change itself follows existing typing patterns; repo-wide strict typing errors pre-existed).

Files changed
- src/Tools/Ratio_Calculator/gui.py
- src/Tools/Ratio_Calculator/roi_provider.py (new)
- tests/test_ratio_calculator_roi_dynamic.py (new)

Automated commands run (evidence)
- `ruff check .` — all checks passed.
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_ratio_calculator_roi_dynamic.py -q` — test passed.
- `python -m pytest -q` — full suite shows unrelated failures (pre-existing).
- `mypy src --strict` — reported repository-wide pre-existing failures unrelated to this change.

If you want I can: run additional targeted tests, wire the tool to a settings-changed signal if one exists (instead of timer), or tighten logging message formats.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a260fe82c832c9bfcf6a6c2605050)