### PR TITLE
Add single-group Summary Table.xlsx export with strict validation

### DIFF
--- a/src/Tools/Stats/PySide6/stats_core.py
+++ b/src/Tools/Stats/PySide6/stats_core.py
@@ -37,6 +37,7 @@ ANOVA_BETWEEN_XLS: Final[str] = "Mixed ANOVA Between Groups.xlsx"
 LMM_BETWEEN_XLS: Final[str] = "Mixed Model Between Groups.xlsx"
 GROUP_CONTRAST_XLS: Final[str] = "Group Contrasts.xlsx"
 BASELINE_VS_ZERO_XLS: Final[str] = "Baseline vs Zero Tests.xlsx"
+SUMMARY_TABLE_XLS: Final[str] = "Summary Table.xlsx"
 
 
 @dataclass
@@ -61,5 +62,6 @@ __all__ = [
     "LMM_BETWEEN_XLS",
     "GROUP_CONTRAST_XLS",
     "BASELINE_VS_ZERO_XLS",
+    "SUMMARY_TABLE_XLS",
     "PipelineStep",
 ]

--- a/src/Tools/Stats/PySide6/stats_main_window.py
+++ b/src/Tools/Stats/PySide6/stats_main_window.py
@@ -70,6 +70,7 @@ from Tools.Stats.PySide6.stats_core import (
     ANOVA_BETWEEN_XLS,
     ANOVA_XLS,
     BASELINE_VS_ZERO_XLS,
+    SUMMARY_TABLE_XLS,
     GROUP_CONTRAST_XLS,
     HARMONIC_XLS,
     LMM_BETWEEN_XLS,
@@ -103,6 +104,7 @@ from Tools.Stats.PySide6.stats_export_formatting import (
 )
 from Tools.Stats.PySide6.stats_qc_reports import export_qc_context_workbook
 from Tools.Stats.PySide6.stats_workers import StatsWorker
+from Tools.Stats.PySide6.summary_table_export import generate_summary_table_export
 from Tools.Stats.PySide6 import stats_workers as stats_worker_funcs
 from Tools.Stats.PySide6.dv_policies import (
     EMPTY_LIST_ERROR,
@@ -238,6 +240,7 @@ class StatsWindow(QMainWindow):
         self.group_contrasts_results_data: Optional[pd.DataFrame] = None
         self.posthoc_results_data: Optional[pd.DataFrame] = None
         self.baseline_vs_zero_results_payload: Optional[dict] = None
+        self._single_model_long_df: Optional[pd.DataFrame] = None
         self.harmonic_check_results_data: List[dict] = []
         self._harmonic_results: dict[PipelineId, list[dict]] = {
             PipelineId.SINGLE: [],
@@ -2829,6 +2832,10 @@ class StatsWindow(QMainWindow):
 
                 paths.extend(result_paths)
 
+            summary_path = self._export_summary_table_single(out_dir)
+            if summary_path is not None:
+                paths.append(summary_path)
+
             dv_variant_paths = self._export_dv_variants(PipelineId.SINGLE, out_dir)
             if dv_variant_paths:
                 paths.extend(dv_variant_paths)
@@ -2848,6 +2855,35 @@ class StatsWindow(QMainWindow):
         except Exception as exc:  # noqa: BLE001
             self.append_log(section, f"  • Export failed: {exc}", level="error")
             return False
+
+    def _export_summary_table_single(self, out_dir: str) -> Path | None:
+        """Export Summary Table workbook for the single-group pipeline."""
+        if self._active_pipeline is PipelineId.BETWEEN:
+            raise NotImplementedError("Summary Table export currently supports single-group runs only.")
+
+        if not isinstance(self._single_model_long_df, pd.DataFrame) or self._single_model_long_df.empty:
+            raise ValueError("Summary Table export requires non-empty single-group model long-format data.")
+        if not isinstance(self.baseline_vs_zero_results_payload, dict):
+            raise ValueError("Summary Table export requires baseline-vs-zero payload data.")
+
+        baseline_df = self.baseline_vs_zero_results_payload.get("results_df")
+        if not isinstance(baseline_df, pd.DataFrame) or baseline_df.empty:
+            raise ValueError("Summary Table export requires baseline-vs-zero results_df.")
+
+        conditions = self._get_selected_conditions()
+        rois = list(self.rois.keys())
+        save_path = Path(out_dir) / SUMMARY_TABLE_XLS
+        return generate_summary_table_export(
+            save_path=save_path,
+            long_df=self._single_model_long_df,
+            baseline_results_df=baseline_df,
+            conditions=conditions,
+            rois=rois,
+            log_func=self._set_status,
+            project_name=self.project_title,
+            run_identifier=self._phase_label,
+            is_between_group=False,
+        )
 
     def _export_dv_variants(self, pipeline_id: PipelineId, out_dir: str) -> list[Path]:
         """Handle the export dv variants step for the Stats PySide6 workflow."""
@@ -3128,6 +3164,7 @@ class StatsWindow(QMainWindow):
     def _apply_rm_anova_results(self, payload: dict, *, update_text: bool = True) -> str:
         """Handle the apply rm anova results step for the Stats PySide6 workflow."""
         self.rm_anova_results_data = payload.get("anova_df_results")
+        self._single_model_long_df = payload.get("model_long_df")
         self._store_dv_metadata(PipelineId.SINGLE, payload)
         self._store_run_report(PipelineId.SINGLE, payload)
         alpha = getattr(self, "_current_alpha", 0.05)
@@ -4097,6 +4134,7 @@ class StatsWindow(QMainWindow):
         """Handle the on run rm anova step for the Stats PySide6 workflow."""
         self._clear_output_views()
         self.rm_anova_results_data = None
+        self._single_model_long_df = None
         self._update_export_buttons()
         self._controller.run_single_group_rm_anova_only()
 

--- a/src/Tools/Stats/PySide6/stats_workers.py
+++ b/src/Tools/Stats/PySide6/stats_workers.py
@@ -1056,6 +1056,7 @@ def run_rm_anova(
 
     return {
         "anova_df_results": anova_df_results,
+        "model_long_df": _long_format_from_bca(all_subject_bca_data),
         "output_text": output_text,
         "dv_metadata": dv_metadata,
         "dv_variants": _serialize_dv_variants_payload(dv_variants_payload),

--- a/src/Tools/Stats/PySide6/summary_table_export.py
+++ b/src/Tools/Stats/PySide6/summary_table_export.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import random
+
+import numpy as np
+import openpyxl
+import pandas as pd
+from openpyxl.styles import Alignment, Font
+from scipy.stats import ttest_1samp
+from statsmodels.stats.multitest import multipletests
+
+from Tools.Stats.Legacy.stats_export import _auto_format_and_write_excel
+
+P_COL_HEADER = "Baseline vs 0 p (BH-FDR)"
+REJECT_COL_HEADER = "Baseline vs 0 reject"
+
+
+def _identify_lot_roi(roi_labels: list[str]) -> str:
+    normalized = {roi: roi.strip().lower() for roi in roi_labels}
+    candidates = [
+        roi
+        for roi, norm in normalized.items()
+        if norm == "lot"
+        or "left occipito temporal" in norm
+        or "left-occipito-temporal" in norm
+        or "left occipito-temporal" in norm
+        or "occipito temporal" in norm
+    ]
+    unique = sorted(set(candidates))
+    if len(unique) != 1:
+        raise ValueError("Cannot compute LOT−Central gradient: LOT ROI not found/unambiguous.")
+    return unique[0]
+
+
+def _identify_central_roi(roi_labels: list[str]) -> str:
+    candidates = [roi for roi in roi_labels if roi.strip().lower() == "central"]
+    if len(candidates) != 1:
+        raise ValueError("Cannot compute LOT−Central gradient: Central ROI not found/unambiguous.")
+    return candidates[0]
+
+
+def _enforce_sheet_formatting(workbook_path: Path, *, decimal_cols: dict[str, list[str]], p_cols: dict[str, list[str]]) -> None:
+    wb = openpyxl.load_workbook(workbook_path)
+    try:
+        for ws in wb.worksheets:
+            ws.freeze_panes = "A2"
+            ws.auto_filter.ref = ws.dimensions
+            header_font = Font(bold=True)
+            center = Alignment(horizontal="center", vertical="center")
+            for cell in ws[1]:
+                cell.font = header_font
+                cell.alignment = center
+            for row in ws.iter_rows(min_row=2, max_row=ws.max_row, min_col=1, max_col=ws.max_column):
+                for cell in row:
+                    cell.alignment = center
+            headers = {str(cell.value): idx for idx, cell in enumerate(ws[1], start=1)}
+            for col_name in decimal_cols.get(ws.title, []):
+                if col_name in headers:
+                    col_idx = headers[col_name]
+                    for row_idx in range(2, ws.max_row + 1):
+                        ws.cell(row=row_idx, column=col_idx).number_format = "0.000000"
+            for col_name in p_cols.get(ws.title, []):
+                if col_name in headers:
+                    col_idx = headers[col_name]
+                    for row_idx in range(2, ws.max_row + 1):
+                        val = ws.cell(row=row_idx, column=col_idx).value
+                        if isinstance(val, (float, int)):
+                            ws.cell(row=row_idx, column=col_idx).number_format = "0.00E+00" if (val != 0 and abs(float(val)) < 0.001) else "0.000000"
+
+            for col_cells in ws.columns:
+                max_len = max(len(str(c.value)) if c.value is not None else 0 for c in col_cells)
+                ws.column_dimensions[col_cells[0].column_letter].width = min(max_len + 2, 80)
+    finally:
+        wb.save(workbook_path)
+        wb.close()
+
+
+def generate_summary_table_export(
+    *,
+    save_path: str | Path,
+    long_df: pd.DataFrame,
+    baseline_results_df: pd.DataFrame,
+    conditions: list[str],
+    rois: list[str],
+    log_func,
+    project_name: str | None = None,
+    run_identifier: str | None = None,
+    is_between_group: bool = False,
+) -> Path:
+    if is_between_group:
+        raise NotImplementedError("Summary Table export currently supports single-group runs only.")
+
+    required_cols = ["subject", "condition", "roi", "value"]
+    missing = [col for col in required_cols if col not in long_df.columns]
+    if missing:
+        raise ValueError(f"Summary Table export missing required long-format columns: {missing}")
+
+    lot_roi = _identify_lot_roi(rois)
+    central_roi = _identify_central_roi(rois)
+
+    baseline_required = ["condition", "roi", "p_corr", "reject"]
+    baseline_missing = [col for col in baseline_required if col not in baseline_results_df.columns]
+    if baseline_missing:
+        raise ValueError(f"Summary Table export missing baseline-vs-zero columns: {baseline_missing}")
+
+    log_func("Generating Summary Table.xlsx…")
+    summary_rows = []
+    baseline_lookup: dict[tuple[str, str], tuple[float, bool]] = {}
+    for row in baseline_results_df.itertuples(index=False):
+        baseline_lookup[(str(row.condition), str(row.roi))] = (float(row.p_corr), bool(row.reject))
+
+    for condition in conditions:
+        for roi in rois:
+            mask = (long_df["condition"].astype(str) == str(condition)) & (long_df["roi"].astype(str) == str(roi))
+            values = long_df.loc[mask, "value"].astype(float)
+            key = (str(condition), str(roi))
+            if key not in baseline_lookup:
+                raise ValueError(f"Missing baseline-vs-zero BH-FDR result for Condition={condition}, ROI={roi}.")
+            p_corr, reject = baseline_lookup[key]
+            summary_rows.append(
+                {
+                    "Condition": condition,
+                    "ROI": roi,
+                    "N": int(values.shape[0]),
+                    "Mean (Summed BCA)": float(values.mean()),
+                    "SD": float(values.std(ddof=1)),
+                    P_COL_HEADER: float(p_corr),
+                    REJECT_COL_HEADER: bool(reject),
+                }
+            )
+
+    roi_summary_df = pd.DataFrame(summary_rows)
+
+    gradient_rows = []
+    gradient_pvals = []
+    paired_cache: dict[str, pd.Series] = {}
+    for condition in conditions:
+        cond_df = long_df.loc[long_df["condition"].astype(str) == str(condition), ["subject", "roi", "value"]].copy()
+        lot_series = cond_df.loc[cond_df["roi"].astype(str) == lot_roi, ["subject", "value"]].set_index("subject")["value"].astype(float)
+        central_series = cond_df.loc[cond_df["roi"].astype(str) == central_roi, ["subject", "value"]].set_index("subject")["value"].astype(float)
+        common = sorted(set(lot_series.index).intersection(set(central_series.index)))
+        gradients = (lot_series.loc[common] - central_series.loc[common]).astype(float)
+        sd = float(gradients.std(ddof=1))
+        if sd == 0:
+            raise ValueError(f"Cannot compute dz for condition '{condition}': gradient SD is zero.")
+        p_raw = float(ttest_1samp(gradients.to_numpy(), popmean=0.0, alternative="two-sided").pvalue)
+        gradient_pvals.append(p_raw)
+        paired_cache[str(condition)] = gradients
+        gradient_rows.append(
+            {
+                "Condition": condition,
+                "Gradient definition": "LOT − Central",
+                "N": int(gradients.shape[0]),
+                "Mean gradient": float(gradients.mean()),
+                "SD gradient": sd,
+                "_p_raw": p_raw,
+                "_dz": float(gradients.mean() / sd),
+            }
+        )
+
+    reject, p_corr, _, _ = multipletests(np.asarray(gradient_pvals, dtype=float), alpha=0.05, method="fdr_bh")
+    for idx, row in enumerate(gradient_rows):
+        row["LOT vs Central p (BH-FDR)"] = float(p_corr[idx])
+        row["LOT vs Central reject"] = bool(reject[idx])
+        row["Effect size (dz)"] = row.pop("_dz")
+        row.pop("_p_raw")
+
+    gradients_df = pd.DataFrame(gradient_rows)
+
+    metadata_rows = [
+        {"Field": "DV column name", "Value": "value"},
+        {"Field": "DV description", "Value": "Summed BCA"},
+        {"Field": "Included conditions", "Value": ", ".join(str(c) for c in conditions)},
+        {"Field": "Included ROIs", "Value": ", ".join(str(r) for r in rois)},
+        {"Field": "Baseline vs zero correction", "Value": "Benjamini–Hochberg (BH-FDR)"},
+        {"Field": "Gradient correction", "Value": "Benjamini–Hochberg (BH-FDR) across conditions"},
+        {"Field": "Timestamp", "Value": datetime.now().isoformat(timespec="seconds")},
+    ]
+    if project_name:
+        metadata_rows.append({"Field": "Project name", "Value": project_name})
+    if run_identifier:
+        metadata_rows.append({"Field": "Run identifier", "Value": run_identifier})
+    metadata_df = pd.DataFrame(metadata_rows)
+
+    save_path = Path(save_path)
+    with pd.ExcelWriter(save_path, engine="xlsxwriter") as writer:
+        _auto_format_and_write_excel(writer, roi_summary_df, "ROI Summary", log_func)
+        _auto_format_and_write_excel(writer, gradients_df, "Gradients", log_func)
+        _auto_format_and_write_excel(writer, metadata_df, "Metadata", log_func)
+
+    _enforce_sheet_formatting(
+        save_path,
+        decimal_cols={
+            "ROI Summary": ["Mean (Summed BCA)", "SD"],
+            "Gradients": ["Mean gradient", "SD gradient", "Effect size (dz)"],
+        },
+        p_cols={
+            "ROI Summary": [P_COL_HEADER],
+            "Gradients": ["LOT vs Central p (BH-FDR)"],
+        },
+    )
+
+    _validate_summary_table(
+        save_path=save_path,
+        roi_summary_df=roi_summary_df,
+        gradients_df=gradients_df,
+        long_df=long_df,
+        baseline_lookup=baseline_lookup,
+        conditions=conditions,
+        rois=rois,
+        lot_roi=lot_roi,
+        central_roi=central_roi,
+    )
+
+    log_func(f"ROI Summary rows: {len(roi_summary_df)}")
+    log_func(f"Gradient rows: {len(gradients_df)}")
+    log_func(f"Saved Summary Table.xlsx: {save_path}")
+    return save_path
+
+
+def _validate_summary_table(*, save_path: Path, roi_summary_df: pd.DataFrame, gradients_df: pd.DataFrame, long_df: pd.DataFrame, baseline_lookup: dict[tuple[str, str], tuple[float, bool]], conditions: list[str], rois: list[str], lot_roi: str, central_roi: str) -> None:
+    wb = openpyxl.load_workbook(save_path)
+    try:
+        expected = {"ROI Summary", "Gradients", "Metadata"}
+        if set(wb.sheetnames) != expected:
+            raise RuntimeError(f"Summary Table workbook sheets mismatch: found={wb.sheetnames}")
+
+        ws = wb["ROI Summary"]
+        rows = list(ws.iter_rows(min_row=2, max_row=ws.max_row, values_only=True))
+        if len(rows) != len(conditions) * len(rois):
+            raise RuntimeError("ROI Summary row count mismatch.")
+        row_conditions = {str(r[0]) for r in rows}
+        row_rois = {str(r[1]) for r in rows}
+        if row_conditions != set(map(str, conditions)):
+            raise RuntimeError("ROI Summary conditions mismatch.")
+        if row_rois != set(map(str, rois)):
+            raise RuntimeError("ROI Summary ROIs mismatch.")
+
+        rng = random.Random(17)
+        sample = rng.sample([(c, r) for c in conditions for r in rois], k=min(3, len(conditions) * len(rois)))
+        workbook_lookup = {(str(r[0]), str(r[1])): r for r in rows}
+        for condition, roi in sample:
+            row = workbook_lookup[(str(condition), str(roi))]
+            vals = long_df.loc[(long_df["condition"].astype(str) == str(condition)) & (long_df["roi"].astype(str) == str(roi)), "value"].astype(float)
+            if abs(float(row[3]) - float(vals.mean())) > 1e-9:
+                raise RuntimeError("ROI Summary mean validation failed.")
+            if abs(float(row[4]) - float(vals.std(ddof=1))) > 1e-9:
+                raise RuntimeError("ROI Summary SD validation failed.")
+            if int(row[2]) != int(vals.shape[0]):
+                raise RuntimeError("ROI Summary N validation failed.")
+            p_corr, reject = baseline_lookup[(str(condition), str(roi))]
+            if abs(float(row[5]) - float(p_corr)) > 1e-12:
+                raise RuntimeError("Baseline-vs-zero corrected p validation failed.")
+            if bool(row[6]) != bool(reject):
+                raise RuntimeError("Baseline-vs-zero reject validation failed.")
+
+        grad_ws = wb["Gradients"]
+        grad_rows = list(grad_ws.iter_rows(min_row=2, max_row=grad_ws.max_row, values_only=True))
+        grad_lookup = {str(r[0]): r for r in grad_rows}
+        for condition in conditions:
+            row = grad_lookup[str(condition)]
+            cond_df = long_df.loc[long_df["condition"].astype(str) == str(condition), ["subject", "roi", "value"]].copy()
+            lot = cond_df.loc[cond_df["roi"].astype(str) == lot_roi, ["subject", "value"]].set_index("subject")["value"].astype(float)
+            central = cond_df.loc[cond_df["roi"].astype(str) == central_roi, ["subject", "value"]].set_index("subject")["value"].astype(float)
+            common = sorted(set(lot.index).intersection(set(central.index)))
+            gradients = lot.loc[common] - central.loc[common]
+            mean = float(gradients.mean())
+            sd = float(gradients.std(ddof=1))
+            dz = mean / sd
+            if abs(float(row[3]) - mean) > 1e-9:
+                raise RuntimeError("Gradient mean validation failed.")
+            if abs(float(row[4]) - sd) > 1e-9:
+                raise RuntimeError("Gradient SD validation failed.")
+            if abs(float(row[7]) - dz) > 1e-9:
+                raise RuntimeError("Gradient dz validation failed.")
+
+        for sheet_name in expected:
+            ws = wb[sheet_name]
+            if ws.freeze_panes != "A2":
+                raise RuntimeError(f"Formatting validation failed: freeze panes not set on {sheet_name}.")
+            if ws.auto_filter.ref is None:
+                raise RuntimeError(f"Formatting validation failed: autofilter missing on {sheet_name}.")
+            for cell in ws[1]:
+                if not bool(cell.font.bold):
+                    raise RuntimeError(f"Formatting validation failed: non-bold header on {sheet_name}.")
+                if cell.alignment.horizontal != "center":
+                    raise RuntimeError(f"Formatting validation failed: header alignment on {sheet_name}.")
+            for row in ws.iter_rows(min_row=2, max_row=ws.max_row, min_col=1, max_col=ws.max_column):
+                for cell in row:
+                    if cell.alignment.horizontal != "center":
+                        raise RuntimeError(f"Formatting validation failed: data alignment on {sheet_name}.")
+    finally:
+        wb.close()

--- a/tests/test_stats_summary_table_export.py
+++ b/tests/test_stats_summary_table_export.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import openpyxl
+import pandas as pd
+
+from Tools.Stats.PySide6.summary_table_export import generate_summary_table_export
+
+
+def test_summary_table_export_roundtrip_and_formatting(tmp_path: Path) -> None:
+    participants = [f"P{i}" for i in range(1, 6)]
+    conditions = ["Words", "Faces"]
+    rois = ["Left Occipito Temporal", "Central", "Parietal"]
+
+    rows = []
+    for p_idx, participant in enumerate(participants, start=1):
+        for c_idx, condition in enumerate(conditions, start=1):
+            rows.append({"subject": participant, "condition": condition, "roi": "Left Occipito Temporal", "value": 2.0 + p_idx + c_idx})
+            rows.append({"subject": participant, "condition": condition, "roi": "Central", "value": 1.0 + p_idx + c_idx})
+            rows.append({"subject": participant, "condition": condition, "roi": "Parietal", "value": 0.5 + p_idx + c_idx})
+    long_df = pd.DataFrame(rows)
+
+    baseline_rows = []
+    for condition in conditions:
+        for roi in rois:
+            baseline_rows.append(
+                {
+                    "condition": condition,
+                    "roi": roi,
+                    "p_corr": 0.01 if roi != "Parietal" else 0.2,
+                    "reject": roi != "Parietal",
+                }
+            )
+    baseline_df = pd.DataFrame(baseline_rows)
+
+    out_path = tmp_path / "Summary Table.xlsx"
+    generate_summary_table_export(
+        save_path=out_path,
+        long_df=long_df,
+        baseline_results_df=baseline_df,
+        conditions=conditions,
+        rois=rois,
+        log_func=lambda _msg: None,
+        project_name="Demo",
+        run_identifier="Phase 1",
+    )
+
+    wb = openpyxl.load_workbook(out_path)
+    try:
+        assert wb.sheetnames == ["ROI Summary", "Gradients", "Metadata"]
+
+        roi_ws = wb["ROI Summary"]
+        assert roi_ws.max_row - 1 == len(conditions) * len(rois)
+
+        grad_ws = wb["Gradients"]
+        assert grad_ws.max_row - 1 == len(conditions)
+
+        for ws in [roi_ws, grad_ws, wb["Metadata"]]:
+            assert ws.freeze_panes == "A2"
+            assert ws.auto_filter.ref is not None
+            for cell in ws[1]:
+                assert cell.font.bold is True
+                assert cell.alignment.horizontal == "center"
+            for row in ws.iter_rows(min_row=2, max_row=ws.max_row):
+                for cell in row:
+                    assert cell.alignment.horizontal == "center"
+    finally:
+        wb.close()


### PR DESCRIPTION
### Motivation
- Provide a deterministic, publication-ready `Summary Table.xlsx` export for single-group Stats runs that assembles ROI-level summaries, LOT−Central gradients, and run metadata from in-memory pipeline results and enforces strict, fail-fast validation.
- Ensure the export uses the same Excel styling/formatting helpers used elsewhere in Stats and that the file is self-checked immediately after write to guarantee correctness and formatting.

### Description
- Added a new module `src/Tools/Stats/PySide6/summary_table_export.py` that builds `Summary Table.xlsx` containing exact sheets `ROI Summary`, `Gradients`, and `Metadata`, implements LOT/Central ROI resolution, uses in-memory long-format data and baseline-vs-zero BH-FDR results, computes paired t-tests and BH-FDR across conditions for gradients, computes `dz`, and raises clear errors for any missing prerequisites or invalid conditions (e.g., between-group runs, missing columns, ambiguous ROIs, zero gradient SD).
- Integrated the export into the single-pipeline export flow in `src/Tools/Stats/PySide6/stats_main_window.py` by plumbing a `model_long_df` field from the RM-ANOVA worker payload and calling the generator automatically in the single-pipeline export sequence; added `SUMMARY_TABLE_XLS` to `src/Tools/Stats/PySide6/stats_core.py` constants.
- Ensured workbook formatting mirrors existing exports by reusing `_auto_format_and_write_excel` from the legacy export helpers and applying sheet-level formatting (bold/centered headers, centered data, freeze panes `A2`, autofilter, numeric formatting) and logging the mandated messages such as `Generating Summary Table.xlsx…`, `ROI Summary rows: <int>`, `Gradient rows: <int>`, and `Saved Summary Table.xlsx: <full_path>`.
- Added strict post-write self-validation that reopens the saved workbook with `openpyxl` and checks sheet membership, row counts, sampled numeric accuracy (N/Mean/SD), baseline p/reject matches, gradient mean/SD/dz, and formatting; any failure raises `RuntimeError` with a clear message.
- Added a unit/integration test `tests/test_stats_summary_table_export.py` that creates a deterministic synthetic dataset (5 participants, 2 conditions, ROIs including LOT-equivalent and `Central` plus one extra ROI), creates matching baseline-vs-zero corrected results, runs the summary writer, and asserts workbook structure and formatting.

### Testing
- Ran linter: `ruff check` on changed files and the new test passed with no issues.
- Byte-compiled changed modules: `python -m compileall` succeeded for the modified/added files.
- Added test `tests/test_stats_summary_table_export.py` and attempted `pytest -q` but test execution is blocked in this environment by an import-time issue in the test harness: `tests/conftest.py` raises `ValueError: PySide6.__spec__ is None` (PySide6/runtime GUI environment mismatch) which prevents pytest from running the test inside this container; therefore the automated test could not be executed here to completion.
- Note: local manual attempts to import/run the new export were limited by package-level imports that bring in GUI dependencies (`PySide6`) in this environment, causing an `ImportError` (`libGL.so.1` missing) when trying to import the full package; the export implementation itself (module) is present and compiled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b69b962a8832c948189cf8ac6a891)