### PR TITLE
docs: add Bash activation commands to agent index

### DIFF
--- a/docs/agent/agent-index.md
+++ b/docs/agent/agent-index.md
@@ -5,7 +5,17 @@ Use this page before gathering broad context. Run the relevant command first, th
 ## First Commands
 
 ```powershell
+# PowerShell
 .\.venv1\Scripts\Activate.ps1
+python .agents/scripts/audit/agent_audit.py
+python .agents/scripts/audit/agent_audit.py --check stats-structure
+python .agents/scripts/audit/agent_audit.py --check stats-reporting-legibility
+python .agents/skills/pyside6-gui-cleanup/scripts/audit_gui_imports.py
+python .agents/skills/legacy-boundary-review/scripts/audit_protected_edits.py
+python .agents/skills/project-path-audit/scripts/audit_hardcoded_paths.py
+
+# Bash
+source .venv1/bin/activate
 python .agents/scripts/audit/agent_audit.py
 python .agents/scripts/audit/agent_audit.py --check stats-structure
 python .agents/scripts/audit/agent_audit.py --check stats-reporting-legibility


### PR DESCRIPTION
### Motivation
- Clarify bootstrapping for non-PowerShell environments by documenting Bash equivalents alongside the existing PowerShell checklist in the agent index.

### Description
- Added a Bash block to the "First Commands" section in `docs/agent/agent-index.md` that mirrors the existing PowerShell commands and preserves the original command order and content.

### Testing
- Ran `python .agents/scripts/audit/agent_audit.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c3a706fa4832cab33a29b31d9591d)