### PR TITLE
docs: refresh agent prompt guidance and legacy-boundary docs

### DIFF
--- a/docs/agent-prompts/bugfix.md
+++ b/docs/agent-prompts/bugfix.md
@@ -2,9 +2,12 @@
 
 Use when fixing a specific defect.
 
-1. Reproduce or identify the failing behavior.
-2. State the smallest safe interpretation of the bug.
-3. Add or update a focused test when practical.
-4. Implement the narrowest fix.
-5. Run `python scripts/agent_audit.py` and the focused test.
-6. Report files changed, verification, and any residual risk.
+1. Start from `docs/agent-index.md` and run the narrowest relevant audit or skill-local script before broad manual inspection.
+2. Reproduce or identify the failing behavior.
+3. State the smallest safe interpretation of the bug and any assumptions.
+4. Add or update a focused test when practical; otherwise document a manual smoke check.
+5. Implement the narrowest behavior-preserving fix.
+6. Run `python scripts/agent_audit.py` plus the focused test or check for the touched area.
+7. Report files changed, verification, skipped checks, residual risk, and why architecture docs did or did not need updates.
+
+Preserve existing processing order, data formats, exports, project paths, and user workflows unless the bug explicitly requires changing them.

--- a/docs/agent-prompts/gui-change.md
+++ b/docs/agent-prompts/gui-change.md
@@ -7,12 +7,16 @@ Goal: change only the requested PySide6 GUI behavior.
 Checks:
 
 ```powershell
+python .agents/skills/pyside6-gui-cleanup/scripts/audit_gui_imports.py
 python scripts/agent_audit.py --check gui
 python -m pytest <nearest pytest-qt test> -q
 ```
 
 Requirements:
 
-- Preserve existing user flows and processing order.
-- Keep long work off the UI thread.
-- Add or update a pytest-qt smoke test, or document manual smoke steps.
+- Preserve existing user flows, processing order, project paths, and export formats.
+- Keep long work off the UI thread; use `QThread` or `QRunnable`/`QThreadPool` for long work.
+- Workers must not touch widgets directly; communicate through signals.
+- Import `QAction` from `PySide6.QtGui` only.
+- Do not introduce Tkinter, CustomTkinter, or CTkMessagebox imports.
+- Add or update a pytest-qt smoke test, or document manual smoke steps when automation is not practical.

--- a/docs/agent-prompts/legacy-boundary.md
+++ b/docs/agent-prompts/legacy-boundary.md
@@ -7,13 +7,17 @@ Goal: keep retired or historical legacy behavior from re-entering active runtime
 Checks:
 
 ```powershell
+python .agents/skills/legacy-boundary-review/scripts/audit_protected_edits.py
 python scripts/agent_audit.py --check protected
 python scripts/agent_audit.py --check source-localization
+python scripts/agent_audit.py --check source-localization-refs
 git diff --name-only
 ```
 
 Requirements:
 
-- Do not recreate `src/Main_App/Legacy_App/**`; active behavior belongs in purpose-based `Main_App` packages.
-- If historical legacy behavior must be referenced, use existing current-app APIs or a focused adapter outside the retired path.
-- Do not revive Source Localization/eLORETA unless explicitly requested as a new restoration feature.
+- Do not recreate `src/Main_App/Legacy_App/**` or `src/Main_App/PySide6_App/**`; active behavior belongs in purpose-based `Main_App` packages.
+- Use active Main App import surfaces: `Main_App.gui`, `Main_App.processing`, `Main_App.io`, `Main_App.projects`, `Main_App.workers`, `Main_App.diagnostics`, and `Main_App.exports`.
+- If historical behavior must be referenced, use existing current-app APIs or a focused adapter outside retired paths.
+- Do not revive Source Localization/eLORETA imports, tests, settings, quarantine dependencies, or UI behavior unless explicitly requested as a restoration feature.
+- Preserve existing processing order, data formats, project paths, and exports.

--- a/docs/agent-prompts/path-audit.md
+++ b/docs/agent-prompts/path-audit.md
@@ -7,12 +7,15 @@ Goal: review or change project-root file I/O without changing data formats.
 Checks:
 
 ```powershell
+python .agents/skills/project-path-audit/scripts/audit_hardcoded_paths.py
 python scripts/agent_audit.py --check paths
 python -m pytest <nearest project/path tests> -q
 ```
 
 Requirements:
 
-- Use active project-root-relative paths.
-- Handle dialog Cancel and repeated operations.
-- Use `tmp_path` for tests.
+- Use active project-root-relative paths and the active `Main_App.projects` import surface for project model/settings/manager behavior.
+- Preserve existing output formats, filenames, sheet names, folder layouts, and repeated-operation behavior unless explicitly asked to change them.
+- Handle `QFileDialog` Cancel and repeated operations without stale UI state.
+- Use PySide6-safe message helpers for user-facing warnings/errors; worker/background callers should log rather than block on popups.
+- Use `tmp_path` for tests instead of hard-coded local paths.

--- a/docs/agent-prompts/pre-ship-review.md
+++ b/docs/agent-prompts/pre-ship-review.md
@@ -3,7 +3,10 @@
 Use before handing off a non-trivial change.
 
 1. Read `docs/reviews/pre_ship_checklist.md`.
