### PR TITLE
Non-blocking memory throttle and safe in-place kurtosis sanitization

### DIFF
--- a/src/Main_App/Performance/process_runner.py
+++ b/src/Main_App/Performance/process_runner.py
@@ -777,13 +777,11 @@ def run_project_parallel(
                 return False
 
             # Optional soft-cap on system RAM
-            while True:
-                mem_ok, percent_used = _memory_ok(memory_limit_ratio)
-                if percent_used > max_memory_percent:
-                    max_memory_percent = percent_used
-                if mem_ok:
-                    break
-                time.sleep(memory_check_interval)
+            mem_ok, percent_used = _memory_ok(memory_limit_ratio)
+            if percent_used > max_memory_percent:
+                max_memory_percent = percent_used
+            if not mem_ok:
+                return False
 
             f = remaining.pop(0)
             fut = pool.submit(
@@ -813,7 +811,7 @@ def run_project_parallel(
                     # Nothing could be submitted (likely due to cancellation).
                     if _cancelled() or not remaining:
                         break
-                    time.sleep(0.05)
+                    time.sleep(max(0.01, float(memory_check_interval)))
                 continue
 
             done, _ = wait(in_flight.keys(), return_when=FIRST_COMPLETED, timeout=0.5)

--- a/src/Main_App/PySide6_App/Backend/preprocess.py
+++ b/src/Main_App/PySide6_App/Backend/preprocess.py
@@ -653,7 +653,7 @@ def perform_preprocessing(
                 k_values = kurtosis(
                     data, axis=1, fisher=True, bias=False
                 )
-                k_values = np.nan_to_num(k_values)
+                k_values = np.nan_to_num(k_values, copy=False)
                 proportion_to_cut = 0.1
                 n_k = len(k_values)
                 trim_count = int(np.floor(n_k * proportion_to_cut))

--- a/tests/test_pipeline_speed_safety.py
+++ b/tests/test_pipeline_speed_safety.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import numpy as np
+
+from Main_App.Performance import process_runner
+
+
+class _FakeFuture:
+    def __init__(self, result_payload):
+        self._result_payload = result_payload
+        self._done = False
+        self._cancelled = False
+
+    def done(self):
+        return self._done
+
+    def result(self):
+        return self._result_payload
+
+    def cancel(self):
+        self._cancelled = True
+
+
+class _FakeExecutor:
+    def __init__(self, *_, **__):
+        self.submitted = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def submit(self, _fn, file_path, *_args, **_kwargs):
+        fut = _FakeFuture({"status": "ok", "file": str(file_path), "audit": {"n_rejected": 0}})
+        self.submitted.append(fut)
+        return fut
+
+
+def test_memory_throttle_does_not_block_harvest(monkeypatch, tmp_path):
+    files = [tmp_path / "a.bdf", tmp_path / "b.bdf"]
+    params = process_runner.RunParams(
+        project_root=tmp_path,
+        data_files=files,
+        settings={},
+        event_map={},
+        save_folder=tmp_path,
+        max_workers=2,
+        memory_soft_limit_ratio=0.85,
+        memory_check_interval_s=0.25,
+    )
+
+    fake_pool = _FakeExecutor()
+    monkeypatch.setattr(process_runner, "ProcessPoolExecutor", lambda *a, **k: fake_pool)
+
+    memory_reads = iter([(True, 40.0), (False, 96.0), (False, 95.0), (True, 50.0), (True, 51.0)])
+    monkeypatch.setattr(process_runner, "_memory_ok", lambda _limit: next(memory_reads))
+
+    wait_calls = {"count": 0}
+
+    def _fake_wait(futures, return_when, timeout):
+        wait_calls["count"] += 1
+        if wait_calls["count"] == 1:
+            return set(), set()
+        for fut in futures:
+            if not fut.done():
+                fut._done = True
+                return {fut}, set()
+        return set(), set()
+
+    monkeypatch.setattr(process_runner, "wait", _fake_wait)
+
+    sleep_calls = []
+    monkeypatch.setattr(process_runner.time, "sleep", lambda secs: sleep_calls.append(secs))
+
+    process_runner.run_project_parallel(params)
+
+    assert wait_calls["count"] >= 2
+    # New behavior: memory gating is non-blocking; outer loop handles backoff.
+    assert 0.25 not in sleep_calls
+    assert all(s >= 0.01 for s in sleep_calls)
+
+
+def test_nan_to_num_inplace_equivalence_for_kurtosis_vector():
+    k_values = np.array([np.nan, np.inf, -np.inf, 1.25, -2.5], dtype=np.float64)
+
+    expected = np.nan_to_num(k_values.copy())
+
+    actual_source = k_values.copy()
+    actual = np.nan_to_num(actual_source, copy=False)
+
+    np.testing.assert_allclose(actual, expected)
+    # copy=False should still preserve shape/dtype semantics used downstream.
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype


### PR DESCRIPTION
### Motivation

- Prevent the dispatcher from stalling when the system memory soft-cap is reached by avoiding a blocking sleep loop inside the submission helper.  
- Reduce temporary allocations during preprocessing by performing `np.nan_to_num` in-place where it is safe (temporary kurtosis vector).  
- Preserve pipeline semantics, observability, and processing order while improving throughput under memory pressure.

### Description

- Replaced the blocking `while True: ... time.sleep(memory_check_interval)` inside `_submit_next_available()` with a single non-blocking memory check that returns `False` immediately when memory is over the soft limit, allowing the outer loop to harvest completed futures.  
- Moved the short `sleep`/backoff to the outer no-in-flight branch and use `time.sleep(max(0.01, float(memory_check_interval)))` to avoid busy-spin while ensuring harvesting remains timely.  
- Changed kurtosis sanitization from `k_values = np.nan_to_num(k_values)` to `k_values = np.nan_to_num(k_values, copy=False)` to enable an in-place replacement on the temporary kurtosis array without changing numeric output, dtype, or shape.  
- Added a focused regression test file `tests/test_pipeline_speed_safety.py` that covers the memory-throttle harvesting behavior and validates numerical equivalence of the in-place `nan_to_num` change.  
- Files touched: `src/Main_App/Performance/process_runner.py`, `src/Main_App/PySide6_App/Backend/preprocess.py`, `tests/test_pipeline_speed_safety.py`; no changes were made under `src/Main_App/Legacy_App/**` or `src/Tools/SourceLocalization/**`.

Explicit confirmation: item (2) “Unified Epoching with `preload=True`” is deferred and was NOT implemented.

### Testing

- Ran `ruff check .` and fixed a test import; `ruff` returned clean results.  
- Executed the targeted regression tests in `tests/test_pipeline_speed_safety.py` under a PySide6-QtCore stub bootstrap and both tests passed (2/2).  
- Attempted `pytest -q` for the full suite but test-collection failed in this environment due to a pre-existing `PySide6.__spec__` module bootstrap issue unrelated to these changes, so full-suite pytest was not run here.  
- Ran `mypy src --strict` as requested; it completed but surfaced many pre-existing type errors in unrelated legacy/debug modules (no new mypy errors attributable to these edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca2f515c0832c8135ef0afd09a49d)