-2. Run `python scripts/agent_audit.py`.
-3. Run the focused tests from `docs/quality/test-selection.md`.
-4. Run broader gates if shared behavior changed.
-5. Report failures with command, reason, and residual risk.
+2. Run the relevant first command from `docs/agent-index.md` before broad manual inspection.
+3. Run `python scripts/agent_audit.py`.
+4. Run the focused tests from `docs/quality/test-selection.md`.
+5. Run broader gates if shared behavior changed.
+6. Confirm retired `src/Main_App/Legacy_App/**` and `src/Main_App/PySide6_App/**` paths were not recreated.
+7. Confirm Source Localization/eLORETA remains removed from active runtime unless explicitly restored.
+8. Report failures with command, reason, residual risk, and whether architecture docs or scoped `AGENTS.md` needed updates.

--- a/docs/architecture/legacy-boundaries.md
+++ b/docs/architecture/legacy-boundaries.md
@@ -1,11 +1,12 @@
 # Legacy Boundaries
 
-Retired Main App legacy path:
+Retired Main App legacy paths:
 
 - `src/Main_App/Legacy_App/**`
+- `src/Main_App/PySide6_App/**`
 
-The historical `Legacy_App` package has been retired. Do not recreate this
-directory; active Main App behavior belongs in purpose-based packages such as
+The historical `Legacy_App` and `PySide6_App` packages have been retired. Do not recreate these
+directories; active Main App behavior belongs in purpose-based packages such as
 `Main_App.processing`, `Main_App.io`, `Main_App.projects`, `Main_App.exports`,
 `Main_App.workers`, `Main_App.diagnostics`, and `Main_App.gui`.
 
@@ -16,7 +17,7 @@ Source Localization/eLORETA is removed from active runtime, not a protected blac
 
 Rules:
 
-- Do not add files under `src/Main_App/Legacy_App/**`.
+- Do not add files under `src/Main_App/Legacy_App/**` or `src/Main_App/PySide6_App/**`.
 - Prefer thin adapters or caller-side normalization in purpose-based Main App packages.
 - When old behavior already has a current-app replacement, use that replacement rather than adding compatibility paths.
 - Do not revive Source Localization/eLORETA imports, tests, settings, or UI behavior unless the user explicitly asks to restore that feature.
@@ -28,6 +29,7 @@ Useful checks:
 python .agents/skills/legacy-boundary-review/scripts/audit_protected_edits.py
 python scripts/agent_audit.py --check protected
 python scripts/agent_audit.py --check source-localization
+python scripts/agent_audit.py --check source-localization-refs
 git diff --name-only
 ```
 

--- a/docs/architecture/protected-paths.txt
+++ b/docs/architecture/protected-paths.txt
@@ -2,8 +2,9 @@
 # Globs use forward slashes and are repo-root relative.
 
 [protected]
-# Retired Main App legacy path. Do not recreate.
+# Retired Main App legacy paths. Do not recreate.
 src/Main_App/Legacy_App/**
+src/Main_App/PySide6_App/**
 
 [dead-code]
 src/Tools/SourceLocalization/**

--- a/docs/reviews/pre_ship_checklist.md
+++ b/docs/reviews/pre_ship_checklist.md
@@ -5,7 +5,7 @@ Use this before handing off non-trivial changes.
 - Run the relevant command from `docs/agent-index.md` before broad manual inspection.
 - The diff is limited to the requested behavior and direct support files.
 - Non-trivial refactors checked the relevant active plan in `docs/exec-plans/active/`.
-- Retired `Legacy_App` paths were not recreated; any historical behavior cleanup preserves the processing pipeline, processing order, data formats, and exports.
+- Retired `Legacy_App` and `PySide6_App` paths were not recreated; any historical behavior cleanup preserves the processing pipeline, processing order, data formats, and exports.
 - Source Localization/eLORETA remains removed from active runtime unless explicitly restored.
 - GUI work uses PySide6 only and imports `QAction` from `PySide6.QtGui`.
 - Long work is off the UI thread and workers do not touch widgets directly.


### PR DESCRIPTION
### Motivation
- Bring the agent prompt templates and nearby guidance up to date with the repo's audit-first workflow and skill-local script usage. 
- Make retired legacy paths explicit (include `src/Main_App/PySide6_App/**`), and tighten GUI and project-path guidance to reflect current PySide6-only rules and project-root discipline. 

### Description
- Updated agent prompt templates in `docs/agent-prompts/` (`bugfix.md`, `gui-change.md`, `legacy-boundary.md`, `path-audit.md`, `pre-ship-review.md`) to start from `docs/agent-index.md`, call skill-local scripts, preserve existing processing/order/formats/paths, and require reporting of skipped checks or doc-update decisions. 
- Clarified GUI rules to require PySide6-only usage, import `QAction` from `PySide6.QtGui`, forbid Tkinter/CustomTkinter/CTkMessagebox, and require non-blocking worker usage and pytest-qt smoke coverage or documented manual checks. 
- Synchronized legacy documentation and manifests by updating `docs/architecture/legacy-boundaries.md`, `docs/architecture/protected-paths.txt`, and `docs/reviews/pre_ship_checklist.md` to include `src/Main_App/PySide6_App/**` and add the `source-localization-refs` audit where relevant. 
- This is documentation-only and does not change runtime code or behavior. 

### Testing
- Ran `python scripts/agent_audit.py` and it passed. 
- Ran `python .agents/skills/legacy-boundary-review/scripts/audit_protected_edits.py` and it passed. 
- Ran `python .agents/skills/pyside6-gui-cleanup/scripts/audit_gui_imports.py` and it passed. 
- Ran `python .agents/skills/project-path-audit/scripts/audit_hardcoded_paths.py` and `git diff --check`, and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6dcd84a8832c9bc085a23a83f191)